### PR TITLE
Add guard against OutOfBoundsException

### DIFF
--- a/src/de.hpi.swa.graal.squeak/src/de/hpi/swa/graal/squeak/nodes/plugins/B2D.java
+++ b/src/de.hpi.swa.graal.squeak/src/de/hpi/swa/graal/squeak/nodes/plugins/B2D.java
@@ -4385,6 +4385,9 @@ public final class B2D {
 
     /* BalloonEngineBase>>#obj:at: */
     private static int objat(final long object, final long index) {
+        if (objBufferIndex + object + index >= workBuffer.length){
+            return 0;
+        }
         return workBuffer[(int) (objBufferIndex + object + index)];
     }
 


### PR DESCRIPTION
We run into this quite often, especially when moving windows opening (window) menus. This fix prevents the exception, but obviously doesn't address the root cause.