### PR TITLE
Separate the roles of NLR and NVR

### DIFF
--- a/src/de.hpi.swa.trufflesqueak.test/src/de/hpi/swa/trufflesqueak/test/runCuisTests.st
+++ b/src/de.hpi.swa.trufflesqueak.test/src/de/hpi/swa/trufflesqueak/test/runCuisTests.st
@@ -18,7 +18,6 @@ StdIOWriteStream stdout newLine; flush.
 
 failingTests := OrderedCollection new.
 {
-    #FinalizationRegistryTest -> #(#testAddGC #testFinalizationWithError). "first test fails when non-command line"
     #FloatTest -> #(#testIsDenormalized #testPrimTruncated).
     #ProcessorTest -> #("flaky" #testGrabProcessor #testGrabProcessorOnlyForNoTimeout #testGrabProcessorOnlyForTimeout #testValueUnpreemptively).
     #SmallIntegerTest -> #(#testMaxVal #testMinVal #testPrintString).

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/exceptions/Returns.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/exceptions/Returns.java
@@ -11,6 +11,7 @@ import com.oracle.truffle.api.nodes.ControlFlowException;
 
 import de.hpi.swa.trufflesqueak.model.ContextObject;
 import de.hpi.swa.trufflesqueak.model.FrameMarker;
+import de.hpi.swa.trufflesqueak.model.NilObject;
 
 public final class Returns {
     private abstract static class AbstractReturn extends ControlFlowException {
@@ -29,12 +30,19 @@ public final class Returns {
 
     public static final class NonLocalReturn extends AbstractReturn {
         private static final long serialVersionUID = 1L;
+        private final transient ContextObject homeContext;
         private final transient Object targetContextOrMarker;
 
-        public NonLocalReturn(final Object returnValue, final Object targetContextOrMarker) {
+        public NonLocalReturn(final Object returnValue, final ContextObject homeContext) {
             super(returnValue);
-            assert targetContextOrMarker instanceof ContextObject || targetContextOrMarker instanceof FrameMarker;
-            this.targetContextOrMarker = targetContextOrMarker;
+            final Object target = homeContext.getFrameSender();
+            assert target instanceof ContextObject || target instanceof FrameMarker;
+            this.homeContext = homeContext;
+            this.targetContextOrMarker = target;
+        }
+
+        public ContextObject getHomeContext() {
+            return homeContext;
         }
 
         public Object getTargetContextOrMarker() {
@@ -43,6 +51,16 @@ public final class Returns {
 
         public ContextObject getTargetContext() {
             return (ContextObject) targetContextOrMarker;
+        }
+
+        public ContextObject getOrCreateTargetContext() {
+            if (targetContextOrMarker instanceof final ContextObject targetContext) {
+                return targetContext;
+            } else if (targetContextOrMarker instanceof final FrameMarker frameMarker) {
+                return frameMarker.getMaterializedContext();
+            } else {
+                throw SqueakExceptions.SqueakException.create("Could not create Context for:", targetContextOrMarker);
+            }
         }
 
         @Override
@@ -54,18 +72,18 @@ public final class Returns {
 
     public static final class NonVirtualReturn extends AbstractReturn {
         private static final long serialVersionUID = 1L;
-        private final transient ContextObject targetContext;
+        private final transient Object targetContextMarkerOrNil;
         private final transient ContextObject currentContext;
 
-        public NonVirtualReturn(final Object returnValue, final ContextObject targetContext, final ContextObject currentContext) {
+        public NonVirtualReturn(final Object returnValue, final Object targetContextMarkerOrNil, final ContextObject currentContext) {
             super(returnValue);
-            assert !targetContext.isDead() : "Cannot return to terminated context";
-            this.targetContext = targetContext;
+            assert targetContextMarkerOrNil instanceof ContextObject || targetContextMarkerOrNil instanceof FrameMarker || targetContextMarkerOrNil == NilObject.SINGLETON;
+            this.targetContextMarkerOrNil = targetContextMarkerOrNil;
             this.currentContext = currentContext;
         }
 
-        public ContextObject getTargetContext() {
-            return targetContext;
+        public Object getTargetContextMarkerOrNil() {
+            return targetContextMarkerOrNil;
         }
 
         public ContextObject getCurrentContext() {
@@ -75,7 +93,7 @@ public final class Returns {
         @Override
         public String toString() {
             CompilerAsserts.neverPartOfCompilation();
-            return "NVR (value: " + returnValue + ", current: " + currentContext + ", target: " + targetContext + ")";
+            return "NVR (value: " + returnValue + ", current: " + currentContext + ", target: " + targetContextMarkerOrNil + ")";
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/exceptions/Returns.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/exceptions/Returns.java
@@ -7,11 +7,13 @@
 package de.hpi.swa.trufflesqueak.exceptions;
 
 import com.oracle.truffle.api.CompilerAsserts;
+import com.oracle.truffle.api.frame.Frame;
 import com.oracle.truffle.api.nodes.ControlFlowException;
 
 import de.hpi.swa.trufflesqueak.model.ContextObject;
 import de.hpi.swa.trufflesqueak.model.FrameMarker;
 import de.hpi.swa.trufflesqueak.model.NilObject;
+import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
 public final class Returns {
     private abstract static class AbstractReturn extends ControlFlowException {
@@ -45,22 +47,16 @@ public final class Returns {
             return homeContext;
         }
 
+        public boolean targetIsFrame(final Frame frame) {
+            return targetContextOrMarker == FrameAccess.getMarker(frame) || targetContextOrMarker == FrameAccess.getContext(frame);
+        }
+
         public Object getTargetContextOrMarker() {
             return targetContextOrMarker;
         }
 
         public ContextObject getTargetContext() {
             return (ContextObject) targetContextOrMarker;
-        }
-
-        public ContextObject getOrCreateTargetContext() {
-            if (targetContextOrMarker instanceof final ContextObject targetContext) {
-                return targetContext;
-            } else if (targetContextOrMarker instanceof final FrameMarker frameMarker) {
-                return frameMarker.getMaterializedContext();
-            } else {
-                throw SqueakExceptions.SqueakException.create("Could not create Context for:", targetContextOrMarker);
-            }
         }
 
         @Override
@@ -80,6 +76,10 @@ public final class Returns {
             assert targetContextMarkerOrNil instanceof ContextObject || targetContextMarkerOrNil instanceof FrameMarker || targetContextMarkerOrNil == NilObject.SINGLETON;
             this.targetContextMarkerOrNil = targetContextMarkerOrNil;
             this.currentContext = currentContext;
+        }
+
+        public boolean targetIsFrame(final Frame frame) {
+            return targetContextMarkerOrNil == FrameAccess.getMarker(frame) || targetContextMarkerOrNil == FrameAccess.getContext(frame);
         }
 
         public Object getTargetContextMarkerOrNil() {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
@@ -253,6 +253,16 @@ public final class ContextObject extends AbstractSqueakObjectWithClassAndHash {
         setSenderUnsafe(value);
     }
 
+    public void setNilSender() {
+        if (truffleFrame != null) {
+            final Object sender = FrameAccess.getSender(getTruffleFrame());
+            if (!hasModifiedSender && sender != NilObject.SINGLETON) {
+                hasModifiedSender = true;
+            }
+        }
+        setSenderUnsafe(NilObject.SINGLETON);
+    }
+
     public void setSenderUnsafe(final AbstractSqueakObject value) {
         FrameAccess.setSender(getOrCreateTruffleFrame(), value);
     }
@@ -403,6 +413,10 @@ public final class ContextObject extends AbstractSqueakObjectWithClassAndHash {
 
     public void markEscaped() {
         escaped = true;
+    }
+
+    public void clearModifiedSender() {
+        hasModifiedSender = false;
     }
 
     public boolean hasModifiedSender() {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/AboutToReturnNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/AboutToReturnNode.java
@@ -22,6 +22,7 @@ import de.hpi.swa.trufflesqueak.model.BlockClosureObject;
 import de.hpi.swa.trufflesqueak.model.BooleanObject;
 import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
 import de.hpi.swa.trufflesqueak.model.ContextObject;
+import de.hpi.swa.trufflesqueak.model.NilObject;
 import de.hpi.swa.trufflesqueak.nodes.AboutToReturnNodeFactory.AboutToReturnImplNodeGen;
 import de.hpi.swa.trufflesqueak.nodes.context.frame.FrameStackReadNode;
 import de.hpi.swa.trufflesqueak.nodes.context.frame.FrameStackWriteNode;
@@ -76,8 +77,18 @@ public abstract class AboutToReturnNode extends AbstractNode {
         @Specialization(guards = {"hasModifiedSender(frame)"})
         protected static final void doAboutToReturn(final VirtualFrame frame, final NonLocalReturn nlr,
                         @Cached("createAboutToReturnSend()") final Dispatch2Node sendAboutToReturnNode) {
-            assert nlr.getTargetContextOrMarker() instanceof ContextObject;
-            sendAboutToReturnNode.execute(frame, FrameAccess.getContext(frame), nlr.getReturnValue(), nlr.getTargetContextOrMarker());
+            // @formatter:off
+            /*
+             *  aboutToReturn: result through: firstUnwindContext
+             *      "Called from VM when an unwindBlock is found between self and its home.
+             *      Return to home's sender, executing unwind blocks on the way."
+             *
+             *      self methodReturnContext return: result through: firstUnwindContext
+             */
+            // @formatter:on
+            // Message receiver should be home Context to return from.
+            // Last argument should be the first unwind-marked Context or nil.
+            sendAboutToReturnNode.execute(frame, nlr.getHomeContext(), nlr.getReturnValue(), NilObject.SINGLETON);
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/AboutToReturnNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/AboutToReturnNode.java
@@ -16,12 +16,12 @@ import com.oracle.truffle.api.nodes.DenyReplace;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.UnadoptableNode;
 
+import de.hpi.swa.trufflesqueak.exceptions.ProcessSwitch;
 import de.hpi.swa.trufflesqueak.exceptions.Returns.NonLocalReturn;
 import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
 import de.hpi.swa.trufflesqueak.model.BlockClosureObject;
 import de.hpi.swa.trufflesqueak.model.BooleanObject;
 import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
-import de.hpi.swa.trufflesqueak.model.ContextObject;
 import de.hpi.swa.trufflesqueak.model.NilObject;
 import de.hpi.swa.trufflesqueak.nodes.AboutToReturnNodeFactory.AboutToReturnImplNodeGen;
 import de.hpi.swa.trufflesqueak.nodes.context.frame.FrameStackReadNode;
@@ -31,6 +31,7 @@ import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchClosureNode;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector2NodeFactory.Dispatch2NodeGen;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector2Node.Dispatch2Node;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
+import de.hpi.swa.trufflesqueak.util.LogUtils;
 
 @SuppressWarnings("truffle-inlining")
 public abstract class AboutToReturnNode extends AbstractNode {
@@ -64,7 +65,12 @@ public abstract class AboutToReturnNode extends AbstractNode {
                         @Cached final DispatchClosureNode dispatchNode) {
             completeTempWriteNode.executeWrite(frame, BooleanObject.TRUE);
             final BlockClosureObject closure = (BlockClosureObject) blockArgumentNode.executeRead(frame);
-            dispatchNode.execute(node, closure, FrameAccess.newClosureArgumentsTemplate(closure, getContextOrMarkerNode.execute(frame), 0));
+            try {
+                dispatchNode.execute(node, closure, FrameAccess.newClosureArgumentsTemplate(closure, getContextOrMarkerNode.execute(frame), 0));
+            } catch (ProcessSwitch ps) {
+                LogUtils.SCHEDULING.warning("AboutToReturnNode: ProcessSwitch during AboutToReturn! ");
+                throw ps;
+            }
         }
 
         @SuppressWarnings("unused")

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteBytecodeNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteBytecodeNode.java
@@ -28,6 +28,7 @@ import de.hpi.swa.trufflesqueak.nodes.bytecodes.JumpBytecodes.ConditionalJumpNod
 import de.hpi.swa.trufflesqueak.nodes.bytecodes.ReturnBytecodes.AbstractReturnNode;
 import de.hpi.swa.trufflesqueak.nodes.bytecodes.SendBytecodes.AbstractSendNode;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
+import de.hpi.swa.trufflesqueak.util.LogUtils;
 
 public final class ExecuteBytecodeNode extends AbstractExecuteContextNode implements BytecodeOSRNode {
     private static final int LOCAL_RETURN_PC = -2;
@@ -54,7 +55,12 @@ public final class ExecuteBytecodeNode extends AbstractExecuteContextNode implem
             return interpretBytecode(frame, startPC);
         } catch (final NonLocalReturn nlr) {
             /* {@link getHandleNonLocalReturnNode()} acts as {@link BranchProfile} */
-            return getHandleNonLocalReturnNode().executeHandle(frame, nlr);
+            final HandleNonLocalReturnNode handleNode = getHandleNonLocalReturnNode();
+            if (FrameAccess.isDead(frame)) {
+                LogUtils.SCHEDULING.fine("ExecuteBytecodeNode: encountered dead frame during NLR");
+                throw nlr;
+            }
+            return handleNode.executeHandle(frame, nlr);
         } catch (final StackOverflowError e) {
             CompilerDirectives.transferToInterpreter();
             throw getContext().tryToSignalLowSpace(frame, e);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteBytecodeNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteBytecodeNode.java
@@ -55,12 +55,8 @@ public final class ExecuteBytecodeNode extends AbstractExecuteContextNode implem
             return interpretBytecode(frame, startPC);
         } catch (final NonLocalReturn nlr) {
             /* {@link getHandleNonLocalReturnNode()} acts as {@link BranchProfile} */
-            final HandleNonLocalReturnNode handleNode = getHandleNonLocalReturnNode();
-            if (FrameAccess.isDead(frame)) {
-                LogUtils.SCHEDULING.fine("ExecuteBytecodeNode: encountered dead frame during NLR");
-                throw nlr;
-            }
-            return handleNode.executeHandle(frame, nlr);
+            assert !FrameAccess.isDead(frame) : "ExecuteBytecodeNode: encountered dead frame during NLR";
+            return getHandleNonLocalReturnNode().executeHandle(frame, nlr);
         } catch (final StackOverflowError e) {
             CompilerDirectives.transferToInterpreter();
             throw getContext().tryToSignalLowSpace(frame, e);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
@@ -103,10 +103,10 @@ public final class ExecuteTopLevelContextNode extends RootNode {
                     activeContext = returnTo(activeContext, sender, result);
                     LogUtils.SCHEDULING.log(Level.FINE, "Local Return on top-level: {0}", activeContext);
                 } catch (final NonLocalReturn nlr) {
-                    activeContext = commonNLReturn(sender, nlr);
+                    activeContext = commonNLReturn(sender, activeContext, nlr);
                     LogUtils.SCHEDULING.log(Level.FINE, "Non Local Return on top-level: {0}", activeContext);
                 } catch (final NonVirtualReturn nvr) {
-                    activeContext = commonReturn(nvr.getCurrentContext(), nvr.getTargetContext(), nvr.getReturnValue());
+                    activeContext = commonNVReturn(activeContext, nvr);
                     LogUtils.SCHEDULING.log(Level.FINE, "Non Virtual Return on top-level: {0}", activeContext);
                 }
             } catch (final ProcessSwitch ps) {
@@ -117,10 +117,20 @@ public final class ExecuteTopLevelContextNode extends RootNode {
     }
 
     @TruffleBoundary
-    private static ContextObject returnTo(final ContextObject activeContext, final AbstractSqueakObject sender, final Object returnValue) {
+    private ContextObject sendCannotReturnOrReturnToTopLevel(final ContextObject startContext, final ContextObject targetContext, final Object returnValue) {
+        // Exit the interpreter loop if the target is the context that started the loop.
+        if (targetContext != null && targetContext == initialContext) {
+            LogUtils.SCHEDULING.fine("sendCannotReturnOrReturnToTopLevel " + targetContext + " with return value: " + returnValue);
+            throw returnToTopLevel(targetContext, returnValue);
+        }
+        return sendCannotReturn(startContext, returnValue);
+    }
+
+    @TruffleBoundary
+    private ContextObject returnTo(final ContextObject activeContext, final AbstractSqueakObject sender, final Object returnValue) {
         if (!(sender instanceof final ContextObject senderContext)) {
             assert sender == NilObject.SINGLETON;
-            throw returnToTopLevel(activeContext, returnValue);
+            return sendCannotReturnOrReturnToTopLevel(activeContext, activeContext, returnValue);
         }
         final ContextObject context;
         if (senderContext.isPrimitiveContext()) {
@@ -133,82 +143,80 @@ public final class ExecuteTopLevelContextNode extends RootNode {
     }
 
     @TruffleBoundary
-    private ContextObject commonNLReturn(final AbstractSqueakObject sender, final NonLocalReturn nlr) {
-        final ContextObject targetContext = nlr.getTargetContext();
-        final Object returnValue = nlr.getReturnValue();
-        if (!(sender instanceof final ContextObject senderContext)) {
-            assert sender == NilObject.SINGLETON;
-            throw returnToTopLevel(targetContext, returnValue);
+    private ContextObject commonNVReturn(final ContextObject activeContext, final NonVirtualReturn nvr) {
+        // Normal returns with modified senders end up here with a target but no start Context.
+        final ContextObject startContextOrNull = nvr.getCurrentContext();
+        final ContextObject startContext;
+        if (startContextOrNull == null) {
+            startContext = activeContext;
+        } else {
+            startContext = startContextOrNull;
         }
-        ContextObject context = senderContext;
-        while (context != targetContext) {
-            if (context.getCodeObject().isUnwindMarked()) {
-                try {
-                    // TODO: make this better
-                    AboutToReturnNode.create(context.getCodeObject()).executeAboutToReturn(context.getTruffleFrame(), nlr);
-                } catch (NonVirtualReturn nvr) {
-                    return commonReturn(nvr.getCurrentContext(), nvr.getTargetContext(), nvr.getReturnValue());
-                }
-            }
-            final AbstractSqueakObject currentSender = context.getSender();
-            if (currentSender instanceof final ContextObject o) {
-                context = o;
-            }
+        // Handle attempted return to a nil sender.
+        final Object targetContextMarkerOrNil = nvr.getTargetContextMarkerOrNil();
+        final Object returnValue = nvr.getReturnValue();
+        if (targetContextMarkerOrNil == NilObject.SINGLETON) {
+            return sendCannotReturnOrReturnToTopLevel(startContext, null, returnValue);
         }
-        context = senderContext;
-        while (context != targetContext) {
-            final AbstractSqueakObject currentSender = context.getSender();
-            if (currentSender instanceof final ContextObject o) {
-                context.terminate();
-                context = o;
-            } else { // TODO: this might need to be handled by a cannotReturn send.
-                LogUtils.SCHEDULING.warning("Unwind error: sender of " + context + " is nil, unwinding towards " + targetContext + " with return value: " + returnValue);
-                break;
-            }
+        // Skip over primitive contexts.
+        assert targetContextMarkerOrNil instanceof ContextObject;
+        final ContextObject possibleTargetContext = (ContextObject) targetContextMarkerOrNil;
+        final ContextObject targetContext;
+        if (possibleTargetContext.isPrimitiveContext()) {
+            targetContext = (ContextObject) possibleTargetContext.getFrameSender();
+        } else {
+            targetContext = possibleTargetContext;
         }
+        // Make sure that the targetContext can be returned to.
+        if (!targetContext.hasClosure() && !targetContext.canBeReturnedTo()) {
+            return sendCannotReturnOrReturnToTopLevel(startContext, targetContext, returnValue);
+        }
+        // Return to the target context with the return value.
         targetContext.push(returnValue);
         return targetContext;
     }
 
     @TruffleBoundary
-    private ContextObject commonReturn(final ContextObject startContext, final ContextObject targetContext, final Object returnValue) {
-        /* "make sure we can return to the given context" */
-        if (!targetContext.hasClosure() && !targetContext.canBeReturnedTo()) {
-            if (startContext == targetContext) {
-                throw returnToTopLevel(targetContext, returnValue);
-            }
-            return sendCannotReturn(startContext, returnValue);
+    private ContextObject commonNLReturn(final AbstractSqueakObject sender, final ContextObject activeContext, final NonLocalReturn nlr) {
+        final ContextObject targetContext = nlr.getTargetContext();
+        final Object returnValue = nlr.getReturnValue();
+        if (!(sender instanceof final ContextObject senderContext)) {
+            assert sender == NilObject.SINGLETON;
+            return sendCannotReturnOrReturnToTopLevel(activeContext, targetContext, returnValue);
         }
-        /*
-         * "If this return is not to our immediate predecessor (i.e. from a method to its sender, or
-         * from a block to its caller), scan the stack for the first unwind marked context and
-         * inform this context and let it deal with it. This provides a chance for ensure unwinding
-         * to occur."
-         */
-        AbstractSqueakObject contextOrNil = startContext;
-        while (contextOrNil != targetContext) {
-            if (!(contextOrNil instanceof final ContextObject context)) {
-                /* "error: sender's instruction pointer or context is nil; cannot return" */
-                assert contextOrNil == NilObject.SINGLETON;
-                return sendCannotReturn(startContext, returnValue);
+        // Make sure target is on sender chain.
+        ContextObject context = senderContext;
+        while (context != targetContext) {
+            final AbstractSqueakObject currentSender = context.getSender();
+            if (currentSender instanceof final ContextObject o) {
+                context = o;
+            } else {
+                return sendCannotReturn(activeContext, returnValue);
             }
-            assert !context.isPrimitiveContext();
+        }
+        // Evaluate unwind-marked blocks on sender chain.
+        context = senderContext;
+        while (context != targetContext) {
             if (context.getCodeObject().isUnwindMarked()) {
-                assert !context.hasClosure();
-                /* "context is marked; break out" */
-                return sendAboutToReturn(startContext, returnValue, context);
+                try {
+                    /*
+                     * TODO: Not sure whether we can mix the virtualized
+                     * Context>>aboutToReturn:through: with sending the actual message. Clearing the
+                     * modified sender forces the use of the virtualized implementation of
+                     * aboutToReturn.
+                     */
+                    context.clearModifiedSender();
+                    AboutToReturnNode.create(context.getCodeObject()).executeAboutToReturn(context.getTruffleFrame(), nlr);
+                } catch (NonVirtualReturn nvr) {
+                    return commonNVReturn(context, nvr);
+                } catch (ProcessSwitch ps) {
+                    LogUtils.SCHEDULING.warning("commonNLReturn: ProcessSwitch during AboutToReturn!");
+                    throw ps;
+                }
             }
-            contextOrNil = context.getSender();
-        }
-        /*
-         * "If we get here there is no unwind to worry about. Simply terminate the stack up to the
-         * localCntx - often just the sender of the method"
-         */
-        ContextObject currentContext = startContext;
-        while (currentContext != targetContext) {
-            final ContextObject sender = (ContextObject) currentContext.getFrameSender();
-            currentContext.terminate();
-            currentContext = sender;
+            final ContextObject currentSender = (ContextObject) context.getSender();
+            context.terminate();
+            context = currentSender;
         }
         targetContext.push(returnValue);
         return targetContext;
@@ -224,11 +232,24 @@ public final class ExecuteTopLevelContextNode extends RootNode {
         throw CompilerDirectives.shouldNotReachHere("cannotReturn should trigger a ProcessSwitch");
     }
 
+    @SuppressWarnings("unused")
     private ContextObject sendAboutToReturn(final ContextObject startContext, final Object returnValue, final ContextObject context) {
+        // TODO: Perhaps use this when image does all aboutToReturn processing.
+        // @formatter:off
+        /*
+         *  aboutToReturn: result through: firstUnwindContext
+         *      "Called from VM when an unwindBlock is found between self and its home.
+         *      Return to home's sender, executing unwind blocks on the way."
+         *
+         *      self methodReturnContext return: result through: firstUnwindContext
+         */
+        // @formatter:on
+        // Message receiver should be home Context to return from.
+        // Last argument should be the first unwind-marked Context or nil.
         try {
             sendAboutToReturnNode.execute(startContext.getTruffleFrame(), startContext, returnValue, context);
         } catch (final NonVirtualReturn nvr) {
-            return commonReturn(nvr.getCurrentContext(), nvr.getTargetContext(), nvr.getReturnValue());
+            return commonNVReturn(context, nvr);
         }
         throw CompilerDirectives.shouldNotReachHere("aboutToReturn should trigger a ProcessSwitch or a NonVirtualReturn");
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/HandleNonLocalReturnNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/HandleNonLocalReturnNode.java
@@ -9,19 +9,17 @@ package de.hpi.swa.trufflesqueak.nodes;
 import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.InlinedConditionProfile;
 
+import de.hpi.swa.trufflesqueak.exceptions.ProcessSwitch;
 import de.hpi.swa.trufflesqueak.exceptions.Returns.NonLocalReturn;
 import de.hpi.swa.trufflesqueak.exceptions.Returns.NonVirtualReturn;
-import de.hpi.swa.trufflesqueak.exceptions.SqueakExceptions;
 import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
 import de.hpi.swa.trufflesqueak.model.ContextObject;
-import de.hpi.swa.trufflesqueak.model.FrameMarker;
-import de.hpi.swa.trufflesqueak.model.NilObject;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
+import de.hpi.swa.trufflesqueak.util.LogUtils;
 
 public abstract class HandleNonLocalReturnNode extends AbstractNode {
     @Child private AboutToReturnNode aboutToReturnNode;
@@ -40,24 +38,19 @@ public abstract class HandleNonLocalReturnNode extends AbstractNode {
     protected final Object doHandle(final VirtualFrame frame, final NonLocalReturn nlr,
                     @Bind final Node node,
                     @Cached final InlinedConditionProfile hasModifiedSenderProfile) {
-        aboutToReturnNode.executeAboutToReturn(frame, nlr); // handle ensure: or ifCurtailed:
+        try {
+            aboutToReturnNode.executeAboutToReturn(frame, nlr); // handle ensure: or ifCurtailed:
+        } catch (ProcessSwitch ps) {
+            LogUtils.SCHEDULING.warning("HandleNonLocalReturnNode: ProcessSwitch during AboutToReturn! ");
+            throw ps;
+        }
         if (hasModifiedSenderProfile.profile(node, FrameAccess.hasModifiedSender(frame))) {
             // Sender might have changed.
-            final ContextObject targetContext;
             final Object targetContextOrMarker = nlr.getTargetContextOrMarker();
-            if (targetContextOrMarker instanceof final ContextObject target) {
-                targetContext = target;
-            } else if (targetContextOrMarker instanceof final FrameMarker targetFrameMarker) {
-                final MaterializedFrame targetFrame = FrameAccess.findFrameForMarker(targetFrameMarker);
-                targetContext = FrameAccess.getContext(targetFrame);
-            } else {
-                assert targetContextOrMarker == NilObject.SINGLETON;
-                throw SqueakExceptions.SqueakException.create("Nil resuming context in HandleNonLocalReturnNode");
-            }
             final ContextObject newSender = FrameAccess.getSenderContext(frame);
             FrameAccess.terminateContextOrFrame(frame);
             // TODO: `target == newSender` may could use special handling?
-            throw new NonVirtualReturn(nlr.getReturnValue(), targetContext, newSender);
+            throw new NonVirtualReturn(nlr.getReturnValue(), targetContextOrMarker, newSender);
         } else {
             FrameAccess.terminateContextOrFrame(frame);
             throw nlr;

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/HandleNonLocalReturnNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/HandleNonLocalReturnNode.java
@@ -38,12 +38,7 @@ public abstract class HandleNonLocalReturnNode extends AbstractNode {
     protected final Object doHandle(final VirtualFrame frame, final NonLocalReturn nlr,
                     @Bind final Node node,
                     @Cached final InlinedConditionProfile hasModifiedSenderProfile) {
-        try {
-            aboutToReturnNode.executeAboutToReturn(frame, nlr); // handle ensure: or ifCurtailed:
-        } catch (ProcessSwitch ps) {
-            LogUtils.SCHEDULING.warning("HandleNonLocalReturnNode: ProcessSwitch during AboutToReturn! ");
-            throw ps;
-        }
+        aboutToReturnNode.executeAboutToReturn(frame, nlr); // handle ensure: or ifCurtailed:
         if (hasModifiedSenderProfile.profile(node, FrameAccess.hasModifiedSender(frame))) {
             // Sender might have changed.
             final Object targetContextOrMarker = nlr.getTargetContextOrMarker();

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ResumeContextRootNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ResumeContextRootNode.java
@@ -37,6 +37,7 @@ public final class ResumeContextRootNode extends AbstractRootNode {
     public Object execute(final VirtualFrame frame) {
         try {
             assert !activeContext.isDead() : "Terminated contexts cannot be resumed";
+            activeContext.clearModifiedSender();
             final int pc = instructionPointerProfile.profile(activeContext.getInstructionPointerForBytecodeLoop());
             if (CompilerDirectives.isPartialEvaluationConstant(pc)) {
                 return executeBytecodeNode.execute(activeContext.getTruffleFrame(), pc);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/accessing/ContextObjectNodes.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/accessing/ContextObjectNodes.java
@@ -92,7 +92,7 @@ public final class ContextObjectNodes {
         @SuppressWarnings("unused")
         @Specialization(guards = "index == SENDER_OR_NIL")
         protected static final void doSender(final ContextObject context, final long index, final NilObject value) {
-            context.removeSender();
+            context.setNilSender();
         }
 
         @Specialization(guards = {"index == INSTRUCTION_POINTER"})

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/bytecodes/SendBytecodes.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/bytecodes/SendBytecodes.java
@@ -141,7 +141,7 @@ public final class SendBytecodes {
                     throw nlr;
                 }
             } catch (final NonVirtualReturn nvr) {
-                if (nvrProfile.profile(nvr.getTargetContext() == FrameAccess.getContext(frame))) {
+                if (nvrProfile.profile(nvr.getTargetContextMarkerOrNil() == FrameAccess.getMarker(frame) || nvr.getTargetContextMarkerOrNil() == FrameAccess.getContext(frame))) {
                     result = nvr.getReturnValue();
                 } else {
                     throw nvr;

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/bytecodes/SendBytecodes.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/bytecodes/SendBytecodes.java
@@ -135,13 +135,13 @@ public final class SendBytecodes {
             try {
                 result = dispatchNode.execute(frame);
             } catch (final NonLocalReturn nlr) {
-                if (nlrProfile.profile(nlr.getTargetContextOrMarker() == FrameAccess.getMarker(frame) || nlr.getTargetContextOrMarker() == FrameAccess.getContext(frame))) {
+                if (nlrProfile.profile(nlr.targetIsFrame(frame))) {
                     result = nlr.getReturnValue();
                 } else {
                     throw nlr;
                 }
             } catch (final NonVirtualReturn nvr) {
-                if (nvrProfile.profile(nvr.getTargetContextMarkerOrNil() == FrameAccess.getMarker(frame) || nvr.getTargetContextMarkerOrNil() == FrameAccess.getContext(frame))) {
+                if (nvrProfile.profile(nvr.targetIsFrame(frame))) {
                     result = nvr.getReturnValue();
                 } else {
                     throw nvr;

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/FrameAccess.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/FrameAccess.java
@@ -236,6 +236,10 @@ public final class FrameAccess {
         return frame.getIntStatic(SlotIndicies.INSTRUCTION_POINTER.ordinal());
     }
 
+    public static boolean isDead(final Frame frame) {
+        return getInstructionPointer(frame) < 0;
+    }
+
     public static void setInstructionPointer(final Frame frame, final int value) {
         frame.setIntStatic(SlotIndicies.INSTRUCTION_POINTER.ordinal(), value);
     }


### PR DESCRIPTION
_Squashed replacement for #201_ 

Three exceptions are used to alter control flow; the first is for non-local returns (up arrows in blocks, or block returns), the second is for normal returns (method return or block return to caller) when the sender has been modified since the Context was started; the third is used to exit the interpreter loop with a return value.

- `NonLocalReturn`:  passes a return value to a sender, executing unwind blocks found between current Context and sender Context
- `NonVirtualReturn`: passes a return value to a Context that is not immediately above the current Java execution node
- `TopLevelReturn`:  passes a return value to the `ExecuteTopLevelContextNode` at the top of the Java stack

This PR includes the following changes:

1. `ResumeContextRootNode` now clears the modified sender flag of the Context being resumed and `commonNLReturn()` in `ExecuteTopLevelContextNode` clears the modified sender flag before `executeAboutToReturn`. They do this so that the modified sender field of a Context correctly indicates whether the Truffle execution stack is different from the Context sender chain.
2. Changed `ReturnFromMethodNode` and `AbstractBlockReturnNode` to use `NonVirtualReturn` when they have modified senders.
3. Changed `AbstractBlockReturnNode` to return to the caller rather than to the sender of the home Context.
4. In `ExecuteTopLevelContextNode`, `NonLocalReturn` and `NonVirtualReturn` were both handled in similar ways: they both would process unwind-marked methods and terminate Contexts found on the sender chain. Changed this so that only `NonLocalReturn` terminates Contexts and handles unwind-marked methods.
5. In `ExecuteTopLevelContextNode`, try to separate errors (returning to a `nil` sender) from exiting the interpreter (`ERROR: A Squeak/Smalltalk image cannot return a result, it can only exit.`)
6. `Context>>aboutToReturn:through:` wants the home Context so that it knows where to return; modified `NonLocalReturn` to save both the `homeContext` and the `frameSender`.

These changes make it possible to run the Cuis tests from within the normal Cuis UI; previously, some tests would dump to the command line with a message.

Known issues:

1. At this time, the internal virtualization of `aboutToReturn:` does not handle the possibility of a `ProcessSwitch` or error occurring during the execution of the `ensure:` block. Some mechanism needs to be created to make it possible to resume the interrupted non-local return or the image should do the unwind rather than the interpreter.
2. There is a possibility that a non-local return may encounter frames with modified senders and would subsequently need to skip Truffle stack frames before resuming the unwind operation.
3. Sending Smalltalk messages from `ExecuteTopLevelContextNode` can confuse the Truffle-stack-frame-walking loops that continue following the Context sender chain after encountering a `ResumeContextRootNode`.
4. Some of the Cuis ProcessTests are assuming that non-local returns are checking for the return Context being on the sender chain prior to doing any unwinding. Among these tests is `ProcessTest>>testResumeWithEnsureAfterBCR`
