### PR TITLE
Materialize stack when exceeding user-defined depth

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -98,7 +98,7 @@ $GRAALVM_HOME/bin/trufflesqueak \
 The following runs the `ArrayTest>>testAtWrap` SUnit test from Squeak/Smalltalk
 using mx's unittest command in debug mode:
 ```bash
-mx -d --env trufflesqueak-jvm unittest -Xss64M \
+mx -d --env trufflesqueak-jvm unittest \
    -DsqueakTests="ArrayTest>>testAtWrap" \
    SqueakSUnitTest --very-verbose --enable-timing --color
 ```

--- a/mx.trufflesqueak/mx_trufflesqueak.py
+++ b/mx.trufflesqueak/mx_trufflesqueak.py
@@ -27,8 +27,6 @@ LANGUAGE_ID = "smalltalk"
 PACKAGE_NAME = "de.hpi.swa.trufflesqueak"
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 VM_ARGS_TESTING = [
-    # Tweak Runtime
-    "-Xss16M",  # Increase stack size
     # Make ReflectionUtils work
     "--add-exports=java.base/jdk.internal.module=ALL-UNNAMED",
     # Tweak GC for GitHub Actions
@@ -356,7 +354,6 @@ mx_sdk.register_graalvm_component(
                 ],
                 default_vm_args=[
                     "--vm.Xms512M",
-                    "--vm.Xss16M",
                     "--vm.-add-exports=java.base/jdk.internal.module=de.hpi.swa.trufflesqueak",
                 ],
             )

--- a/src/de.hpi.swa.trufflesqueak.shared/src/de/hpi/swa/trufflesqueak/shared/SqueakLanguageOptions.java
+++ b/src/de.hpi.swa.trufflesqueak.shared/src/de/hpi/swa/trufflesqueak/shared/SqueakLanguageOptions.java
@@ -10,6 +10,9 @@ public final class SqueakLanguageOptions {
     public static final String CODE_FLAG = "--code";
     public static final String CODE_FLAG_SHORT = "-c";
     public static final String CODE_HELP = "Smalltalk code to be executed without display";
+    public static final String CONTEXT_STACK_DEPTH = "context-stack-depth";
+    public static final String CONTEXT_STACK_DEPTH_FLAG = "--" + CONTEXT_STACK_DEPTH;
+    public static final String CONTEXT_STACK_DEPTH_HELP = "Flush context stack when it reaches this depth (0 = disabled)";
     public static final String HEADLESS = "headless";
     public static final String HEADLESS_FLAG = "--" + HEADLESS;
     public static final String HEADLESS_HELP = "Run without a display";

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/SqueakOptions.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/SqueakOptions.java
@@ -43,6 +43,9 @@ public final class SqueakOptions {
     @Option(name = SqueakLanguageOptions.RESOURCE_SUMMARY, category = OptionCategory.USER, stability = OptionStability.EXPERIMENTAL, help = SqueakLanguageOptions.RESOURCE_SUMMARY_HELP, usageSyntax = "false|true")//
     public static final OptionKey<Boolean> ResourceSummary = new OptionKey<>(false);
 
+    @Option(name = SqueakLanguageOptions.CONTEXT_STACK_DEPTH, category = OptionCategory.USER, stability = OptionStability.EXPERIMENTAL, help = SqueakLanguageOptions.CONTEXT_STACK_DEPTH_HELP, usageSyntax = "number")//
+    public static final OptionKey<Integer> ContextStackDepth = new OptionKey<>(1000);
+
     @Option(name = SqueakLanguageOptions.SIGNAL_INPUT_SEMAPHORE, category = OptionCategory.INTERNAL, stability = OptionStability.EXPERIMENTAL, help = SqueakLanguageOptions.SIGNAL_INPUT_SEMAPHORE_HELP, usageSyntax = "false|true")//
     public static final OptionKey<Boolean> SignalInputSemaphore = new OptionKey<>(false);
 
@@ -60,7 +63,7 @@ public final class SqueakOptions {
     }
 
     public record SqueakContextOptions(String imagePath, String[] imageArguments, boolean printResourceSummary, boolean isHeadless, boolean isQuiet, boolean disableInterruptHandler,
-                    boolean disableStartup, boolean isTesting, boolean signalInputSemaphore) {
+                    int maximumContextStackDepth, boolean disableStartup, boolean isTesting, boolean signalInputSemaphore) {
         public static SqueakContextOptions create(final OptionValues options) {
             return new SqueakContextOptions(
                             options.get(ImagePath).isEmpty() ? null : options.get(ImagePath),
@@ -69,6 +72,7 @@ public final class SqueakOptions {
                             options.get(Headless),
                             options.get(Quiet),
                             options.get(Interrupts),
+                            Math.max(0, options.get(ContextStackDepth)),
                             options.get(Startup),
                             options.get(Testing),
                             options.get(SignalInputSemaphore));

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/SqueakOptions.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/SqueakOptions.java
@@ -63,7 +63,7 @@ public final class SqueakOptions {
     }
 
     public record SqueakContextOptions(String imagePath, String[] imageArguments, boolean printResourceSummary, boolean isHeadless, boolean isQuiet, boolean disableInterruptHandler,
-                    int maximumContextStackDepth, boolean disableStartup, boolean isTesting, boolean signalInputSemaphore) {
+                    int maxContextStackDepth, boolean disableStartup, boolean isTesting, boolean signalInputSemaphore) {
         public static SqueakContextOptions create(final OptionValues options) {
             return new SqueakContextOptions(
                             options.get(ImagePath).isEmpty() ? null : options.get(ImagePath),

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/SqueakOptions.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/SqueakOptions.java
@@ -44,7 +44,7 @@ public final class SqueakOptions {
     public static final OptionKey<Boolean> ResourceSummary = new OptionKey<>(false);
 
     @Option(name = SqueakLanguageOptions.CONTEXT_STACK_DEPTH, category = OptionCategory.USER, stability = OptionStability.EXPERIMENTAL, help = SqueakLanguageOptions.CONTEXT_STACK_DEPTH_HELP, usageSyntax = "number")//
-    public static final OptionKey<Integer> ContextStackDepth = new OptionKey<>(1000);
+    public static final OptionKey<Integer> ContextStackDepth = new OptionKey<>(2 << 12);
 
     @Option(name = SqueakLanguageOptions.SIGNAL_INPUT_SEMAPHORE, category = OptionCategory.INTERNAL, stability = OptionStability.EXPERIMENTAL, help = SqueakLanguageOptions.SIGNAL_INPUT_SEMAPHORE_HELP, usageSyntax = "false|true")//
     public static final OptionKey<Boolean> SignalInputSemaphore = new OptionKey<>(false);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
@@ -174,8 +174,7 @@ public final class SqueakImageContext {
     private int lowSpaceSkippedSendsCount;
 
     /* Context stack depth */
-    @CompilationFinal
-    private final int MAXIMUM_CONTEXT_STACK_DEPTH;
+    @CompilationFinal private final int maxContextStackDepth;
     private int currentContextStackDepth;
 
     @CompilationFinal private ClassObject fractionClass;
@@ -205,7 +204,7 @@ public final class SqueakImageContext {
         patch(environment);
         options = SqueakContextOptions.create(env.getOptions());
         isHeadless = options.isHeadless();
-        MAXIMUM_CONTEXT_STACK_DEPTH = options.maximumContextStackDepth();
+        maxContextStackDepth = options.maxContextStackDepth();
         interrupt = new CheckForInterruptsState(this);
         allocationReporter = env.lookup(AllocationReporter.class);
         SqueakMessageInterceptor.enableIfRequested(environment);
@@ -423,21 +422,24 @@ public final class SqueakImageContext {
      * CONTEXT STACK DEPTH MANAGEMENT
      */
 
-    public void enteringTopLevelContextNode() {
-        if (MAXIMUM_CONTEXT_STACK_DEPTH != 0)
-            currentContextStackDepth = 0;
-    }
-
-    public boolean enteringContextNodeWouldExceedDepth() {
-        if (MAXIMUM_CONTEXT_STACK_DEPTH == 0)
+    public boolean enteringContextExceedsDepth() {
+        if (maxContextStackDepth == 0) {
             return false;
-        else
-            return ++currentContextStackDepth > MAXIMUM_CONTEXT_STACK_DEPTH;
+        } else {
+            return ++currentContextStackDepth > maxContextStackDepth;
+        }
     }
 
-    public void exitingContextNode() {
-        if (MAXIMUM_CONTEXT_STACK_DEPTH != 0)
+    public void exitingContext() {
+        if (maxContextStackDepth != 0) {
             --currentContextStackDepth;
+        }
+    }
+
+    public void resetContextStackDepth() {
+        if (maxContextStackDepth != 0) {
+            currentContextStackDepth = 0;
+        }
     }
 
     /*

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
@@ -93,7 +93,7 @@ public final class ExecuteTopLevelContextNode extends RootNode {
             assert sender == NilObject.SINGLETON || ((ContextObject) sender).hasTruffleFrame();
             try {
                 image.lastSeenContext = null;  // Reset materialization mechanism.
-                image.enteringTopLevelContextNode();
+                image.resetContextStackDepth();
                 final Object result = callNode.call(activeContext.getCallTarget());
                 activeContext = returnTo(activeContext, sender, result);
                 LogUtils.SCHEDULING.log(Level.FINE, "Local Return on top-level: {0}", activeContext);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
@@ -93,6 +93,7 @@ public final class ExecuteTopLevelContextNode extends RootNode {
             assert sender == NilObject.SINGLETON || ((ContextObject) sender).hasTruffleFrame();
             try {
                 image.lastSeenContext = null;  // Reset materialization mechanism.
+                image.enteringTopLevelContextNode();
                 final Object result = callNode.call(activeContext.getCallTarget());
                 activeContext = returnTo(activeContext, sender, result);
                 LogUtils.SCHEDULING.log(Level.FINE, "Local Return on top-level: {0}", activeContext);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/StartContextRootNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/StartContextRootNode.java
@@ -51,10 +51,9 @@ public final class StartContextRootNode extends AbstractRootNode {
     public Object execute(final VirtualFrame frame) {
         initializeFrame(frame);
         try {
-            if (image.enteringContextNodeWouldExceedDepth()) {
+            if (image.enteringContextExceedsDepth()) {
                 throw ProcessSwitch.create(getGetOrCreateContextNode().executeGet(frame));
             }
-
             interruptHandlerNode.execute(frame);
             return executeBytecodeNode.execute(frame, initialPC);
         } catch (final NonVirtualReturn | ProcessSwitch nvr) {
@@ -62,7 +61,7 @@ public final class StartContextRootNode extends AbstractRootNode {
             getGetOrCreateContextNode().executeGet(frame).markEscaped();
             throw nvr;
         } finally {
-            image.exitingContextNode();
+            image.exitingContext();
             materializeContextOnMethodExitNode.execute(frame);
         }
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/StartContextRootNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/StartContextRootNode.java
@@ -16,6 +16,7 @@ import com.oracle.truffle.api.nodes.NodeInfo;
 import de.hpi.swa.trufflesqueak.SqueakLanguage;
 import de.hpi.swa.trufflesqueak.exceptions.ProcessSwitch;
 import de.hpi.swa.trufflesqueak.exceptions.Returns.NonVirtualReturn;
+import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
 import de.hpi.swa.trufflesqueak.model.BlockClosureObject;
 import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
 import de.hpi.swa.trufflesqueak.model.NilObject;
@@ -31,6 +32,8 @@ public final class StartContextRootNode extends AbstractRootNode {
     @CompilationFinal private int initialPC;
     @CompilationFinal private int initialSP;
 
+    @CompilationFinal private final SqueakImageContext image;
+
     @Children private FrameStackWriteNode[] writeTempNodes;
     @Child private CheckForInterruptsQuickNode interruptHandlerNode;
     @Child private AbstractExecuteContextNode executeBytecodeNode;
@@ -39,7 +42,8 @@ public final class StartContextRootNode extends AbstractRootNode {
 
     public StartContextRootNode(final SqueakLanguage language, final CompiledCodeObject code) {
         super(language, code);
-        interruptHandlerNode = CheckForInterruptsQuickNode.createForSend(code);
+        image = code.getSqueakClass().getImage();
+        interruptHandlerNode = CheckForInterruptsQuickNode.createForSend(image, code);
         executeBytecodeNode = new ExecuteBytecodeNode(code);
     }
 
@@ -47,13 +51,18 @@ public final class StartContextRootNode extends AbstractRootNode {
     public Object execute(final VirtualFrame frame) {
         initializeFrame(frame);
         try {
+            if (image.enteringContextNodeWouldExceedDepth()) {
+                throw ProcessSwitch.create(getGetOrCreateContextNode().executeGet(frame));
+            }
+
             interruptHandlerNode.execute(frame);
             return executeBytecodeNode.execute(frame, initialPC);
         } catch (final NonVirtualReturn | ProcessSwitch nvr) {
-            /** {@link getGetOrCreateContextNode()} acts as {@link BranchProfile} */
+            /* {@link getGetOrCreateContextNode()} acts as {@link BranchProfile} */
             getGetOrCreateContextNode().executeGet(frame).markEscaped();
             throw nvr;
         } finally {
+            image.exitingContextNode();
             materializeContextOnMethodExitNode.execute(frame);
         }
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/StartContextRootNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/StartContextRootNode.java
@@ -52,7 +52,8 @@ public final class StartContextRootNode extends AbstractRootNode {
         initializeFrame(frame);
         try {
             if (image.enteringContextExceedsDepth()) {
-                throw ProcessSwitch.create(getGetOrCreateContextNode().executeGet(frame));
+                CompilerDirectives.transferToInterpreter();
+                throw ProcessSwitch.create(GetOrCreateContextNode.getOrCreateUncached(frame));
             }
             interruptHandlerNode.execute(frame);
             return executeBytecodeNode.execute(frame, initialPC);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interrupts/CheckForInterruptsQuickNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interrupts/CheckForInterruptsQuickNode.java
@@ -23,8 +23,7 @@ import de.hpi.swa.trufflesqueak.util.LogUtils;
 public abstract class CheckForInterruptsQuickNode extends AbstractNode {
     private static final int MIN_NUMBER_OF_BYTECODE_FOR_INTERRUPT_CHECKS = 32;
 
-    public static final CheckForInterruptsQuickNode createForSend(final CompiledCodeObject code) {
-        final SqueakImageContext image = code.getSqueakClass().getImage();
+    public static final CheckForInterruptsQuickNode createForSend(final SqueakImageContext image, final CompiledCodeObject code) {
         /*
          * Only check for interrupts if method is relatively large. Avoid check if primitive method
          * or if a closure is activated (effectively what #primitiveClosureValueNoContextSwitch is


### PR DESCRIPTION
Track the entries and exits of StartContextRootNode.execute() to count the Smalltalk context depth since the resumption of the active process. When the Smalltalk context depth exceeds a user-defined number, cause a process switch, flushing the Java stack and materializing all of the virtual Smalltalk contexts.

This PR adds an experimental option `--context-stack-depth=<int>` to control the maximum context stack depth. If the option is not present on the command line, the value defaults to 1000. 

Setting the option to zero will entirely disable the check and (hopefully) remove any run-time overhead.