### PR TITLE
Restore mark bit of traversed objects before returning from someInstanceOf

### DIFF
--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/AbstractSqueakObjectWithClassAndHash.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/AbstractSqueakObjectWithClassAndHash.java
@@ -183,6 +183,18 @@ public abstract class AbstractSqueakObjectWithClassAndHash extends AbstractSquea
         }
     }
 
+    /**
+     * @return <tt>true</tt> if already marked, <tt>false</tt> otherwise
+     */
+    public final boolean tryToUnmark(final boolean currentMarkingFlag) {
+        if (getMarkingFlag() == currentMarkingFlag) {
+            toggleMarkingFlag();
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     @SuppressWarnings("unused")
     public void pointersBecomeOneWay(final Object[] from, final Object[] to) {
         // Do nothing by default.

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/MiscellaneousPrimitives.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/MiscellaneousPrimitives.java
@@ -102,7 +102,7 @@ public final class MiscellaneousPrimitives extends AbstractPrimitiveFactoryHolde
 
         @SuppressWarnings("unused")
         @Specialization(guards = "classObject.isImmediateClassType()")
-        protected static final Object doImmeditate(final ClassObject classObject) {
+        protected static final Object doImmediate(final ClassObject classObject) {
             throw PrimitiveFailed.GENERIC_ERROR;
         }
 
@@ -111,11 +111,7 @@ public final class MiscellaneousPrimitives extends AbstractPrimitiveFactoryHolde
             if (classObject.getSqueakHash() == SqueakImageConstants.FREE_OBJECT_CLASS_INDEX_PUN) {
                 return NilObject.SINGLETON; // Class has not been instantiated yet
             }
-            try {
-                return ObjectGraphUtils.someInstanceOf(getContext(), classObject);
-            } catch (final IndexOutOfBoundsException e) {
-                throw PrimitiveFailed.GENERIC_ERROR;
-            }
+            return ObjectGraphUtils.someInstanceOf(getContext(), classObject);
         }
     }
 


### PR DESCRIPTION
`Behavior >> someInstance` (primitive 77) returns the first instance of the receiver's class.

In the implementation of the primitive, `someInstanceOf(...)` returns immediately upon encountering the first object of that class, leaving the enumerated objects up to that point with a different state from the rest of the objects in the object graph. This causes problems for future object graph traversals:

![TS someInstance before](https://github.com/user-attachments/assets/1f5a8ac9-b5d1-4c05-a6c6-6df678266dbb)

Changed `someInstanceOf(...)` to save the objects marked during the enumeration so that they can be unmarked before it returns.

![TS someInstance after](https://github.com/user-attachments/assets/c992db3d-d07c-4b50-8d49-f8e2dafdbda0)
