### PR TITLE
ObjectGraphUtils traversal optimizations

### DIFF
--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/AbstractSqueakObjectWithClassAndHash.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/AbstractSqueakObjectWithClassAndHash.java
@@ -6,6 +6,7 @@
  */
 package de.hpi.swa.trufflesqueak.model;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import org.graalvm.collections.UnmodifiableEconomicMap;
 
 import com.oracle.truffle.api.CompilerAsserts;
@@ -55,7 +56,7 @@ public abstract class AbstractSqueakObjectWithClassAndHash extends AbstractSquea
             // Lookup a VarHandle for the 'flag' squeakHashAndBits
             FLAGS_HANDLE = MethodHandles.lookup().findVarHandle(AbstractSqueakObjectWithClassAndHash.class, "squeakHashAndBits", int.class);
         } catch (NoSuchFieldException | IllegalAccessException e) {
-            throw new Error(e);
+            throw CompilerDirectives.shouldNotReachHere("Unable to find a VarHandle for squeakHashAndBits", e);
         }
     }
 
@@ -150,9 +151,8 @@ public abstract class AbstractSqueakObjectWithClassAndHash extends AbstractSquea
     }
 
     /*
-     * Marking flag manipulations. The True/False suffix indicates the state of the
-     * MARK_BIT that corresponds to the object being in the marked state. All operations
-     * are thread safe.
+     * Marking flag manipulations. The True/False suffix indicates the state of the MARK_BIT that
+     * corresponds to the object being in the marked state. All operations are thread safe.
      */
 
     /**
@@ -204,9 +204,13 @@ public abstract class AbstractSqueakObjectWithClassAndHash extends AbstractSquea
     /**
      * Unmark this object; thread safe.
      */
-    public final void unmarkTrue() { tryToMarkFalse(); }
+    public final void unmarkTrue() {
+        tryToMarkFalse();
+    }
 
-    public final void unmarkFalse() { tryToMarkTrue(); }
+    public final void unmarkFalse() {
+        tryToMarkTrue();
+    }
 
     @Override
     public String toString() {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/AbstractSqueakObjectWithClassAndHash.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/AbstractSqueakObjectWithClassAndHash.java
@@ -79,7 +79,7 @@ public abstract class AbstractSqueakObjectWithClassAndHash extends AbstractSquea
         squeakHashAndBits = AbstractSqueakObjectWithClassAndHash.HASH_UNINITIALIZED;
         squeakClass = klass;
         if (markingFlag) {
-            tryToMarkTrue();
+            initMarkTrue();
         }
     }
 
@@ -154,6 +154,10 @@ public abstract class AbstractSqueakObjectWithClassAndHash extends AbstractSquea
      * Marking flag manipulations. The True/False suffix indicates the state of the MARK_BIT that
      * corresponds to the object being in the marked state. All operations are thread safe.
      */
+
+    private void initMarkTrue() {
+        squeakHashAndBits |= MARK_BIT;
+    }
 
     /**
      * @return <tt>true</tt> if marked, <tt>false</tt> otherwise; thread safe

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/EphemeronObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/EphemeronObject.java
@@ -118,9 +118,9 @@ public final class EphemeronObject extends AbstractPointersObject {
         hasBeenSignaled = true;
     }
 
-    public boolean keyHasBeenMarked(final boolean currentMarkingFlag) {
+    public boolean keyHasBeenMarked(final ObjectTracer tracer) {
         if (instVarAt0Slow(ObjectLayouts.EPHEMERON.KEY) instanceof final AbstractSqueakObjectWithClassAndHash key) {
-            return key.isMarked(currentMarkingFlag);
+            return tracer.isMarked(key);
         } else {
             return true;
         }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/StoragePrimitives.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/StoragePrimitives.java
@@ -54,7 +54,6 @@ import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive1WithFallbac
 import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive2WithFallback;
 import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive3WithFallback;
 import de.hpi.swa.trufflesqueak.nodes.primitives.SqueakPrimitive;
-import de.hpi.swa.trufflesqueak.util.ArrayUtils;
 import de.hpi.swa.trufflesqueak.util.MiscUtils;
 
 public final class StoragePrimitives extends AbstractPrimitiveFactoryHolder {
@@ -514,7 +513,7 @@ public final class StoragePrimitives extends AbstractPrimitiveFactoryHolder {
         @Specialization
         protected final ArrayObject doAll(@SuppressWarnings("unused") final Object receiver) {
             final SqueakImageContext image = getContext();
-            return image.asArrayOfObjects(ArrayUtils.toArray(image.objectGraphUtils.allInstances()));
+            return image.asArrayOfObjects(image.objectGraphUtils.allInstances());
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/FrameAccess.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/FrameAccess.java
@@ -479,17 +479,18 @@ public final class FrameAccess {
         CompilerDirectives.bailout("Finding materializable frames should never be part of compiled code as it triggers deopts");
         LogUtils.ITERATE_FRAMES.fine("Iterating frames to find a marker...");
         final Frame frame = Truffle.getRuntime().iterateFrames(frameInstance -> {
-            if (frameInstance.getCallTarget() instanceof final RootCallTarget rct && rct.getRootNode() instanceof final ResumeContextRootNode rcrn) {
-                /*
-                 * Reached end of Smalltalk activations on Truffle frames.
-                 */
-                final ContextObject context = rcrn.getActiveContext();
-                assert context.getFrameMarker() == frameMarker : "Failed to find frameMarker in ResumeContextRootNode";
-                return context.getTruffleFrame();
-            }
             final Frame current = frameInstance.getFrame(FrameInstance.FrameAccess.READ_ONLY);
             if (!isTruffleSqueakFrame(current)) {
-                return null;
+                if (frameInstance.getCallTarget() instanceof final RootCallTarget rct && rct.getRootNode() instanceof final ResumeContextRootNode rcrn) {
+                    /*
+                     * Reached end of Smalltalk activations on Truffle frames.
+                     */
+                    final ContextObject context = rcrn.getActiveContext();
+                    assert context.getFrameMarker() == frameMarker : "Failed to find frameMarker in ResumeContextRootNode";
+                    return context.getTruffleFrame();
+                } else {
+                    return null;
+                }
             }
             LogUtils.ITERATE_FRAMES.fine(() -> "..." + FrameAccess.getCodeObject(current).toString());
             if (frameMarker == getMarker(current)) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/ObjectGraphUtils.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/ObjectGraphUtils.java
@@ -43,7 +43,7 @@ import de.hpi.swa.trufflesqueak.nodes.ResumeContextRootNode;
 public final class ObjectGraphUtils {
     private static final int ADDITIONAL_SPACE = 10_000;
     private static int lastSeenObjects = 500_000;
-    private static final int USABLE_THREAD_COUNT = Math.min(Runtime.getRuntime().availableProcessors(), 1);
+    private static final int USABLE_THREAD_COUNT = Math.min(Runtime.getRuntime().availableProcessors(), 4);
     private static final ExecutorService EXECUTOR = Executors.newFixedThreadPool(USABLE_THREAD_COUNT, r -> new Thread(r, "TruffleSqueakObjectGraphUtils"));
 
     private final SqueakImageContext image;

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/ObjectGraphUtils.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/ObjectGraphUtils.java
@@ -582,8 +582,8 @@ public final class ObjectGraphUtils {
                 if (!FrameAccess.isTruffleSqueakFrame(current)) {
                     if (frameInstance.getCallTarget() instanceof final RootCallTarget rct && rct.getRootNode() instanceof final ResumeContextRootNode rcrn) {
                         /*
-                         * Reached end of Smalltalk activations on Truffle frames. From here, tracing
-                         * should continue to walk senders via ContextObjects.
+                         * Reached end of Smalltalk activations on Truffle frames. From here,
+                         * tracing should continue to walk senders via ContextObjects.
                          */
                         return rcrn.getActiveContext(); // break
                     } else {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/ObjectGraphUtils.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/ObjectGraphUtils.java
@@ -505,13 +505,11 @@ public final class ObjectGraphUtils {
 
         private void addObjectsFromFrames() {
             CompilerAsserts.neverPartOfCompilation();
-            boolean[] atLeastOneFrame = {false};
             Truffle.getRuntime().iterateFrames(frameInstance -> {
                 final Frame current = frameInstance.getFrame(FrameInstance.FrameAccess.READ_ONLY);
                 if (!FrameAccess.isTruffleSqueakFrame(current)) {
                     return null;
                 }
-                atLeastOneFrame[0] = true;
                 addAllIfUnmarked(current.getArguments());
                 addIfUnmarked(FrameAccess.getContext(current));
                 FrameAccess.iterateStackSlots(current, slotIndex -> {
@@ -521,9 +519,6 @@ public final class ObjectGraphUtils {
                 });
                 return null;
             });
-            if (!atLeastOneFrame[0]) {
-                System.out.println("ObjectTracer did not find any frames!");
-            }
         }
 
         private AbstractSqueakObjectWithClassAndHash getNext() {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/ObjectGraphUtils.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/ObjectGraphUtils.java
@@ -465,7 +465,7 @@ public final class ObjectGraphUtils {
         finishPendingMarking(pending);
     }
 
-    private void finishPendingMarking(final ObjectTracer pending) {
+    private static void finishPendingMarking(final ObjectTracer pending) {
         AbstractSqueakObjectWithClassAndHash currentObject;
         while ((currentObject = pending.getNext()) != null) {
             pending.tracePointers(currentObject);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/ObjectGraphUtils.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/ObjectGraphUtils.java
@@ -612,22 +612,12 @@ public final class ObjectGraphUtils {
         }
 
         public boolean isMarked(final AbstractSqueakObjectWithClassAndHash object) {
-            if (currentMarkingFlag) {
-                return object.isMarkedTrue();
-            } else {
-                return object.isMarkedFalse();
-            }
+            return object.isMarkedWith(currentMarkingFlag);
         }
 
         public void addIfUnmarked(final Object object) {
-            if (currentMarkingFlag) {
-                if ((object instanceof final AbstractSqueakObjectWithClassAndHash o) && o.tryToMarkTrue()) {
-                    workStack.addFirst(o);
-                }
-            } else {
-                if ((object instanceof final AbstractSqueakObjectWithClassAndHash o) && o.tryToMarkFalse()) {
-                    workStack.addFirst(o);
-                }
+            if ((object instanceof final AbstractSqueakObjectWithClassAndHash o) && o.tryToMarkWith(currentMarkingFlag)) {
+                workStack.addFirst(o);
             }
         }
 
@@ -646,20 +636,11 @@ public final class ObjectGraphUtils {
          * Unmark all objects remaining in the object graph traversal AND in the argument.
          */
         private void unmarkAll(final ArrayDeque<AbstractSqueakObjectWithClassAndHash> objects) {
-            if (currentMarkingFlag) {
-                for (final AbstractSqueakObjectWithClassAndHash object : workStack) {
-                    object.unmarkTrue();
-                }
-                for (final AbstractSqueakObjectWithClassAndHash object : objects) {
-                    object.unmarkTrue();
-                }
-            } else {
-                for (final AbstractSqueakObjectWithClassAndHash object : workStack) {
-                    object.unmarkFalse();
-                }
-                for (final AbstractSqueakObjectWithClassAndHash object : objects) {
-                    object.unmarkFalse();
-                }
+            for (final AbstractSqueakObjectWithClassAndHash object : workStack) {
+                object.unmarkWith(currentMarkingFlag);
+            }
+            for (final AbstractSqueakObjectWithClassAndHash object : objects) {
+                object.unmarkWith(currentMarkingFlag);
             }
         }
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/ObjectGraphUtils.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/ObjectGraphUtils.java
@@ -578,16 +578,17 @@ public final class ObjectGraphUtils {
         private void addObjectsFromFrames() {
             CompilerAsserts.neverPartOfCompilation();
             final ContextObject resumeContextObject = Truffle.getRuntime().iterateFrames(frameInstance -> {
-                if (frameInstance.getCallTarget() instanceof final RootCallTarget rct && rct.getRootNode() instanceof final ResumeContextRootNode rcrn) {
-                    /*
-                     * Reached end of Smalltalk activations on Truffle frames. From here, tracing
-                     * should continue to walk senders via ContextObjects.
-                     */
-                    return rcrn.getActiveContext(); // break
-                }
                 final Frame current = frameInstance.getFrame(FrameInstance.FrameAccess.READ_ONLY);
                 if (!FrameAccess.isTruffleSqueakFrame(current)) {
-                    return null; // skip
+                    if (frameInstance.getCallTarget() instanceof final RootCallTarget rct && rct.getRootNode() instanceof final ResumeContextRootNode rcrn) {
+                        /*
+                         * Reached end of Smalltalk activations on Truffle frames. From here, tracing
+                         * should continue to walk senders via ContextObjects.
+                         */
+                        return rcrn.getActiveContext(); // break
+                    } else {
+                        return null; // skip
+                    }
                 }
                 addAllIfUnmarked(current.getArguments());
                 addIfUnmarked(FrameAccess.getContext(current));

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/ObjectGraphUtils.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/ObjectGraphUtils.java
@@ -100,7 +100,6 @@ public final class ObjectGraphUtils {
             }
         }
 
-
         final long startTime = System.nanoTime();
 
         final ObjectTracer roots = new ObjectTracer(true);
@@ -433,7 +432,7 @@ public final class ObjectGraphUtils {
         return true;
     }
 
-    private void traceRemainingEphemerons(final ArrayDeque<EphemeronObject> ephemeronsToBeMarked, final ObjectTracer pending, final boolean currentMarkingFlag) {
+    private static void traceRemainingEphemerons(final ArrayDeque<EphemeronObject> ephemeronsToBeMarked, final ObjectTracer pending, final boolean currentMarkingFlag) {
         // Trace the ephemerons that have marked keys until there are only ephemerons with unmarked
         // keys left.
         while (true) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/ObjectGraphUtils.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/ObjectGraphUtils.java
@@ -42,6 +42,8 @@ public final class ObjectGraphUtils {
 
     private static int lastSeenObjects = 500_000;
 
+    private final int usableThreadCount = Math.min(Runtime.getRuntime().availableProcessors(), 4);
+
     private final SqueakImageContext image;
     private final boolean trackOperations;
 
@@ -49,8 +51,6 @@ public final class ObjectGraphUtils {
         this.image = image;
         this.trackOperations = image.options.printResourceSummary() || LogUtils.OBJECT_GRAPH.isLoggable(Level.FINE);
     }
-
-    final int usableThreadCount = Math.min(Runtime.getRuntime().availableProcessors(), 4);
 
     public static int getLastSeenObjects() {
         return lastSeenObjects;
@@ -514,7 +514,7 @@ public final class ObjectGraphUtils {
             });
         }
 
-        public ObjectTracer(ObjectTracer roots) {
+        public ObjectTracer(final ObjectTracer roots) {
             // Create an empty traversal based on this root traversal.
             this.currentMarkingFlag = roots.currentMarkingFlag;
         }


### PR DESCRIPTION
Changed ObjectTracer to mark unmarked objects when adding them to the workStack. This avoids an extra check in all of the traversals and eliminates the potential examination of an object multiple times.

Since the workStack is a stack, reordered the initialization to put the specialObjectsArray (and its contents) at the top of the stack and changed tracePointers to add the class after the inner pointers so that the class would be traversed before the other pointers.

Rearranged pointersBecomeOneWay and allInstancesOf so that up to 4 tasks can work independently on subgraphs of the entire object graph.