### PR TITLE
Separate the roles of NLR and NVR

### DIFF
--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/exceptions/Returns.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/exceptions/Returns.java
@@ -54,18 +54,22 @@ public final class Returns {
 
     public static final class NonVirtualReturn extends AbstractReturn {
         private static final long serialVersionUID = 1L;
-        private final transient ContextObject targetContext;
+        private final transient Object targetContextOrMarker;
         private final transient ContextObject currentContext;
 
-        public NonVirtualReturn(final Object returnValue, final ContextObject targetContext, final ContextObject currentContext) {
+        public NonVirtualReturn(final Object returnValue, final Object targetContextOrMarker, final ContextObject currentContext) {
             super(returnValue);
-            assert !targetContext.isDead() : "Cannot return to terminated context";
-            this.targetContext = targetContext;
+            assert targetContextOrMarker instanceof ContextObject || targetContextOrMarker instanceof FrameMarker;
+            this.targetContextOrMarker = targetContextOrMarker;
             this.currentContext = currentContext;
         }
 
+        public Object getTargetContextOrMarker() {
+            return targetContextOrMarker;
+        }
+
         public ContextObject getTargetContext() {
-            return targetContext;
+            return (ContextObject) targetContextOrMarker;
         }
 
         public ContextObject getCurrentContext() {
@@ -75,7 +79,7 @@ public final class Returns {
         @Override
         public String toString() {
             CompilerAsserts.neverPartOfCompilation();
-            return "NVR (value: " + returnValue + ", current: " + currentContext + ", target: " + targetContext + ")";
+            return "NVR (value: " + returnValue + ", current: " + currentContext + ", target: " + targetContextOrMarker + ")";
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/exceptions/Returns.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/exceptions/Returns.java
@@ -11,6 +11,7 @@ import com.oracle.truffle.api.nodes.ControlFlowException;
 
 import de.hpi.swa.trufflesqueak.model.ContextObject;
 import de.hpi.swa.trufflesqueak.model.FrameMarker;
+import de.hpi.swa.trufflesqueak.model.NilObject;
 
 public final class Returns {
     private abstract static class AbstractReturn extends ControlFlowException {
@@ -64,22 +65,18 @@ public final class Returns {
 
     public static final class NonVirtualReturn extends AbstractReturn {
         private static final long serialVersionUID = 1L;
-        private final transient Object targetContextOrMarker;
+        private final transient Object targetContextMarkerOrNil;
         private final transient ContextObject currentContext;
 
-        public NonVirtualReturn(final Object returnValue, final Object targetContextOrMarker, final ContextObject currentContext) {
+        public NonVirtualReturn(final Object returnValue, final Object targetContextMarkerOrNil, final ContextObject currentContext) {
             super(returnValue);
-            assert targetContextOrMarker instanceof ContextObject || targetContextOrMarker instanceof FrameMarker;
-            this.targetContextOrMarker = targetContextOrMarker;
+            assert targetContextMarkerOrNil instanceof ContextObject || targetContextMarkerOrNil instanceof FrameMarker || targetContextMarkerOrNil == NilObject.SINGLETON;
+            this.targetContextMarkerOrNil = targetContextMarkerOrNil;
             this.currentContext = currentContext;
         }
 
-        public Object getTargetContextOrMarker() {
-            return targetContextOrMarker;
-        }
-
-        public ContextObject getTargetContext() {
-            return (ContextObject) targetContextOrMarker;
+        public Object getTargetContextMarkerOrNil() {
+            return targetContextMarkerOrNil;
         }
 
         public ContextObject getCurrentContext() {
@@ -89,7 +86,7 @@ public final class Returns {
         @Override
         public String toString() {
             CompilerAsserts.neverPartOfCompilation();
-            return "NVR (value: " + returnValue + ", current: " + currentContext + ", target: " + targetContextOrMarker + ")";
+            return "NVR (value: " + returnValue + ", current: " + currentContext + ", target: " + targetContextMarkerOrNil + ")";
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/exceptions/Returns.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/exceptions/Returns.java
@@ -45,6 +45,16 @@ public final class Returns {
             return (ContextObject) targetContextOrMarker;
         }
 
+        public ContextObject getOrCreateTargetContext() {
+            if (targetContextOrMarker instanceof final ContextObject targetContext) {
+                return targetContext;
+            } else if (targetContextOrMarker instanceof final FrameMarker frameMarker) {
+                return frameMarker.getMaterializedContext();
+            } else {
+                throw SqueakExceptions.SqueakException.create("Could not create Context for:", targetContextOrMarker);
+            }
+        }
+
         @Override
         public String toString() {
             CompilerAsserts.neverPartOfCompilation();

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/exceptions/Returns.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/exceptions/Returns.java
@@ -75,10 +75,6 @@ public final class Returns {
             this.currentContext = currentContext;
         }
 
-        public Object getTargetContextOrMarker() {
-            return targetContextOrMarker;
-        }
-
         public Object getTargetContextMarkerOrNil() {
             return targetContextMarkerOrNil;
         }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/exceptions/Returns.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/exceptions/Returns.java
@@ -75,6 +75,10 @@ public final class Returns {
             this.currentContext = currentContext;
         }
 
+        public Object getTargetContextOrMarker() {
+            return targetContextOrMarker;
+        }
+
         public Object getTargetContextMarkerOrNil() {
             return targetContextMarkerOrNil;
         }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/exceptions/Returns.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/exceptions/Returns.java
@@ -30,12 +30,19 @@ public final class Returns {
 
     public static final class NonLocalReturn extends AbstractReturn {
         private static final long serialVersionUID = 1L;
+        private final transient ContextObject homeContext;
         private final transient Object targetContextOrMarker;
 
-        public NonLocalReturn(final Object returnValue, final Object targetContextOrMarker) {
+        public NonLocalReturn(final Object returnValue, final ContextObject homeContext) {
             super(returnValue);
-            assert targetContextOrMarker instanceof ContextObject || targetContextOrMarker instanceof FrameMarker;
-            this.targetContextOrMarker = targetContextOrMarker;
+            final Object target = homeContext.getFrameSender();
+            assert target instanceof ContextObject || target instanceof FrameMarker;
+            this.homeContext = homeContext;
+            this.targetContextOrMarker = target;
+        }
+
+        public ContextObject getHomeContext() {
+            return homeContext;
         }
 
         public Object getTargetContextOrMarker() {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
@@ -405,6 +405,10 @@ public final class ContextObject extends AbstractSqueakObjectWithClassAndHash {
         escaped = true;
     }
 
+    public void clearModifiedSender() {
+        hasModifiedSender = false;
+    }
+
     public boolean hasModifiedSender() {
         return hasModifiedSender;
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
@@ -253,6 +253,16 @@ public final class ContextObject extends AbstractSqueakObjectWithClassAndHash {
         setSenderUnsafe(value);
     }
 
+    public void setNilSender() {
+        if (truffleFrame != null) {
+            final Object sender = FrameAccess.getSender(getTruffleFrame());
+            if (!hasModifiedSender && sender != NilObject.SINGLETON) {
+                hasModifiedSender = true;
+            }
+        }
+        setSenderUnsafe(NilObject.SINGLETON);
+    }
+
     public void setSenderUnsafe(final AbstractSqueakObject value) {
         FrameAccess.setSender(getOrCreateTruffleFrame(), value);
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/AboutToReturnNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/AboutToReturnNode.java
@@ -76,8 +76,8 @@ public abstract class AboutToReturnNode extends AbstractNode {
         @Specialization(guards = {"hasModifiedSender(frame)"})
         protected static final void doAboutToReturn(final VirtualFrame frame, final NonLocalReturn nlr,
                         @Cached("createAboutToReturnSend()") final Dispatch2Node sendAboutToReturnNode) {
-            assert nlr.getTargetContextOrMarker() instanceof ContextObject;
-            sendAboutToReturnNode.execute(frame, FrameAccess.getContext(frame), nlr.getReturnValue(), nlr.getTargetContextOrMarker());
+//            assert nlr.getTargetContextOrMarker() instanceof ContextObject;
+            sendAboutToReturnNode.execute(frame, FrameAccess.getContext(frame), nlr.getReturnValue(), nlr.getOrCreateTargetContext());
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/AboutToReturnNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/AboutToReturnNode.java
@@ -77,6 +77,7 @@ public abstract class AboutToReturnNode extends AbstractNode {
         @Specialization(guards = {"hasModifiedSender(frame)"})
         protected static final void doAboutToReturn(final VirtualFrame frame, final NonLocalReturn nlr,
                         @Cached("createAboutToReturnSend()") final Dispatch2Node sendAboutToReturnNode) {
+            // @formatter:off
             /*
              *  aboutToReturn: result through: firstUnwindContext
 	         *      "Called from VM when an unwindBlock is found between self and its home.
@@ -84,6 +85,7 @@ public abstract class AboutToReturnNode extends AbstractNode {
              *
 	         *      self methodReturnContext return: result through: firstUnwindContext
              */
+            // @formatter:on
             // Message receiver should be home Context to return from.
             // Last argument should be the first unwind-marked Context or nil.
             sendAboutToReturnNode.execute(frame, nlr.getHomeContext(), nlr.getReturnValue(), NilObject.SINGLETON);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/AboutToReturnNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/AboutToReturnNode.java
@@ -80,10 +80,10 @@ public abstract class AboutToReturnNode extends AbstractNode {
             // @formatter:off
             /*
              *  aboutToReturn: result through: firstUnwindContext
-	         *      "Called from VM when an unwindBlock is found between self and its home.
-	         *      Return to home's sender, executing unwind blocks on the way."
+             *      "Called from VM when an unwindBlock is found between self and its home.
+             *      Return to home's sender, executing unwind blocks on the way."
              *
-	         *      self methodReturnContext return: result through: firstUnwindContext
+             *      self methodReturnContext return: result through: firstUnwindContext
              */
             // @formatter:on
             // Message receiver should be home Context to return from.

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/AboutToReturnNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/AboutToReturnNode.java
@@ -76,7 +76,7 @@ public abstract class AboutToReturnNode extends AbstractNode {
         @Specialization(guards = {"hasModifiedSender(frame)"})
         protected static final void doAboutToReturn(final VirtualFrame frame, final NonLocalReturn nlr,
                         @Cached("createAboutToReturnSend()") final Dispatch2Node sendAboutToReturnNode) {
-//            assert nlr.getTargetContextOrMarker() instanceof ContextObject;
+            /* assert nlr.getTargetContextOrMarker() instanceof ContextObject; */
             sendAboutToReturnNode.execute(frame, FrameAccess.getContext(frame), nlr.getReturnValue(), nlr.getOrCreateTargetContext());
         }
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/AboutToReturnNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/AboutToReturnNode.java
@@ -22,6 +22,7 @@ import de.hpi.swa.trufflesqueak.model.BlockClosureObject;
 import de.hpi.swa.trufflesqueak.model.BooleanObject;
 import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
 import de.hpi.swa.trufflesqueak.model.ContextObject;
+import de.hpi.swa.trufflesqueak.model.NilObject;
 import de.hpi.swa.trufflesqueak.nodes.AboutToReturnNodeFactory.AboutToReturnImplNodeGen;
 import de.hpi.swa.trufflesqueak.nodes.context.frame.FrameStackReadNode;
 import de.hpi.swa.trufflesqueak.nodes.context.frame.FrameStackWriteNode;
@@ -76,8 +77,16 @@ public abstract class AboutToReturnNode extends AbstractNode {
         @Specialization(guards = {"hasModifiedSender(frame)"})
         protected static final void doAboutToReturn(final VirtualFrame frame, final NonLocalReturn nlr,
                         @Cached("createAboutToReturnSend()") final Dispatch2Node sendAboutToReturnNode) {
-            /* assert nlr.getTargetContextOrMarker() instanceof ContextObject; */
-            sendAboutToReturnNode.execute(frame, FrameAccess.getContext(frame), nlr.getReturnValue(), nlr.getOrCreateTargetContext());
+            /*
+             *  aboutToReturn: result through: firstUnwindContext
+	         *      "Called from VM when an unwindBlock is found between self and its home.
+	         *      Return to home's sender, executing unwind blocks on the way."
+             *
+	         *      self methodReturnContext return: result through: firstUnwindContext
+             */
+            // Message receiver should be home Context to return from.
+            // Last argument should be the first unwind-marked Context or nil.
+            sendAboutToReturnNode.execute(frame, nlr.getHomeContext(), nlr.getReturnValue(), NilObject.SINGLETON);
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteBytecodeNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteBytecodeNode.java
@@ -56,7 +56,7 @@ public final class ExecuteBytecodeNode extends AbstractExecuteContextNode implem
         } catch (final NonLocalReturn nlr) {
             /* {@link getHandleNonLocalReturnNode()} acts as {@link BranchProfile} */
             if (FrameAccess.isDead(frame)) {
-                LogUtils.SCHEDULING.info("ExecuteBytecodeNode: encountered dead frame during NLR");
+                LogUtils.SCHEDULING.fine("ExecuteBytecodeNode: encountered dead frame during NLR");
                 throw nlr;
             }
             return getHandleNonLocalReturnNode().executeHandle(frame, nlr);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteBytecodeNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteBytecodeNode.java
@@ -55,11 +55,12 @@ public final class ExecuteBytecodeNode extends AbstractExecuteContextNode implem
             return interpretBytecode(frame, startPC);
         } catch (final NonLocalReturn nlr) {
             /* {@link getHandleNonLocalReturnNode()} acts as {@link BranchProfile} */
+            final HandleNonLocalReturnNode handleNode = getHandleNonLocalReturnNode();
             if (FrameAccess.isDead(frame)) {
                 LogUtils.SCHEDULING.fine("ExecuteBytecodeNode: encountered dead frame during NLR");
                 throw nlr;
             }
-            return getHandleNonLocalReturnNode().executeHandle(frame, nlr);
+            return handleNode.executeHandle(frame, nlr);
         } catch (final StackOverflowError e) {
             CompilerDirectives.transferToInterpreter();
             throw getContext().tryToSignalLowSpace(frame, e);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteBytecodeNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteBytecodeNode.java
@@ -28,6 +28,7 @@ import de.hpi.swa.trufflesqueak.nodes.bytecodes.JumpBytecodes.ConditionalJumpNod
 import de.hpi.swa.trufflesqueak.nodes.bytecodes.ReturnBytecodes.AbstractReturnNode;
 import de.hpi.swa.trufflesqueak.nodes.bytecodes.SendBytecodes.AbstractSendNode;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
+import de.hpi.swa.trufflesqueak.util.LogUtils;
 
 public final class ExecuteBytecodeNode extends AbstractExecuteContextNode implements BytecodeOSRNode {
     private static final int LOCAL_RETURN_PC = -2;
@@ -54,6 +55,10 @@ public final class ExecuteBytecodeNode extends AbstractExecuteContextNode implem
             return interpretBytecode(frame, startPC);
         } catch (final NonLocalReturn nlr) {
             /* {@link getHandleNonLocalReturnNode()} acts as {@link BranchProfile} */
+            if (FrameAccess.isDead(frame)) {
+                LogUtils.SCHEDULING.info("ExecuteBytecodeNode: encountered dead frame during NLR");
+                throw nlr;
+            }
             return getHandleNonLocalReturnNode().executeHandle(frame, nlr);
         } catch (final StackOverflowError e) {
             CompilerDirectives.transferToInterpreter();

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
@@ -177,6 +177,7 @@ public final class ExecuteTopLevelContextNode extends RootNode {
         /* "make sure we can return to the given context" */
         if (!targetContext.hasClosure() && !targetContext.canBeReturnedTo()) {
             if (startContext == targetContext) {
+                image.printToStdErr("returnToTopLevel", startContext, "with return value:", returnValue);
                 throw returnToTopLevel(targetContext, returnValue);
             }
             return sendCannotReturn(startContext, returnValue);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
@@ -202,6 +202,9 @@ public final class ExecuteTopLevelContextNode extends RootNode {
                     AboutToReturnNode.create(context.getCodeObject()).executeAboutToReturn(context.getTruffleFrame(), nlr);
                 } catch (NonVirtualReturn nvr) {
                     return commonNVReturn(context, nvr);
+                } catch (ProcessSwitch ps) {
+                    LogUtils.SCHEDULING.info("commonNLReturn: ProcessSwitch during AboutToReturn! ");
+                    throw ps;
                 }
             }
             final ContextObject currentSender = (ContextObject) context.getSender();

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
@@ -200,7 +200,7 @@ public final class ExecuteTopLevelContextNode extends RootNode {
                     context.clearModifiedSender();
                     AboutToReturnNode.create(context.getCodeObject()).executeAboutToReturn(context.getTruffleFrame(), nlr);
                 } catch (NonVirtualReturn nvr) {
-                    return returnTo(context, nvr.getTargetContext(), nvr.getReturnValue());
+                    return commonNVReturn(context, nvr);
                 }
             }
             final ContextObject currentSender = (ContextObject) context.getSender();

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
@@ -117,7 +117,7 @@ public final class ExecuteTopLevelContextNode extends RootNode {
     private ContextObject sendCannotReturnOrReturnToTopLevel(final ContextObject startContext, final ContextObject targetContext, final Object returnValue) {
         // Exit the interpreter loop if the target is the context that started the loop.
         if (targetContext != null && targetContext == initialContext) {
-            LogUtils.SCHEDULING.info("sendCannotReturnOrReturnToTopLevel " + targetContext + " with return value: " + returnValue);
+            LogUtils.SCHEDULING.fine("sendCannotReturnOrReturnToTopLevel " + targetContext + " with return value: " + returnValue);
             throw returnToTopLevel(targetContext, returnValue);
         }
         return sendCannotReturn(startContext, returnValue);
@@ -203,7 +203,7 @@ public final class ExecuteTopLevelContextNode extends RootNode {
                 } catch (NonVirtualReturn nvr) {
                     return commonNVReturn(context, nvr);
                 } catch (ProcessSwitch ps) {
-                    LogUtils.SCHEDULING.info("commonNLReturn: ProcessSwitch during AboutToReturn! ");
+                    LogUtils.SCHEDULING.warning("commonNLReturn: ProcessSwitch during AboutToReturn!");
                     throw ps;
                 }
             }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
@@ -214,6 +214,7 @@ public final class ExecuteTopLevelContextNode extends RootNode {
         /* "make sure we can return to the given context" */
         if (!targetContext.hasClosure() && !targetContext.canBeReturnedTo()) {
             if (startContext == targetContext) {
+                image.printToStdErr("returnToTopLevel", startContext, "with return value:", returnValue);
                 throw returnToTopLevel(targetContext, returnValue);
             }
             return sendCannotReturn(startContext, returnValue);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
@@ -171,7 +171,9 @@ public final class ExecuteTopLevelContextNode extends RootNode {
     }
 
     @TruffleBoundary
-    private ContextObject commonReturn(final ContextObject startContext, final ContextObject targetContext, final Object returnValue) {
+    private ContextObject commonReturn(final ContextObject startContextOrNull, final ContextObject targetContext, final Object returnValue) {
+        // Normal returns with modified senders end up here with a target but no start Context.
+        final ContextObject startContext = startContextOrNull == null ? targetContext : startContextOrNull;
         /* "make sure we can return to the given context" */
         if (!targetContext.hasClosure() && !targetContext.canBeReturnedTo()) {
             if (startContext == targetContext) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
@@ -241,22 +241,22 @@ public final class ExecuteTopLevelContextNode extends RootNode {
                 return sendCannotReturn(startContext, returnValue);
             }
             assert !context.isPrimitiveContext();
-            if (context.getCodeObject().isUnwindMarked()) {
-                try {
-                    // TODO: make this better. Clearing the modified sender permits virtualization
-                    // of aboutToReturn
-                    context.clearModifiedSender();
-                    AboutToReturnNode.create(context.getCodeObject()).executeAboutToReturn(context.getTruffleFrame(), nlr);
-                } catch (NonVirtualReturn nvr) {
-                    return commonNVReturn(context, nvr);
-                } catch (ProcessSwitch ps) {
-                    LogUtils.SCHEDULING.info("commonNLReturn: ProcessSwitch during AboutToReturn! ");
-                    throw ps;
-                }
-            }
-            final ContextObject currentSender = (ContextObject) context.getSender();
-            context.terminate();
-            context = currentSender;
+//            if (context.getCodeObject().isUnwindMarked()) {
+//                assert !context.hasClosure();
+//                /* "context is marked; break out" */
+//                return sendAboutToReturn(startContext, returnValue, context);
+//            }
+            contextOrNil = context.getSender();
+        }
+        /*
+         * "If we get here there is no unwind to worry about. Simply terminate the stack up to the
+         * localCntx - often just the sender of the method"
+         */
+        ContextObject currentContext = startContext;
+        while (currentContext != targetContext) {
+            final ContextObject sender = (ContextObject) currentContext.getFrameSender();
+            currentContext.terminate();
+            currentContext = sender;
         }
         targetContext.push(returnValue);
         return targetContext;

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
@@ -230,6 +230,7 @@ public final class ExecuteTopLevelContextNode extends RootNode {
         throw CompilerDirectives.shouldNotReachHere("cannotReturn should trigger a ProcessSwitch");
     }
 
+    @SuppressWarnings("unused")
     private ContextObject sendAboutToReturn(final ContextObject startContext, final Object returnValue, final ContextObject context) {
         // TODO: Perhaps use this when image does all aboutToReturn processing.
         /*

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
@@ -191,7 +191,8 @@ public final class ExecuteTopLevelContextNode extends RootNode {
         while (context != targetContext) {
             if (context.getCodeObject().isUnwindMarked()) {
                 try {
-                    // TODO: make this better. Clearing the modified sender permits virtualization of aboutToReturn
+                    // TODO: make this better. Clearing the modified sender permits virtualization
+                    // of aboutToReturn
                     context.clearModifiedSender();
                     AboutToReturnNode.create(context.getCodeObject()).executeAboutToReturn(context.getTruffleFrame(), nlr);
                 } catch (NonVirtualReturn nvr) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
@@ -196,7 +196,8 @@ public final class ExecuteTopLevelContextNode extends RootNode {
         while (context != targetContext) {
             if (context.getCodeObject().isUnwindMarked()) {
                 try {
-                    // TODO: make this better. Clearing the modified sender permits virtualization of aboutToReturn
+                    // TODO: make this better. Clearing the modified sender permits virtualization
+                    // of aboutToReturn
                     context.clearModifiedSender();
                     AboutToReturnNode.create(context.getCodeObject()).executeAboutToReturn(context.getTruffleFrame(), nlr);
                 } catch (NonVirtualReturn nvr) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
@@ -199,9 +199,11 @@ public final class ExecuteTopLevelContextNode extends RootNode {
         while (context != targetContext) {
             if (context.getCodeObject().isUnwindMarked()) {
                 try {
-                    /* TODO: Not sure whether we can mix the virtualized Context>>aboutToReturn:through:
-                     *  with sending the actual message. Clearing the modified sender forces the use
-                     *  of the virtualized implementation of aboutToReturn.
+                    /*
+                     * TODO: Not sure whether we can mix the virtualized
+                     * Context>>aboutToReturn:through: with sending the actual message. Clearing the
+                     * modified sender forces the use of the virtualized implementation of
+                     * aboutToReturn.
                      */
                     context.clearModifiedSender();
                     AboutToReturnNode.create(context.getCodeObject()).executeAboutToReturn(context.getTruffleFrame(), nlr);
@@ -233,6 +235,7 @@ public final class ExecuteTopLevelContextNode extends RootNode {
     @SuppressWarnings("unused")
     private ContextObject sendAboutToReturn(final ContextObject startContext, final Object returnValue, final ContextObject context) {
         // TODO: Perhaps use this when image does all aboutToReturn processing.
+        // @formatter:off
         /*
          *  aboutToReturn: result through: firstUnwindContext
          *      "Called from VM when an unwindBlock is found between self and its home.
@@ -240,6 +243,7 @@ public final class ExecuteTopLevelContextNode extends RootNode {
          *
          *      self methodReturnContext return: result through: firstUnwindContext
          */
+        // @formatter:on
         // Message receiver should be home Context to return from.
         // Last argument should be the first unwind-marked Context or nil.
         try {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/HandleNonLocalReturnNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/HandleNonLocalReturnNode.java
@@ -9,18 +9,14 @@ package de.hpi.swa.trufflesqueak.nodes;
 import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.InlinedConditionProfile;
 
 import de.hpi.swa.trufflesqueak.exceptions.Returns.NonLocalReturn;
 import de.hpi.swa.trufflesqueak.exceptions.Returns.NonVirtualReturn;
-import de.hpi.swa.trufflesqueak.exceptions.SqueakExceptions;
 import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
 import de.hpi.swa.trufflesqueak.model.ContextObject;
-import de.hpi.swa.trufflesqueak.model.FrameMarker;
-import de.hpi.swa.trufflesqueak.model.NilObject;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
 public abstract class HandleNonLocalReturnNode extends AbstractNode {
@@ -43,21 +39,11 @@ public abstract class HandleNonLocalReturnNode extends AbstractNode {
         aboutToReturnNode.executeAboutToReturn(frame, nlr); // handle ensure: or ifCurtailed:
         if (hasModifiedSenderProfile.profile(node, FrameAccess.hasModifiedSender(frame))) {
             // Sender might have changed.
-            final ContextObject targetContext;
             final Object targetContextOrMarker = nlr.getTargetContextOrMarker();
-            if (targetContextOrMarker instanceof final ContextObject target) {
-                targetContext = target;
-            } else if (targetContextOrMarker instanceof final FrameMarker targetFrameMarker) {
-                final MaterializedFrame targetFrame = FrameAccess.findFrameForMarker(targetFrameMarker);
-                targetContext = FrameAccess.getContext(targetFrame);
-            } else {
-                assert targetContextOrMarker == NilObject.SINGLETON;
-                throw SqueakExceptions.SqueakException.create("Nil resuming context in HandleNonLocalReturnNode");
-            }
             final ContextObject newSender = FrameAccess.getSenderContext(frame);
             FrameAccess.terminateContextOrFrame(frame);
             // TODO: `target == newSender` may could use special handling?
-            throw new NonVirtualReturn(nlr.getReturnValue(), targetContext, newSender);
+            throw new NonVirtualReturn(nlr.getReturnValue(), targetContextOrMarker, newSender);
         } else {
             FrameAccess.terminateContextOrFrame(frame);
             throw nlr;

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/HandleNonLocalReturnNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/HandleNonLocalReturnNode.java
@@ -41,7 +41,7 @@ public abstract class HandleNonLocalReturnNode extends AbstractNode {
         try {
             aboutToReturnNode.executeAboutToReturn(frame, nlr); // handle ensure: or ifCurtailed:
         } catch (ProcessSwitch ps) {
-            LogUtils.SCHEDULING.info("HandleNonLocalReturnNode: ProcessSwitch during AboutToReturn! ");
+            LogUtils.SCHEDULING.warning("HandleNonLocalReturnNode: ProcessSwitch during AboutToReturn! ");
             throw ps;
         }
         if (hasModifiedSenderProfile.profile(node, FrameAccess.hasModifiedSender(frame))) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ResumeContextRootNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ResumeContextRootNode.java
@@ -37,7 +37,7 @@ public final class ResumeContextRootNode extends AbstractRootNode {
     public Object execute(final VirtualFrame frame) {
         try {
             assert !activeContext.isDead() : "Terminated contexts cannot be resumed";
-//            activeContext.clearModifiedSender();
+            activeContext.clearModifiedSender();
             final int pc = instructionPointerProfile.profile(activeContext.getInstructionPointerForBytecodeLoop());
             if (CompilerDirectives.isPartialEvaluationConstant(pc)) {
                 return executeBytecodeNode.execute(activeContext.getTruffleFrame(), pc);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ResumeContextRootNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ResumeContextRootNode.java
@@ -37,7 +37,7 @@ public final class ResumeContextRootNode extends AbstractRootNode {
     public Object execute(final VirtualFrame frame) {
         try {
             assert !activeContext.isDead() : "Terminated contexts cannot be resumed";
-            activeContext.clearModifiedSender();
+//            activeContext.clearModifiedSender();
             final int pc = instructionPointerProfile.profile(activeContext.getInstructionPointerForBytecodeLoop());
             if (CompilerDirectives.isPartialEvaluationConstant(pc)) {
                 return executeBytecodeNode.execute(activeContext.getTruffleFrame(), pc);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ResumeContextRootNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ResumeContextRootNode.java
@@ -37,6 +37,7 @@ public final class ResumeContextRootNode extends AbstractRootNode {
     public Object execute(final VirtualFrame frame) {
         try {
             assert !activeContext.isDead() : "Terminated contexts cannot be resumed";
+            activeContext.clearModifiedSender();
             final int pc = instructionPointerProfile.profile(activeContext.getInstructionPointerForBytecodeLoop());
             if (CompilerDirectives.isPartialEvaluationConstant(pc)) {
                 return executeBytecodeNode.execute(activeContext.getTruffleFrame(), pc);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/accessing/ContextObjectNodes.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/accessing/ContextObjectNodes.java
@@ -92,7 +92,7 @@ public final class ContextObjectNodes {
         @SuppressWarnings("unused")
         @Specialization(guards = "index == SENDER_OR_NIL")
         protected static final void doSender(final ContextObject context, final long index, final NilObject value) {
-            context.removeSender();
+            context.setNilSender();
         }
 
         @Specialization(guards = {"index == INSTRUCTION_POINTER"})

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/bytecodes/ReturnBytecodes.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/bytecodes/ReturnBytecodes.java
@@ -93,7 +93,7 @@ public final class ReturnBytecodes {
             // Target is sender of closure's home context.
             final ContextObject homeContext = FrameAccess.getClosure(frame).getHomeContext();
             if (homeContext.canBeReturnedTo()) {
-                throw new NonLocalReturn(returnValue, homeContext.getFrameSender());
+                throw new NonLocalReturn(returnValue, homeContext);
             } else {
                 CompilerDirectives.transferToInterpreter();
                 final ContextObject contextObject = GetOrCreateContextNode.getOrCreateUncached(frame);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/bytecodes/ReturnBytecodes.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/bytecodes/ReturnBytecodes.java
@@ -12,6 +12,7 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.profiles.ConditionProfile;
 
 import de.hpi.swa.trufflesqueak.exceptions.Returns.NonLocalReturn;
+import de.hpi.swa.trufflesqueak.exceptions.Returns.NonVirtualReturn;
 import de.hpi.swa.trufflesqueak.exceptions.SqueakExceptions.SqueakException;
 import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
 import de.hpi.swa.trufflesqueak.model.BooleanObject;
@@ -72,8 +73,9 @@ public final class ReturnBytecodes {
         protected Object execute(final VirtualFrame frame, final Object returnValue) {
             assert !FrameAccess.hasClosure(frame);
             if (hasModifiedSenderProfile.profile(FrameAccess.hasModifiedSender(frame))) {
+                // ToDo: It may be that the sender is always materialized, but it is not a requirement at this time.
                 assert FrameAccess.getSender(frame) instanceof ContextObject : "Sender must be a materialized ContextObject";
-                throw new NonLocalReturn(returnValue, FrameAccess.getSender(frame));
+                throw new NonVirtualReturn(returnValue, FrameAccess.getSender(frame), null);
             } else {
                 return returnValue;
             }
@@ -176,17 +178,7 @@ public final class ReturnBytecodes {
         @Override
         public final Object executeReturnSpecialized(final VirtualFrame frame) {
             if (hasModifiedSenderProfile.profile(FrameAccess.hasModifiedSender(frame))) {
-                // Target is sender of closure's home context.
-                final ContextObject homeContext = FrameAccess.getClosure(frame).getHomeContext();
-                if (homeContext.canBeReturnedTo()) {
-                    throw new NonLocalReturn(getReturnValue(frame), homeContext.getFrameSender());
-                } else {
-                    CompilerDirectives.transferToInterpreter();
-                    final ContextObject contextObject = GetOrCreateContextNode.getOrCreateUncached(frame);
-                    final SqueakImageContext image = getContext();
-                    image.cannotReturn.executeAsSymbolSlow(image, frame, contextObject, getReturnValue(frame));
-                    throw CompilerDirectives.shouldNotReachHere();
-                }
+                throw new NonVirtualReturn(getReturnValue(frame), FrameAccess.getSender(frame), null);
             } else {
                 return getReturnValue(frame);
             }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/bytecodes/ReturnBytecodes.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/bytecodes/ReturnBytecodes.java
@@ -73,7 +73,8 @@ public final class ReturnBytecodes {
         protected Object execute(final VirtualFrame frame, final Object returnValue) {
             assert !FrameAccess.hasClosure(frame);
             if (hasModifiedSenderProfile.profile(FrameAccess.hasModifiedSender(frame))) {
-                // ToDo: It may be that the sender is always materialized, but it is not a requirement at this time.
+                // ToDo: It may be that the sender is always materialized, but it is not a
+                // requirement at this time.
                 assert FrameAccess.getSender(frame) instanceof ContextObject : "Sender must be a materialized ContextObject";
                 throw new NonVirtualReturn(returnValue, FrameAccess.getSender(frame), null);
             } else {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/bytecodes/SendBytecodes.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/bytecodes/SendBytecodes.java
@@ -141,7 +141,7 @@ public final class SendBytecodes {
                     throw nlr;
                 }
             } catch (final NonVirtualReturn nvr) {
-                if (nvrProfile.profile(nvr.getTargetContext() == FrameAccess.getContext(frame))) {
+                if (nvrProfile.profile(nvr.getTargetContextOrMarker() == FrameAccess.getMarker(frame) || nvr.getTargetContextOrMarker() == FrameAccess.getContext(frame))) {
                     result = nvr.getReturnValue();
                 } else {
                     throw nvr;

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/bytecodes/SendBytecodes.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/bytecodes/SendBytecodes.java
@@ -141,7 +141,7 @@ public final class SendBytecodes {
                     throw nlr;
                 }
             } catch (final NonVirtualReturn nvr) {
-                if (nvrProfile.profile(nvr.getTargetContextOrMarker() == FrameAccess.getMarker(frame) || nvr.getTargetContextOrMarker() == FrameAccess.getContext(frame))) {
+                if (nvrProfile.profile(nvr.getTargetContextMarkerOrNil() == FrameAccess.getMarker(frame) || nvr.getTargetContextMarkerOrNil() == FrameAccess.getContext(frame))) {
                     result = nvr.getReturnValue();
                 } else {
                     throw nvr;

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/FrameAccess.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/FrameAccess.java
@@ -236,6 +236,10 @@ public final class FrameAccess {
         return frame.getIntStatic(SlotIndicies.INSTRUCTION_POINTER.ordinal());
     }
 
+    public static boolean isDead(final Frame frame) {
+        return getInstructionPointer(frame) < 0;
+    }
+
     public static void setInstructionPointer(final Frame frame, final int value) {
         frame.setIntStatic(SlotIndicies.INSTRUCTION_POINTER.ordinal(), value);
     }


### PR DESCRIPTION
Three exceptions are used to alter control flow; the first is for non-local returns (up arrows in blocks, or block returns), the second is for normal returns (method return or block return to caller) when the sender has been modified since the Context was started; the third is used to exit the interpreter loop with a return value.

- `NonLocalReturn`:  passes a return value to a sender, executing unwind blocks found between current Context and sender Context
- `NonVirtualReturn`: passes a return value to a Context that is not immediately above the current Java execution node
- `TopLevelReturn`:  passes a return value to the `ExecuteTopLevelContextNode` at the top of the Java stack

This PR includes the following changes:

1. `ResumeContextRootNode` now clears the modified sender flag of the Context being resumed and `commonNLReturn()` in `ExecuteTopLevelContextNode` clears the modified sender flag before `executeAboutToReturn`. They do this so that the modified sender field of a Context correctly indicates whether the Truffle execution stack is different from the Context sender chain.
2. Changed `ReturnFromMethodNode` and `AbstractBlockReturnNode` to use `NonVirtualReturn` when they have modified senders.
3. Changed `AbstractBlockReturnNode` to return to the caller rather than to the sender of the home Context.
4. In `ExecuteTopLevelContextNode`, `NonLocalReturn` and `NonVirtualReturn` were both handled in similar ways: they both would process unwind-marked methods and terminate Contexts found on the sender chain. Changed this so that only `NonLocalReturn` terminates Contexts and handles unwind-marked methods.
5. In `ExecuteTopLevelContextNode`, try to separate errors (returning to a `nil` sender) from exiting the interpreter (`ERROR: A Squeak/Smalltalk image cannot return a result, it can only exit.`)

Known issues:

1. At this time, the internal virtualization of `aboutToReturn:` does not handle the possibility of a `ProcessSwitch` or error occurring during the execution of the `ensure:` block. Some mechanism needs to be created to make it possible to resume the interrupted non-local return.
2. There is a possibility that a non-local return may encounter frames with modified senders and would subsequently need to skip Truffle stack frames before resuming the unwind operation.
3. Sending Smalltalk messages from `ExecuteTopLevelContextNode` can confuse the Truffle-stack-frame-walking loops that continue following the Context sender chain after encountering a `ResumeContextRootNode`.
4. Some of the Cuis ProcessTests are assuming that non-local returns are checking for the return Context being on the sender chain prior to doing any unwinding. Among these tests is `ProcessTest>>testResumeWithEnsureAfterBCR`

The following tests pass only after several retries:
```
StringTest>>#testFindSelector
SHParserST80Test>>#testNumbers
```