### PR TITLE
Materialize stack when more than 1000 sends deep

### DIFF
--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakSystemAttributes.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakSystemAttributes.java
@@ -69,7 +69,7 @@ public final class SqueakSystemAttributes {
                 final String minor1 = new StringBuilder("0").append(osVersionParts[1]).toString();
                 final String minor2 = osVersionParts[1];
                 final String sub = osVersionParts[2];
-                value = new StringBuilder(major).append(minor2.length() == 2 ? minor2 : minor1).append(".").append(sub).toString();
+                value = new StringBuilder(major).append(minor2.length() == 2 ? minor2 : minor1).append('.').append(sub).toString();
             }
         } else {
             value = osVersion;

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakSystemAttributes.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakSystemAttributes.java
@@ -64,14 +64,12 @@ public final class SqueakSystemAttributes {
              */
             value = "1016.0";
             final String[] osVersionParts = osVersion.split("\\.");
-            if (osVersionParts.length == 2) {
+            if (osVersionParts.length == 3) {
                 final String major = osVersionParts[0];
-                try {
-                    final int minor = Integer.parseInt(osVersionParts[1]);
-                    value = String.format("%s%02d.0", major, minor);
-                } catch (final NumberFormatException e) {
-                    // give up
-                }
+                final String minor1 = new StringBuilder("0").append(osVersionParts[1]).toString();
+                final String minor2 = osVersionParts[1];
+                final String sub = osVersionParts[2];
+                value = new StringBuilder(major).append(minor2.length() == 2 ? minor2 : minor1).append(".").append(sub).toString();
             }
         } else {
             value = osVersion;
@@ -79,7 +77,9 @@ public final class SqueakSystemAttributes {
         operatingSystemVersion = asByteString(value);
 
         if (osArch.equals("aarch64")) {
-            value = "armv8"; /* For `SmalltalkImage>>#isLowerPerformance`. */
+            value = "arm64";    /* Requires one of #('aarch64' 'arm64') for 'FFIPlatformDescription>>#abi'. */
+                                /* Begins with "arm" for `SmalltalkImage>>#isLowerPerformance`. */
+//            value = "aarch64";
         } else {
             value = "x64"; /* For users of `Smalltalk os platformSubtype`. */
         }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
@@ -93,7 +93,7 @@ public final class ExecuteTopLevelContextNode extends RootNode {
             assert sender == NilObject.SINGLETON || ((ContextObject) sender).hasTruffleFrame();
             try {
                 image.lastSeenContext = null;  // Reset materialization mechanism.
-                StartContextRootNode.StartingNewProcess();
+                StartContextRootNode.startingNewProcess();
                 final Object result = callNode.call(activeContext.getCallTarget());
                 activeContext = returnTo(activeContext, sender, result);
                 LogUtils.SCHEDULING.log(Level.FINE, "Local Return on top-level: {0}", activeContext);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
@@ -93,6 +93,7 @@ public final class ExecuteTopLevelContextNode extends RootNode {
             assert sender == NilObject.SINGLETON || ((ContextObject) sender).hasTruffleFrame();
             try {
                 image.lastSeenContext = null;  // Reset materialization mechanism.
+                StartContextRootNode.StartingNewProcess();
                 final Object result = callNode.call(activeContext.getCallTarget());
                 activeContext = returnTo(activeContext, sender, result);
                 LogUtils.SCHEDULING.log(Level.FINE, "Local Return on top-level: {0}", activeContext);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/StartContextRootNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/StartContextRootNode.java
@@ -34,10 +34,6 @@ public final class StartContextRootNode extends AbstractRootNode {
     private static final int MaximumStackDepth = 1000;
     private static int ApproximateStackDepth;
 
-    public static void startingNewProcess() {
-        ApproximateStackDepth = 0;
-    }
-
     @Children private FrameStackWriteNode[] writeTempNodes;
     @Child private CheckForInterruptsQuickNode interruptHandlerNode;
     @Child private AbstractExecuteContextNode executeBytecodeNode;
@@ -48,6 +44,10 @@ public final class StartContextRootNode extends AbstractRootNode {
         super(language, code);
         interruptHandlerNode = CheckForInterruptsQuickNode.createForSend(code);
         executeBytecodeNode = new ExecuteBytecodeNode(code);
+    }
+
+    public static void startingNewProcess() {
+        ApproximateStackDepth = 0;
     }
 
     @Override

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/StartContextRootNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/StartContextRootNode.java
@@ -32,9 +32,9 @@ public final class StartContextRootNode extends AbstractRootNode {
     @CompilationFinal private int initialSP;
 
     private static final int MaximumStackDepth = 1000;
-    private static int ApproximateStackDepth = 0;
+    private static int ApproximateStackDepth;
 
-    public static void StartingNewProcess() {
+    public static void startingNewProcess() {
         ApproximateStackDepth = 0;
     }
 
@@ -54,7 +54,7 @@ public final class StartContextRootNode extends AbstractRootNode {
     public Object execute(final VirtualFrame frame) {
         initializeFrame(frame);
         try {
-            if ( ++ApproximateStackDepth > MaximumStackDepth ) {
+            if (++ApproximateStackDepth > MaximumStackDepth) {
                 throw ProcessSwitch.create(getGetOrCreateContextNode().executeGet(frame));
             }
 


### PR DESCRIPTION
Track the entries and exits of StartContextRootNode.execute() to count the Smalltalk context depth since the resumption of the active process.

When the Smalltalk context depth exceeds 1000, cause a process switch (to the current Smalltalk context), flushing the Java stack and materializing all of the virtual contexts.