### PR TITLE
Fix NullPointerException when disabling fullscreen

### DIFF
--- a/src/de.hpi.swa.graal.squeak/src/de/hpi/swa/graal/squeak/io/SqueakDisplay.java
+++ b/src/de.hpi.swa.graal.squeak/src/de/hpi/swa/graal/squeak/io/SqueakDisplay.java
@@ -71,7 +71,7 @@ public final class SqueakDisplay implements SqueakDisplayInterface {
 
     public int buttons = 0;
     private Dimension rememberedWindowSize = null;
-    private Point rememberedWindowLocation;
+    private Point rememberedWindowLocation = null;
     private boolean deferUpdates = false;
 
     public SqueakDisplay(final SqueakImageContext image) {
@@ -288,7 +288,13 @@ public final class SqueakDisplay implements SqueakDisplayInterface {
             frame.setResizable(true);
         }
         frame.pack();
-        frame.setLocation(rememberedWindowLocation);
+        if (!enable) {
+            if (rememberedWindowLocation != null) {
+                frame.setLocation(rememberedWindowLocation);
+            }
+            rememberedWindowLocation = null;
+            rememberedWindowSize = null;
+        }
         frame.setVisible(true);
     }
 


### PR DESCRIPTION
Calling `DisplayScreen fullScreenOff` causes a crash if you have not been in fullscreen mode yet (and thus `rememberedWindowLocation` is `null`).
This is not an issue for `rememberedWindowSize`, which is also `null`, because [`setPreferredSize` allows `null`](https://docs.oracle.com/javase/7/docs/api/java/awt/Component.html#setPreferredSize(java.awt.Dimension)).

<details>
<summary>Stacktrace</summary>
```
[graalsqueak] Running Squeak/Smalltalk on OpenJDK GraalVM CE 19.0.0 (Graal-compiled)...
[graalsqueak] Image loaded in 10147ms.
ERROR: java.lang.NullPointerException
org.graalvm.polyglot.PolyglotException: java.lang.NullPointerException
        at java.awt.Component.setLocation(Component.java:2130)
        at java.awt.Window.setLocation(Window.java:934)
        at de.hpi.swa.graal.squeak.io.SqueakDisplay.setFullscreen(SqueakDisplay.java:291)
        at de.hpi.swa.graal.squeak.nodes.primitives.impl.ControlPrimitives$PrimSetFullScreenNode.doFullScreen(ControlPrimitives.java:994)
        at de.hpi.swa.graal.squeak.nodes.primitives.impl.ControlPrimitivesFactory$PrimSetFullScreenNodeFactory$PrimSetFullScreenNodeGen.executeAndSpecialize(ControlPrimitivesFactory.java:5057)
        at de.hpi.swa.graal.squeak.nodes.primitives.impl.ControlPrimitivesFactory$PrimSetFullScreenNodeFactory$PrimSetFullScreenNodeGen.executeWithArguments(ControlPrimitivesFactory.java:5019)
        at de.hpi.swa.graal.squeak.nodes.DispatchEagerlyNode.doPrimitiveEagerly(DispatchEagerlyNode.java:43)
        at de.hpi.swa.graal.squeak.nodes.DispatchEagerlyNodeGen.executeAndSpecialize(DispatchEagerlyNodeGen.java:131)
        at de.hpi.swa.graal.squeak.nodes.DispatchEagerlyNodeGen.executeDispatch(DispatchEagerlyNodeGen.java:74)
        at de.hpi.swa.graal.squeak.nodes.DispatchSendNode.doDispatch(DispatchSendNode.java:41)
        at de.hpi.swa.graal.squeak.nodes.DispatchSendNodeGen.executeAndSpecialize(DispatchSendNodeGen.java:85)
        at de.hpi.swa.graal.squeak.nodes.DispatchSendNodeGen.executeSend(DispatchSendNodeGen.java:69)
        at de.hpi.swa.graal.squeak.nodes.bytecodes.SendBytecodes$AbstractSendNode.executeVoid(SendBytecodes.java:67)
        at de.hpi.swa.graal.squeak.nodes.ExecuteContextNode.startBytecode(ExecuteContextNode.java:213)
        at de.hpi.swa.graal.squeak.nodes.ExecuteContextNode.doVirtualized(ExecuteContextNode.java:86)
        at de.hpi.swa.graal.squeak.nodes.ExecuteContextNodeGen.executeAndSpecialize(ExecuteContextNodeGen.java:57)
        at de.hpi.swa.graal.squeak.nodes.ExecuteContextNodeGen.executeContext(ExecuteContextNodeGen.java:42)
        at de.hpi.swa.graal.squeak.nodes.EnterCodeNode.enterVirtualized(EnterCodeNode.java:91)
        at de.hpi.swa.graal.squeak.nodes.EnterCodeNodeGen.executeAndSpecialize(EnterCodeNodeGen.java:59)
        at de.hpi.swa.graal.squeak.nodes.EnterCodeNodeGen.execute(EnterCodeNodeGen.java:47)
        at de.hpi.swa.graal.squeak.nodes.EnterCodeNode$SqueakCodeRootNode.execute(EnterCodeNode.java:61)
        at <squeaksmalltalk> Metaclass (DisplayScreen)>>fullScreenOff(Unknown)
        at <squeaksmalltalk> Metaclass (CMFGraalSqueakImagePreparation)>>startUp:(Metaclass (CMFGraalSqueakImagePreparation)>>startUp::1:0-10)
        at <squeaksmalltalk> SmalltalkImage>>send:toClassesNamedIn:with:(SmalltalkImage>>send:toClassesNamedIn:with::1:0-23)
        at <squeaksmalltalk> ExecuteTopLevelContextNode(OrderedCollection>>do::1:0-17)
        at org.graalvm.polyglot.Value.execute(Value.java:336)
        at de.hpi.swa.graal.squeak.launcher.GraalSqueakLauncher.execute(GraalSqueakLauncher.java:98)
        at de.hpi.swa.graal.squeak.launcher.GraalSqueakLauncher.launch(GraalSqueakLauncher.java:73)
        at org.graalvm.launcher.AbstractLanguageLauncher.launch(AbstractLanguageLauncher.java:121)
        at org.graalvm.launcher.AbstractLanguageLauncher.launch(AbstractLanguageLauncher.java:70)
        at de.hpi.swa.graal.squeak.launcher.GraalSqueakLauncher.main(GraalSqueakLauncher.java:46)
Original Internal Error:
java.lang.NullPointerException
        at java.awt.Component.setLocation(Component.java:2130)
        at java.awt.Window.setLocation(Window.java:934)
        at de.hpi.swa.graal.squeak.io.SqueakDisplay.setFullscreen(SqueakDisplay.java:291)
        at de.hpi.swa.graal.squeak.nodes.primitives.impl.ControlPrimitives$PrimSetFullScreenNode.doFullScreen(ControlPrimitives.java:994)
        at de.hpi.swa.graal.squeak.nodes.primitives.impl.ControlPrimitivesFactory$PrimSetFullScreenNodeFactory$PrimSetFullScreenNodeGen.executeAndSpecialize(ControlPrimitivesFactory.java:5057)
        at de.hpi.swa.graal.squeak.nodes.primitives.impl.ControlPrimitivesFactory$PrimSetFullScreenNodeFactory$PrimSetFullScreenNodeGen.executeWithArguments(ControlPrimitivesFactory.java:5019)
        at de.hpi.swa.graal.squeak.nodes.DispatchEagerlyNode.doPrimitiveEagerly(DispatchEagerlyNode.java:43)
        at de.hpi.swa.graal.squeak.nodes.DispatchEagerlyNodeGen.executeAndSpecialize(DispatchEagerlyNodeGen.java:131)
        at de.hpi.swa.graal.squeak.nodes.DispatchEagerlyNodeGen.executeDispatch(DispatchEagerlyNodeGen.java:74)
        at de.hpi.swa.graal.squeak.nodes.DispatchSendNode.doDispatch(DispatchSendNode.java:41)
        at de.hpi.swa.graal.squeak.nodes.DispatchSendNodeGen.executeAndSpecialize(DispatchSendNodeGen.java:85)
        at de.hpi.swa.graal.squeak.nodes.DispatchSendNodeGen.executeSend(DispatchSendNodeGen.java:69)
        at de.hpi.swa.graal.squeak.nodes.bytecodes.SendBytecodes$AbstractSendNode.executeVoid(SendBytecodes.java:67)
        at de.hpi.swa.graal.squeak.nodes.ExecuteContextNode.startBytecode(ExecuteContextNode.java:213)
        at de.hpi.swa.graal.squeak.nodes.ExecuteContextNode.doVirtualized(ExecuteContextNode.java:86)
        at de.hpi.swa.graal.squeak.nodes.ExecuteContextNodeGen.executeAndSpecialize(ExecuteContextNodeGen.java:57)
        at de.hpi.swa.graal.squeak.nodes.ExecuteContextNodeGen.executeContext(ExecuteContextNodeGen.java:42)
        at de.hpi.swa.graal.squeak.nodes.EnterCodeNode.enterVirtualized(EnterCodeNode.java:91)
        at de.hpi.swa.graal.squeak.nodes.EnterCodeNodeGen.executeAndSpecialize(EnterCodeNodeGen.java:59)
        at de.hpi.swa.graal.squeak.nodes.EnterCodeNodeGen.execute(EnterCodeNodeGen.java:47)
        at de.hpi.swa.graal.squeak.nodes.EnterCodeNode$SqueakCodeRootNode.execute(EnterCodeNode.java:61)
        at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callProxy(OptimizedCallTarget.java:325)
        at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callRoot(OptimizedCallTarget.java:315)
        at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callBoundary(OptimizedCallTarget.java:302)
        at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.doInvoke(OptimizedCallTarget.java:284)
        at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callDirect(OptimizedCallTarget.java:239)
        at org.graalvm.compiler.truffle.runtime.OptimizedDirectCallNode.call(OptimizedDirectCallNode.java:63)
        at de.hpi.swa.graal.squeak.nodes.DispatchEagerlyNode.doDirect(DispatchEagerlyNode.java:56)
        at de.hpi.swa.graal.squeak.nodes.DispatchEagerlyNodeGen.executeAndSpecialize(DispatchEagerlyNodeGen.java:169)
        at de.hpi.swa.graal.squeak.nodes.DispatchEagerlyNodeGen.executeDispatch(DispatchEagerlyNodeGen.java:74)
        at de.hpi.swa.graal.squeak.nodes.DispatchSendNode.doDispatch(DispatchSendNode.java:41)
        at de.hpi.swa.graal.squeak.nodes.DispatchSendNodeGen.executeAndSpecialize(DispatchSendNodeGen.java:85)
        at de.hpi.swa.graal.squeak.nodes.DispatchSendNodeGen.executeSend(DispatchSendNodeGen.java:69)
        at de.hpi.swa.graal.squeak.nodes.bytecodes.SendBytecodes$AbstractSendNode.executeVoid(SendBytecodes.java:67)
        at de.hpi.swa.graal.squeak.nodes.ExecuteContextNode.startBytecode(ExecuteContextNode.java:213)
        at de.hpi.swa.graal.squeak.nodes.ExecuteContextNode.doVirtualized(ExecuteContextNode.java:86)
        at de.hpi.swa.graal.squeak.nodes.ExecuteContextNodeGen.executeAndSpecialize(ExecuteContextNodeGen.java:57)
        at de.hpi.swa.graal.squeak.nodes.ExecuteContextNodeGen.executeContext(ExecuteContextNodeGen.java:42)
        at de.hpi.swa.graal.squeak.nodes.EnterCodeNode.enterVirtualized(EnterCodeNode.java:91)
        at de.hpi.swa.graal.squeak.nodes.EnterCodeNodeGen.executeAndSpecialize(EnterCodeNodeGen.java:59)
        at de.hpi.swa.graal.squeak.nodes.EnterCodeNodeGen.execute(EnterCodeNodeGen.java:47)
        at de.hpi.swa.graal.squeak.nodes.EnterCodeNode$SqueakCodeRootNode.execute(EnterCodeNode.java:61)
        at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callProxy(OptimizedCallTarget.java:325)
        at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callRoot(OptimizedCallTarget.java:315)
        at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callBoundary(OptimizedCallTarget.java:302)
        at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.doInvoke(OptimizedCallTarget.java:284)
        at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callIndirect(OptimizedCallTarget.java:227)
        at org.graalvm.compiler.truffle.runtime.OptimizedIndirectCallNode.call(OptimizedIndirectCallNode.java:48)
        at de.hpi.swa.graal.squeak.nodes.DispatchEagerlyNode.doIndirect(DispatchEagerlyNode.java:62)
        at de.hpi.swa.graal.squeak.nodes.DispatchEagerlyNodeGen.executeDispatch(DispatchEagerlyNodeGen.java:70)
        at de.hpi.swa.graal.squeak.nodes.DispatchSendNode.doDispatch(DispatchSendNode.java:41)
        at de.hpi.swa.graal.squeak.nodes.DispatchSendNodeGen.executeSend(DispatchSendNodeGen.java:39)
        at de.hpi.swa.graal.squeak.nodes.primitives.impl.ControlPrimitives$AbstractPerformPrimitiveNode.dispatch(ControlPrimitives.java:133)
        at de.hpi.swa.graal.squeak.nodes.primitives.impl.ControlPrimitives$AbstractPerformPrimitiveNode.dispatch(ControlPrimitives.java:127)
        at de.hpi.swa.graal.squeak.nodes.primitives.impl.ControlPrimitives$PrimPerformNode.perform(ControlPrimitives.java:172)
        at de.hpi.swa.graal.squeak.nodes.primitives.impl.ControlPrimitivesFactory$PrimPerformNodeFactory$PrimPerformNodeGen.executeWithArguments(ControlPrimitivesFactory.java:173)
        at de.hpi.swa.graal.squeak.nodes.DispatchEagerlyNode.doPrimitiveEagerly(DispatchEagerlyNode.java:43)
        at de.hpi.swa.graal.squeak.nodes.DispatchEagerlyNodeGen.executeDispatch(DispatchEagerlyNodeGen.java:50)
        at de.hpi.swa.graal.squeak.nodes.DispatchSendNode.doDispatch(DispatchSendNode.java:41)
        at de.hpi.swa.graal.squeak.nodes.DispatchSendNodeGen.executeSend(DispatchSendNodeGen.java:39)
        at de.hpi.swa.graal.squeak.nodes.bytecodes.SendBytecodes$AbstractSendNode.executeVoid(SendBytecodes.java:67)
        at de.hpi.swa.graal.squeak.nodes.ExecuteContextNode.startBytecode(ExecuteContextNode.java:213)
        at de.hpi.swa.graal.squeak.nodes.ExecuteContextNode.doVirtualized(ExecuteContextNode.java:86)
        at de.hpi.swa.graal.squeak.nodes.ExecuteContextNodeGen.executeContext(ExecuteContextNodeGen.java:32)
        at de.hpi.swa.graal.squeak.nodes.EnterCodeNode.enterVirtualized(EnterCodeNode.java:91)
        at de.hpi.swa.graal.squeak.nodes.EnterCodeNodeGen.execute(EnterCodeNodeGen.java:39)
        at de.hpi.swa.graal.squeak.nodes.EnterCodeNode$SqueakCodeRootNode.execute(EnterCodeNode.java:61)
        at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callProxy(OptimizedCallTarget.java:325)
        at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callRoot(OptimizedCallTarget.java:315)
        at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callBoundary(OptimizedCallTarget.java:302)
        at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.doInvoke(OptimizedCallTarget.java:284)
        at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callDirect(OptimizedCallTarget.java:239)
        at org.graalvm.compiler.truffle.runtime.OptimizedDirectCallNode.call(OptimizedDirectCallNode.java:63)
        at de.hpi.swa.graal.squeak.nodes.BlockActivationNode.doDirect(BlockActivationNode.java:29)
        at de.hpi.swa.graal.squeak.nodes.BlockActivationNodeGen.executeBlock(BlockActivationNodeGen.java:44)
        at de.hpi.swa.graal.squeak.nodes.primitives.impl.BlockClosurePrimitives$PrimClosureValue1Node.doValue(BlockClosurePrimitives.java:57)
        at de.hpi.swa.graal.squeak.nodes.primitives.impl.BlockClosurePrimitivesFactory$PrimClosureValue1NodeFactory$PrimClosureValue1NodeGen.executeWithArguments(BlockClosurePrimitivesFactory.java:259)
        at de.hpi.swa.graal.squeak.nodes.DispatchEagerlyNode.doPrimitiveEagerly(DispatchEagerlyNode.java:43)
        at de.hpi.swa.graal.squeak.nodes.DispatchEagerlyNodeGen.executeDispatch(DispatchEagerlyNodeGen.java:50)
        at de.hpi.swa.graal.squeak.nodes.DispatchSendNode.doDispatch(DispatchSendNode.java:41)
        at de.hpi.swa.graal.squeak.nodes.DispatchSendNodeGen.executeSend(DispatchSendNodeGen.java:39)
        at de.hpi.swa.graal.squeak.nodes.bytecodes.SendBytecodes$AbstractSendNode.executeVoid(SendBytecodes.java:67)
        at de.hpi.swa.graal.squeak.nodes.ExecuteContextNode.resumeBytecode(ExecuteContextNode.java:299)
        at de.hpi.swa.graal.squeak.nodes.ExecuteContextNode.doNonVirtualized(ExecuteContextNode.java:117)
        at de.hpi.swa.graal.squeak.nodes.ExecuteContextNodeGen.executeAndSpecialize(ExecuteContextNodeGen.java:62)
        at de.hpi.swa.graal.squeak.nodes.ExecuteContextNodeGen.executeContext(ExecuteContextNodeGen.java:42)
        at de.hpi.swa.graal.squeak.nodes.ExecuteTopLevelContextNode.executeLoop(ExecuteTopLevelContextNode.java:84)
        at de.hpi.swa.graal.squeak.nodes.ExecuteTopLevelContextNode.execute(ExecuteTopLevelContextNode.java:51)
        at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callProxy(OptimizedCallTarget.java:325)
        at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callRoot(OptimizedCallTarget.java:315)
        at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callBoundary(OptimizedCallTarget.java:302)
        at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.doInvoke(OptimizedCallTarget.java:284)
        at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callIndirect(OptimizedCallTarget.java:227)
        at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.call(OptimizedCallTarget.java:214)
        at de.hpi.swa.graal.squeak.SqueakImage.execute(SqueakImage.java:58)
        at de.hpi.swa.graal.squeak.SqueakImageGen$InteropLibraryExports$Cached.execute(SqueakImageGen.java:77)
        at com.oracle.truffle.api.interop.InteropLibraryGen$CachedDispatch.execute(InteropLibraryGen.java:2626)
        at com.oracle.truffle.polyglot.PolyglotValue$InteropCodeCache$AbstractExecuteNode.executeShared(PolyglotValue.java:1345)
        at com.oracle.truffle.polyglot.PolyglotValue$InteropCodeCache$ExecuteNoArgsNode.executeImpl(PolyglotValue.java:1452)
        at com.oracle.truffle.polyglot.HostToGuestRootNode.execute(HostToGuestRootNode.java:94)
        at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callProxy(OptimizedCallTarget.java:325)
        at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callRoot(OptimizedCallTarget.java:315)
        at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callBoundary(OptimizedCallTarget.java:302)
        at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.doInvoke(OptimizedCallTarget.java:284)
        at org.graalvm.compiler.truffle.runtime.OptimizedCallTarget$OptimizedCallProfiled.call(OptimizedCallTarget.java:872)
        at com.oracle.truffle.polyglot.PolyglotValue$InteropValue.execute(PolyglotValue.java:2013)
        at org.graalvm.polyglot.Value.execute(Value.java:336)
        at de.hpi.swa.graal.squeak.launcher.GraalSqueakLauncher.execute(GraalSqueakLauncher.java:98)
        at de.hpi.swa.graal.squeak.launcher.GraalSqueakLauncher.launch(GraalSqueakLauncher.java:73)
        at org.graalvm.launcher.AbstractLanguageLauncher.launch(AbstractLanguageLauncher.java:121)
        at org.graalvm.launcher.AbstractLanguageLauncher.launch(AbstractLanguageLauncher.java:70)
        at de.hpi.swa.graal.squeak.launcher.GraalSqueakLauncher.main(GraalSqueakLauncher.java:46)
Caused by: Attached Guest Language Frames (5)
```
</details>