### PR TITLE
Add missing DRAG.DROP event if transfer flavor is not supported

### DIFF
--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/io/SqueakDisplay.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/io/SqueakDisplay.java
@@ -444,6 +444,8 @@ public final class SqueakDisplay implements SqueakDisplayInterface {
                     }
                 }
             }
+            image.dropPluginFileList = new String[0];
+            addDragEvent(DRAG.DROP, dtde.getLocation());
             dtde.rejectDrop();
         }
 


### PR DESCRIPTION
Fixes #125.