### PR TITLE
Materialize stack when more than 1000 sends deep

### DIFF
--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
@@ -93,6 +93,7 @@ public final class ExecuteTopLevelContextNode extends RootNode {
             assert sender == NilObject.SINGLETON || ((ContextObject) sender).hasTruffleFrame();
             try {
                 image.lastSeenContext = null;  // Reset materialization mechanism.
+                StartContextRootNode.startingNewProcess();
                 final Object result = callNode.call(activeContext.getCallTarget());
                 activeContext = returnTo(activeContext, sender, result);
                 LogUtils.SCHEDULING.log(Level.FINE, "Local Return on top-level: {0}", activeContext);


### PR DESCRIPTION
Track the entries and exits of StartContextRootNode.execute() to count the Smalltalk context depth since the resumption of the active process.

When the Smalltalk context depth exceeds 1000, cause a process switch (to the current Smalltalk context), flushing the Java stack and materializing all of the virtual Smalltalk contexts.