### PR TITLE
B2D: fix oval width calculation and fetchIntegerofObject()

### DIFF
--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/B2D.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/B2D.java
@@ -3760,7 +3760,7 @@ public final class B2D {
         final int w;
 
         w = (point2GetX() - point1GetX()) / 2;
-        h = (point2GetX() - point1GetY()) / 2;
+        h = (point2GetY() - point1GetY()) / 2;
         cx = (point2GetX() + point1GetX()) / 2;
         cy = (point2GetY() + point1GetY()) / 2;
         for (int i = 0; i <= 15; i++) {
@@ -7145,7 +7145,7 @@ public final class B2D {
     }
 
     private static int fetchIntegerofObject(final int index, final PointersObject object) {
-        return (int) object.instVarAt0Slow(index);
+        return (int) (long) object.instVarAt0Slow(index);
     }
 
     private void workbufferAtput(final int index, final int value) {


### PR DESCRIPTION
`fetchIntegerofObject(...)` was crashing trying to convert a Long directly to an int. Fixed by adding an intermediate cast to long.

`loadOvallineFillleftFillrightFill(...)` was incorrectly calculating the height by subtracting top from right instead of top from bottom.

These problems would show up when **platformProcessorType** is set to "aarch64", the Squeak preferences are set to rounded buttons and not flat widgets, and the scroll bar was at its minimum vertical size, forcing the scroll thumb to be drawn as an oval rather than a rounded rectangle.