### PR TITLE
save PC before executeReturn

### DIFF
--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteBytecodeNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteBytecodeNode.java
@@ -119,6 +119,9 @@ public final class ExecuteBytecodeNode extends AbstractExecuteContextNode implem
                 pc = successor;
                 continue bytecode_loop;
             } else if (node instanceof final AbstractReturnNode returnNode) {
+                /* Save pc in frame since ReturnFromClosureNode could send aboutToReturn or cannotReturn */
+                pc = returnNode.getSuccessorIndex();
+                FrameAccess.setInstructionPointer(frame, pc);
                 returnValue = returnNode.executeReturn(frame);
                 pc = LOCAL_RETURN_PC;
                 continue bytecode_loop;


### PR DESCRIPTION
Save the current PC in the frame before executing a return byte code since there is the possibility that aboutToReturn or cannotReturn would be sent and, in response to the message, the image might try to examine or resume the current context.