### PR TITLE
Make ContextPart>>terminateTo: confirm sender chain before terminating Contexts

### DIFF
--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
@@ -209,14 +209,14 @@ public final class ContextObject extends AbstractSqueakObjectWithClassAndHash {
     public AbstractSqueakObject getSender() {
         final Object value = getFrameSender();
         if (value instanceof final FrameMarker f) {
-            return fillInSenderFromMaker(f);
+            return fillInSenderFromMarker(f);
         } else {
             return (AbstractSqueakObject) value;
         }
     }
 
     @TruffleBoundary
-    private AbstractSqueakObject fillInSenderFromMaker(final FrameMarker value) {
+    private AbstractSqueakObject fillInSenderFromMarker(final FrameMarker value) {
         final CompiledCodeObject methodOrBlock = getCodeObject();
         if (!methodOrBlock.hasPrimitive() || methodOrBlock.isUnwindMarked() || methodOrBlock.isExceptionHandlerMarked()) {
             /*
@@ -262,6 +262,12 @@ public final class ContextObject extends AbstractSqueakObjectWithClassAndHash {
             hasModifiedSender = false;
         }
         FrameAccess.setSender(getOrCreateTruffleFrame(), NilObject.SINGLETON);
+    }
+
+    public void clearModifiedSender() {
+        if (hasModifiedSender) {
+            hasModifiedSender = false;
+        }
     }
 
     public Object getInstructionPointer(final InlinedConditionProfile nilProfile, final Node node) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/bytecodes/ReturnBytecodes.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/bytecodes/ReturnBytecodes.java
@@ -63,6 +63,9 @@ public final class ReturnBytecodes {
     }
 
     private static final class ReturnFromMethodNode extends AbstractReturnKindNode {
+
+        /* Return to sender (never needs to unwind) */
+
         private final ConditionProfile hasModifiedSenderProfile = ConditionProfile.create();
 
         @Override
@@ -78,6 +81,9 @@ public final class ReturnBytecodes {
     }
 
     private static final class ReturnFromClosureNode extends AbstractReturnKindNode {
+
+        /* Return to closure's home context's sender, executing unwind blocks */
+
         @Override
         protected Object execute(final VirtualFrame frame, final Object returnValue) {
             assert FrameAccess.hasClosure(frame);
@@ -158,6 +164,9 @@ public final class ReturnBytecodes {
     }
 
     public abstract static class AbstractBlockReturnNode extends AbstractReturnNode {
+
+        /* Return to caller (never needs to unwind) */
+
         private final ConditionProfile hasModifiedSenderProfile = ConditionProfile.create();
 
         protected AbstractBlockReturnNode(final CompiledCodeObject code, final int index) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/FrameAccess.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/FrameAccess.java
@@ -325,6 +325,9 @@ public final class FrameAccess {
     public static void terminate(final Frame frame) {
         setInstructionPointer(frame, ContextObject.NIL_PC_VALUE);
         setSender(frame, NilObject.SINGLETON);
+        if (frame.getObject(SlotIndicies.THIS_CONTEXT.ordinal()) instanceof final ContextObject context) {
+            context.clearModifiedSender();
+        }
     }
 
     public static boolean isTruffleSqueakFrame(final Frame frame) {


### PR DESCRIPTION
1. PrimTerminateNode describes primitive 196 as
```
            /*
             * Terminate all the Contexts between me and previousContext, if previousContext is on
             * my Context stack. Make previousContext my sender.
             */
```
but the implementation was terminating Contexts above the receiver, stopping when finding either previousContext or nil.

Modified implementation to check for previousContext first, and, if found, then do the termination.

2. Corrected an asymmetry between ContextObject.terminate() and FrameAccess.terminate(): ContextObject cleared the modified sender flag, but FrameAccess did not. Not sure ContextObject.clearModifiedSender needs to check before clearing the flag [just following the example in ContextObject.removeSender()]

3. Fixed typo and added some documentation for the return bytecodes. 