### PR TITLE
Introduce toggle for image reloading

### DIFF
--- a/src/de.hpi.swa.graal.squeak.test/src/de/hpi/swa/graal/squeak/test/SqueakBasicImageTest.java
+++ b/src/de.hpi.swa.graal.squeak.test/src/de/hpi/swa/graal/squeak/test/SqueakBasicImageTest.java
@@ -96,12 +96,6 @@ public class SqueakBasicImageTest extends AbstractSqueakTestCaseWithImage {
     }
 
     @Test
-    public void testInspectSqueakTest() {
-        assumeNotOnMXGate();
-        assertTrue(runTestCase("ArrayTest").passed);
-    }
-
-    @Test
     public void testInspectSqueakTestSelector() {
         assumeNotOnMXGate();
         image.getOutput().println(evaluate("(WordArrayTest run: #testCannotPutNegativeValue) asString"));

--- a/src/de.hpi.swa.graal.squeak.test/src/de/hpi/swa/graal/squeak/test/SqueakSUnitTest.java
+++ b/src/de.hpi.swa.graal.squeak.test/src/de/hpi/swa/graal/squeak/test/SqueakSUnitTest.java
@@ -38,12 +38,23 @@ import org.junit.runners.Parameterized.Parameters;
  * $ mx unittest -DsqueakTests="SqueakSSLTest>>testConnectAccept" SqueakSUnitTest --very-verbose --enable-timing
  * </pre>
  *
+ * The system property {@code reloadImage} defines the behavior in event of a Java exception from a
+ * primitive or test timeout expiry. The property value "exception" reloads the image and tries to
+ * ensure a clean state for the next test case. If no next test case exists, reloading the image is
+ * skipped. Using a value of {@code never} turns off image reloading, such that the image is only
+ * loaded once in the very beginning of the test session. This can be unreliable, but saves a
+ * significant amount of time when running buggy test suites locally.
+ *
  * </p>
  */
 @RunWith(Parameterized.class)
 public class SqueakSUnitTest extends AbstractSqueakTestCaseWithImage {
 
     private static final String TEST_CLASS_PROPERTY = "squeakTests";
+
+    private static final String RELOAD_IMAGE_PROPERTY = "reloadImage";
+    private static final String RELOAD_ON_EXCEPTION = "exception";
+    private static final String RELOAD_NEVER = "never";
 
     protected static final List<SqueakTest> TESTS = selectTestsToRun().collect(toList());
 
@@ -66,7 +77,7 @@ public class SqueakSUnitTest extends AbstractSqueakTestCaseWithImage {
     public void runSqueakTest() throws Throwable {
         checkTermination();
 
-        final TestResult result = runTestCase(test.className, test.selector);
+        final TestResult result = runTestCase(buildRequest());
 
         checkResult(result);
     }
@@ -76,6 +87,27 @@ public class SqueakSUnitTest extends AbstractSqueakTestCaseWithImage {
         if (test.type == TestType.SLOWLY_FAILING || test.type == TestType.SLOWLY_PASSING) {
             assumeNotOnMXGate();
         }
+    }
+
+    private TestRequest buildRequest() {
+        return new TestRequest(test.className, test.selector, isReloadOnException());
+    }
+
+    private boolean isReloadOnException() {
+        final String value = System.getProperty(RELOAD_IMAGE_PROPERTY, RELOAD_ON_EXCEPTION);
+        switch (value) {
+            case RELOAD_NEVER:
+                return false;
+            case RELOAD_ON_EXCEPTION:
+                return !isLastTestCase();
+            default:
+                throw new IllegalArgumentException(value);
+        }
+    }
+
+    private boolean isLastTestCase() {
+        final SqueakTest last = TESTS.get(TESTS.size() - 1);
+        return !last.nameEquals(test);
     }
 
     private void checkResult(final TestResult result) throws Throwable {


### PR DESCRIPTION
Implement a system property to influence when the Squeak
image is reloaded. This aids debugging cases in which
(failed) Squeak test cases taint the image.
Second improvement is to reload the image only if the
test case has a successor.