### PR TITLE
Lazy-initialize squeakHashAndFlags & simplify ContextObject

### DIFF
--- a/src/de.hpi.swa.trufflesqueak.test/src/de/hpi/swa/trufflesqueak/test/AbstractSqueakTestCase.java
+++ b/src/de.hpi.swa.trufflesqueak.test/src/de/hpi/swa/trufflesqueak/test/AbstractSqueakTestCase.java
@@ -39,7 +39,7 @@ public abstract class AbstractSqueakTestCase {
     protected static PointersObject nilClassBinding;
 
     protected static final CompiledCodeObject makeMethod(final byte[] bytes, final long header, final Object[] literals) {
-        return new CompiledCodeObject(image, bytes, header, literals, image.compiledMethodClass);
+        return new CompiledCodeObject(bytes, header, literals, image.compiledMethodClass);
     }
 
     protected static final CompiledCodeObject makeMethod(final int header, final Object[] literals, final int... intbytes) {

--- a/src/de.hpi.swa.trufflesqueak.test/src/de/hpi/swa/trufflesqueak/test/AbstractSqueakTestCaseWithDummyImage.java
+++ b/src/de.hpi.swa.trufflesqueak.test/src/de/hpi/swa/trufflesqueak/test/AbstractSqueakTestCaseWithDummyImage.java
@@ -41,11 +41,11 @@ public abstract class AbstractSqueakTestCaseWithDummyImage extends AbstractSquea
 
         final ClassObject bindingClass = setupMeta(new ClassObject(image), null, 1L, "Binding");
         final ClassObject classBindingClass = setupMeta(new ClassObject(image), bindingClass, 2L, "ClassBinding");
-        nilClassBinding = new PointersObject(image, classBindingClass, classBindingClass.getLayout());
+        nilClassBinding = new PointersObject(classBindingClass, classBindingClass.getLayout());
         nilClassBinding.instVarAtPut0Slow(0, asByteSymbol("UndefinedObject"));
         nilClassBinding.instVarAtPut0Slow(1, image.nilClass);
 
-        image.setHiddenRoots(ArrayObject.createEmptyStrategy(image, image.arrayClass, 0));
+        image.setHiddenRoots(ArrayObject.createEmptyStrategy(image.arrayClass, 0));
         context.enter();
     }
 
@@ -134,7 +134,7 @@ public abstract class AbstractSqueakTestCaseWithDummyImage extends AbstractSquea
     }
 
     private static NativeObject asByteSymbol(final String value) {
-        return NativeObject.newNativeBytes(image, image.getByteSymbolClass(), MiscUtils.stringToBytes(value));
+        return NativeObject.newNativeBytes(image.getByteSymbolClass(), MiscUtils.stringToBytes(value));
     }
 
     @AfterClass

--- a/src/de.hpi.swa.trufflesqueak.test/src/de/hpi/swa/trufflesqueak/test/ObjectLayoutTest.java
+++ b/src/de.hpi.swa.trufflesqueak.test/src/de/hpi/swa/trufflesqueak/test/ObjectLayoutTest.java
@@ -187,7 +187,7 @@ public final class ObjectLayoutTest extends AbstractSqueakTestCaseWithDummyImage
     }
 
     private static PointersObject instantiate(final ClassObject dummyClass) {
-        return (PointersObject) SqueakObjectNewNode.executeUncached(image, dummyClass);
+        return (PointersObject) SqueakObjectNewNode.executeUncached(dummyClass);
     }
 
     private static void writeAndValidate(final AbstractPointersObject obj, final int index, final Object value) {

--- a/src/de.hpi.swa.trufflesqueak.test/src/de/hpi/swa/trufflesqueak/test/SqueakPrimitiveTest.java
+++ b/src/de.hpi.swa.trufflesqueak.test/src/de/hpi/swa/trufflesqueak/test/SqueakPrimitiveTest.java
@@ -41,7 +41,7 @@ public final class SqueakPrimitiveTest extends AbstractSqueakTestCaseWithDummyIm
         for (int i = 1; i < 8; i++) {
             assertNotSame(NilObject.SINGLETON, rcvr.getObject(i));
         }
-        final Object result = runPrimitive(105, rcvr, 1L, 6L, ArrayObject.createEmptyStrategy(image, image.arrayClass, 10), 1L);
+        final Object result = runPrimitive(105, rcvr, 1L, 6L, ArrayObject.createEmptyStrategy(image.arrayClass, 10), 1L);
         assertSame(result, rcvr);
         for (int i = 0; i < 6; i++) {
             assertSame(NilObject.SINGLETON, rcvr.getObject(i));

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
@@ -141,7 +141,7 @@ public final class SqueakImageContext {
     public final ClassObject metaClass = new ClassObject(this);
     public final ClassObject nilClass = new ClassObject(this);
 
-    public final CompiledCodeObject dummyMethod = new CompiledCodeObject(this, null, CompiledCodeHeaderUtils.makeHeader(true, 1, 0, 0, false, true), ArrayUtils.EMPTY_ARRAY, compiledMethodClass);
+    public final CompiledCodeObject dummyMethod = new CompiledCodeObject(null, CompiledCodeHeaderUtils.makeHeader(true, 1, 0, 0, false, true), ArrayUtils.EMPTY_ARRAY, compiledMethodClass);
     public final VirtualFrame externalSenderFrame = FrameAccess.newDummyFrame(dummyMethod);
 
     /* Method Cache */
@@ -366,7 +366,7 @@ public final class SqueakImageContext {
         final PointersObject methodNode;
         try {
             methodNode = (PointersObject) parserSharedInstance.send(this, "parse:class:noPattern:notifying:ifFail:",
-                            smalltalkSource, nilClass, BooleanObject.TRUE, requestorSharedInstanceOrNil, BlockClosureObject.create(this, blockClosureClass, 0));
+                            smalltalkSource, nilClass, BooleanObject.TRUE, requestorSharedInstanceOrNil, BlockClosureObject.create(blockClosureClass, 0));
         } catch (final ProcessSwitch e) {
             /*
              * A ProcessSwitch exception is thrown in case of a syntax error to open the
@@ -377,7 +377,7 @@ public final class SqueakImageContext {
         }
         final CompiledCodeObject doItMethod = (CompiledCodeObject) methodNode.send(this, "generate");
 
-        final ContextObject doItContext = new ContextObject(this, doItMethod.getSqueakContextSize());
+        final ContextObject doItContext = new ContextObject(doItMethod.getSqueakContextSize());
         doItContext.setReceiver(NilObject.SINGLETON);
         doItContext.setCodeObject(doItMethod);
         doItContext.setInstructionPointer(0);
@@ -416,10 +416,6 @@ public final class SqueakImageContext {
 
     public SqueakLanguage getLanguage() {
         return language;
-    }
-
-    public boolean getCurrentMarkingFlag() {
-        return currentMarkingFlag;
     }
 
     public boolean toggleCurrentMarkingFlag() {
@@ -611,12 +607,12 @@ public final class SqueakImageContext {
 
     public NativeObject getResourcesDirectory() {
         ensureResourcesDirectoryAndPathInitialized();
-        return NativeObject.newNativeBytes(this, byteStringClass, resourcesDirectoryBytes.clone());
+        return NativeObject.newNativeBytes(byteStringClass, resourcesDirectoryBytes.clone());
     }
 
     public NativeObject getResourcesPath() {
         ensureResourcesDirectoryAndPathInitialized();
-        return NativeObject.newNativeBytes(this, byteStringClass, resourcesPathBytes.clone());
+        return NativeObject.newNativeBytes(byteStringClass, resourcesPathBytes.clone());
     }
 
     private void ensureResourcesDirectoryAndPathInitialized() {
@@ -1097,11 +1093,11 @@ public final class SqueakImageContext {
      */
 
     public ArrayObject asArrayOfLongs(final long... elements) {
-        return ArrayObject.createWithStorage(this, arrayClass, elements);
+        return ArrayObject.createWithStorage(arrayClass, elements);
     }
 
     public ArrayObject asArrayOfObjects(final Object... elements) {
-        return ArrayObject.createWithStorage(this, arrayClass, elements);
+        return ArrayObject.createWithStorage(arrayClass, elements);
     }
 
     public ClassObject getFractionClass() {
@@ -1135,7 +1131,7 @@ public final class SqueakImageContext {
         }
         final long gcd = Math.abs(m);
         // Instantiate reduced fraction
-        final PointersObject fraction = new PointersObject(this, getFractionClass(), fractionClass.getLayout());
+        final PointersObject fraction = new PointersObject(getFractionClass(), fractionClass.getLayout());
         writeNode.execute(inlineTarget, fraction, FRACTION.NUMERATOR, actualNumerator / gcd);
         writeNode.execute(inlineTarget, fraction, FRACTION.DENOMINATOR, actualDenominator / gcd);
         return fraction;
@@ -1149,11 +1145,11 @@ public final class SqueakImageContext {
     }
 
     public NativeObject asByteArray(final byte[] bytes) {
-        return NativeObject.newNativeBytes(this, byteArrayClass, bytes);
+        return NativeObject.newNativeBytes(byteArrayClass, bytes);
     }
 
     public NativeObject asByteString(final byte[] bytes) {
-        return NativeObject.newNativeBytes(this, byteStringClass, bytes);
+        return NativeObject.newNativeBytes(byteStringClass, bytes);
     }
 
     public NativeObject asByteString(final String value) {
@@ -1166,7 +1162,7 @@ public final class SqueakImageContext {
     }
 
     private NativeObject asWideString(final String value) {
-        return NativeObject.newNativeInts(this, getWideStringClass(), MiscUtils.stringToCodePointsArray(value));
+        return NativeObject.newNativeInts(getWideStringClass(), MiscUtils.stringToCodePointsArray(value));
     }
 
     public NativeObject asString(final String value, final InlinedConditionProfile wideStringProfile, final Node node) {
@@ -1174,18 +1170,18 @@ public final class SqueakImageContext {
     }
 
     public PointersObject asPoint(final AbstractPointersObjectWriteNode writeNode, final Node inlineTarget, final Object xPos, final Object yPos) {
-        final PointersObject point = new PointersObject(this, pointClass, null);
+        final PointersObject point = new PointersObject(pointClass, null);
         writeNode.execute(inlineTarget, point, POINT.X, xPos);
         writeNode.execute(inlineTarget, point, POINT.Y, yPos);
         return point;
     }
 
     public ArrayObject newEmptyArray() {
-        return ArrayObject.createWithStorage(this, arrayClass, ArrayUtils.EMPTY_ARRAY);
+        return ArrayObject.createWithStorage(arrayClass, ArrayUtils.EMPTY_ARRAY);
     }
 
     public PointersObject newMessage(final AbstractPointersObjectWriteNode writeNode, final Node inlineTarget, final NativeObject selector, final ClassObject lookupClass, final Object[] arguments) {
-        final PointersObject message = new PointersObject(this, messageClass, null);
+        final PointersObject message = new PointersObject(messageClass, null);
         writeNode.execute(inlineTarget, message, MESSAGE.SELECTOR, selector);
         writeNode.execute(inlineTarget, message, MESSAGE.ARGUMENTS, asArrayOfObjects(arguments));
         assert message.instsize() > MESSAGE.LOOKUP_CLASS : "Early versions do not have lookupClass";

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageWriter.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageWriter.java
@@ -65,7 +65,7 @@ public final class SqueakImageWriter {
         this.image = image;
         final TruffleFile truffleFile = image.env.getPublicTruffleFile(image.getImagePath());
         stream = new BufferedOutputStream(truffleFile.newOutputStream());
-        freeList = NativeObject.newNativeLongs(image, image.nilClass /* ignored */, SqueakImageConstants.NUM_FREE_LISTS);
+        freeList = NativeObject.newNativeLongs(image.nilClass /* ignored */, SqueakImageConstants.NUM_FREE_LISTS);
     }
 
     /*
@@ -278,7 +278,7 @@ public final class SqueakImageWriter {
     }
 
     private long reserveBoxedFloat(final double value) {
-        return reserveBoxedObject(new FloatObject(image, value));
+        return reserveBoxedObject(new FloatObject(value));
     }
 
     private long reserveBoxedObject(final AbstractSqueakObjectWithHash object) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/AbstractPointersObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/AbstractPointersObject.java
@@ -17,7 +17,6 @@ import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.nodes.Node;
 
 import de.hpi.swa.trufflesqueak.image.SqueakImageChunk;
-import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
 import de.hpi.swa.trufflesqueak.image.SqueakImageWriter;
 import de.hpi.swa.trufflesqueak.model.layout.ObjectLayout;
 import de.hpi.swa.trufflesqueak.model.layout.SlotLocation;
@@ -60,8 +59,8 @@ public abstract class AbstractPointersObject extends AbstractSqueakObjectWithCla
         super();
     }
 
-    protected AbstractPointersObject(final SqueakImageContext image, final ClassObject classObject, final ObjectLayout layout) {
-        super(image, classObject);
+    protected AbstractPointersObject(final ClassObject classObject, final ObjectLayout layout) {
+        super(classObject);
         if (layout != null) {
             CompilerAsserts.partialEvaluationConstant(layout);
             this.layout = layout;

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/AbstractSqueakObjectWithClassAndHash.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/AbstractSqueakObjectWithClassAndHash.java
@@ -28,7 +28,8 @@ public abstract class AbstractSqueakObjectWithClassAndHash extends AbstractSquea
 
     // For special/well-known objects only.
     protected AbstractSqueakObjectWithClassAndHash() {
-        this(HASH_UNINITIALIZED, null);
+        /* Flags are zero and hash is uninitialized. squeakClass is null. */
+        super();
     }
 
     protected AbstractSqueakObjectWithClassAndHash(final long header, final ClassObject klass) {
@@ -36,12 +37,9 @@ public abstract class AbstractSqueakObjectWithClassAndHash extends AbstractSquea
         squeakClass = klass;
     }
 
-    protected AbstractSqueakObjectWithClassAndHash(final SqueakImageContext image, final ClassObject klass) {
-        this(image.getCurrentMarkingFlag(), klass);
-    }
-
-    private AbstractSqueakObjectWithClassAndHash(final boolean markingFlag, final ClassObject klass) {
-        super(markingFlag);
+    protected AbstractSqueakObjectWithClassAndHash(final ClassObject klass) {
+        /* Flags are zero and hash is uninitialized. */
+        super();
         squeakClass = klass;
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/AbstractVariablePointersObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/AbstractVariablePointersObject.java
@@ -9,7 +9,6 @@ package de.hpi.swa.trufflesqueak.model;
 import com.oracle.truffle.api.nodes.Node;
 
 import de.hpi.swa.trufflesqueak.image.SqueakImageChunk;
-import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
 import de.hpi.swa.trufflesqueak.model.layout.ObjectLayout;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectIdentityNode;
 import de.hpi.swa.trufflesqueak.util.ArrayUtils;
@@ -22,8 +21,8 @@ public abstract class AbstractVariablePointersObject extends AbstractPointersObj
         super(header, classObject);
     }
 
-    public AbstractVariablePointersObject(final SqueakImageContext image, final ClassObject classObject, final ObjectLayout layout, final int variableSize) {
-        super(image, classObject, layout);
+    public AbstractVariablePointersObject(final ClassObject classObject, final ObjectLayout layout, final int variableSize) {
+        super(classObject, layout);
         variablePart = ArrayUtils.withAll(variableSize, NilObject.SINGLETON);
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ArrayObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ArrayObject.java
@@ -15,7 +15,6 @@ import com.oracle.truffle.api.profiles.InlinedConditionProfile;
 
 import de.hpi.swa.trufflesqueak.image.SqueakImageChunk;
 import de.hpi.swa.trufflesqueak.image.SqueakImageConstants;
-import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
 import de.hpi.swa.trufflesqueak.image.SqueakImageWriter;
 import de.hpi.swa.trufflesqueak.nodes.accessing.ArrayObjectNodes.ArrayObjectSizeNode;
 import de.hpi.swa.trufflesqueak.nodes.accessing.ArrayObjectNodes.ArrayObjectWriteNode;
@@ -39,8 +38,8 @@ public final class ArrayObject extends AbstractSqueakObjectWithClassAndHash {
         super(); // for special ArrayObjects only
     }
 
-    private ArrayObject(final SqueakImageContext image, final ClassObject classObject, final Object storage) {
-        super(image, classObject);
+    private ArrayObject(final ClassObject classObject, final Object storage) {
+        super(classObject);
         this.storage = storage;
     }
 
@@ -53,16 +52,16 @@ public final class ArrayObject extends AbstractSqueakObjectWithClassAndHash {
         storage = storageCopy;
     }
 
-    public static ArrayObject createEmptyStrategy(final SqueakImageContext image, final ClassObject classObject, final int size) {
-        return new ArrayObject(image, classObject, size);
+    public static ArrayObject createEmptyStrategy(final ClassObject classObject, final int size) {
+        return new ArrayObject(classObject, size);
     }
 
-    public static ArrayObject createObjectStrategy(final SqueakImageContext image, final ClassObject classObject, final int size) {
-        return new ArrayObject(image, classObject, ArrayUtils.withAll(size, NilObject.SINGLETON));
+    public static ArrayObject createObjectStrategy(final ClassObject classObject, final int size) {
+        return new ArrayObject(classObject, ArrayUtils.withAll(size, NilObject.SINGLETON));
     }
 
-    public static ArrayObject createWithStorage(final SqueakImageContext image, final ClassObject classObject, final Object storage) {
-        return new ArrayObject(image, classObject, storage);
+    public static ArrayObject createWithStorage(final ClassObject classObject, final Object storage) {
+        return new ArrayObject(classObject, storage);
     }
 
     public static boolean isCharNilTag(final char value) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/BlockClosureObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/BlockClosureObject.java
@@ -28,8 +28,8 @@ public final class BlockClosureObject extends AbstractSqueakObjectWithClassAndHa
     @CompilationFinal private Object receiver;
     @CompilationFinal(dimensions = 0) private Object[] copiedValues;
 
-    private BlockClosureObject(final SqueakImageContext image, final ClassObject squeakClass) {
-        super(image, squeakClass);
+    private BlockClosureObject(final ClassObject squeakClass) {
+        super(squeakClass);
     }
 
     private BlockClosureObject(final long header, final ClassObject squeakClass) {
@@ -37,9 +37,9 @@ public final class BlockClosureObject extends AbstractSqueakObjectWithClassAndHa
         copiedValues = ArrayUtils.EMPTY_ARRAY; // Ensure copied is set.
     }
 
-    public BlockClosureObject(final SqueakImageContext image, final ClassObject squeakClass, final CompiledCodeObject block, final int startPC, final int numArgs, final Object[] copied,
+    public BlockClosureObject(final ClassObject squeakClass, final CompiledCodeObject block, final int startPC, final int numArgs, final Object[] copied,
                     final Object receiver, final ContextObject outerContext) {
-        super(image, squeakClass);
+        super(squeakClass);
         assert startPC > 0;
         this.block = block;
         this.outerContext = outerContext;
@@ -63,8 +63,8 @@ public final class BlockClosureObject extends AbstractSqueakObjectWithClassAndHa
         return new BlockClosureObject(header, squeakClass);
     }
 
-    public static BlockClosureObject create(final SqueakImageContext image, final ClassObject squeakClass, final int extraSize) {
-        final BlockClosureObject result = new BlockClosureObject(image, squeakClass);
+    public static BlockClosureObject create(final ClassObject squeakClass, final int extraSize) {
+        final BlockClosureObject result = new BlockClosureObject(squeakClass);
         result.copiedValues = new Object[extraSize];
         return result;
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ClassObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ClassObject.java
@@ -60,7 +60,7 @@ public final class ClassObject extends AbstractSqueakObjectWithClassAndHash {
     }
 
     private ClassObject(final ClassObject original) {
-        super(original);
+        super((AbstractSqueakObjectWithClassAndHash) original);
         image = original.image;
         instancesAreClasses = original.instancesAreClasses;
         superclass = original.superclass;
@@ -72,7 +72,7 @@ public final class ClassObject extends AbstractSqueakObjectWithClassAndHash {
     }
 
     public ClassObject(final SqueakImageContext image, final ClassObject classObject, final int size) {
-        super(image, classObject);
+        super(classObject);
         this.image = image;
         pointers = ArrayUtils.withAll(Math.max(size - CLASS_DESCRIPTION.INLINE_POINTERS, 0), NilObject.SINGLETON);
         instancesAreClasses = image.isMetaClass(classObject);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/CompiledCodeObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/CompiledCodeObject.java
@@ -105,8 +105,8 @@ public final class CompiledCodeObject extends AbstractSqueakObjectWithClassAndHa
         super(header, classObject);
     }
 
-    public CompiledCodeObject(final SqueakImageContext image, final byte[] bytes, final long header, final Object[] literals, final ClassObject classObject) {
-        super(image, classObject);
+    public CompiledCodeObject(final byte[] bytes, final long header, final Object[] literals, final ClassObject classObject) {
+        super(classObject);
         this.header = CompiledCodeHeaderUtils.toInt(header);
         this.literals = literals;
         this.bytes = bytes;
@@ -140,13 +140,13 @@ public final class CompiledCodeObject extends AbstractSqueakObjectWithClassAndHa
         bytes = outerCode.bytes;
     }
 
-    private CompiledCodeObject(final int size, final SqueakImageContext image, final ClassObject classObject) {
-        super(image, classObject);
+    private CompiledCodeObject(final int size, final ClassObject classObject) {
+        super(classObject);
         bytes = new byte[size];
     }
 
-    public static CompiledCodeObject newOfSize(final SqueakImageContext image, final int size, final ClassObject classObject) {
-        return new CompiledCodeObject(size, image, classObject);
+    public static CompiledCodeObject newOfSize(final int size, final ClassObject classObject) {
+        return new CompiledCodeObject(size, classObject);
     }
 
     private boolean hasExecutionData() {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/EmptyObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/EmptyObject.java
@@ -8,13 +8,12 @@ package de.hpi.swa.trufflesqueak.model;
 
 import de.hpi.swa.trufflesqueak.exceptions.SqueakExceptions.SqueakException;
 import de.hpi.swa.trufflesqueak.image.SqueakImageChunk;
-import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
 import de.hpi.swa.trufflesqueak.image.SqueakImageWriter;
 
 public final class EmptyObject extends AbstractSqueakObjectWithClassAndHash {
 
-    public EmptyObject(final SqueakImageContext image, final ClassObject classObject) {
-        super(image, classObject);
+    public EmptyObject(final ClassObject classObject) {
+        super(classObject);
     }
 
     public EmptyObject(final long header, final ClassObject classObject) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/EphemeronObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/EphemeronObject.java
@@ -100,7 +100,7 @@ public final class EphemeronObject extends AbstractPointersObject {
     }
 
     public EphemeronObject(final SqueakImageContext image, final ClassObject classObject, final ObjectLayout layout) {
-        super(image, classObject, layout);
+        super(classObject, layout);
         image.containsEphemerons = true;
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/FloatObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/FloatObject.java
@@ -20,8 +20,8 @@ public final class FloatObject extends AbstractSqueakObjectWithHash {
     public static final int WORD_LENGTH = 2;
     private double doubleValue;
 
-    public FloatObject(final SqueakImageContext image) {
-        super(image);
+    public FloatObject() {
+        super();
     }
 
     private FloatObject(final FloatObject original) {
@@ -29,8 +29,8 @@ public final class FloatObject extends AbstractSqueakObjectWithHash {
         doubleValue = original.doubleValue;
     }
 
-    public FloatObject(final SqueakImageContext image, final double doubleValue) {
-        super(image);
+    public FloatObject(final double doubleValue) {
+        super();
         this.doubleValue = doubleValue;
     }
 
@@ -64,8 +64,8 @@ public final class FloatObject extends AbstractSqueakObjectWithHash {
         // Nothing to do
     }
 
-    public static FloatObject valueOf(final SqueakImageContext image, final double value) {
-        return new FloatObject(image, value);
+    public static FloatObject valueOf(final double value) {
+        return new FloatObject(value);
     }
 
     public static Object newFrom(final SqueakImageChunk chunk) {
@@ -73,7 +73,7 @@ public final class FloatObject extends AbstractSqueakObjectWithHash {
         final long lowValue = Integer.toUnsignedLong(VarHandleUtils.getInt(chunk.getBytes(), 0));
         final long highValue = Integer.toUnsignedLong(VarHandleUtils.getInt(chunk.getBytes(), 1));
         final double value = Double.longBitsToDouble(highValue << 32 | lowValue);
-        return Double.isFinite(value) ? value : new FloatObject(chunk.getImage(), value);
+        return Double.isFinite(value) ? value : new FloatObject(value);
     }
 
     public long getHigh() {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/NativeObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/NativeObject.java
@@ -52,8 +52,8 @@ public final class NativeObject extends AbstractSqueakObjectWithClassAndHash {
         this.storage = storage;
     }
 
-    private NativeObject(final SqueakImageContext image, final ClassObject classObject, final Object storage) {
-        super(image, classObject);
+    private NativeObject(final ClassObject classObject, final Object storage) {
+        super(classObject);
         assert storage != null : "Unexpected `null` value";
         this.storage = storage;
     }
@@ -67,48 +67,48 @@ public final class NativeObject extends AbstractSqueakObjectWithClassAndHash {
         return new NativeObject(chunk.getHeader(), chunk.getSqueakClass(), chunk.getBytes());
     }
 
-    public static NativeObject newNativeBytes(final SqueakImageContext img, final ClassObject klass, final byte[] bytes) {
-        return new NativeObject(img, klass, bytes);
+    public static NativeObject newNativeBytes(final ClassObject klass, final byte[] bytes) {
+        return new NativeObject(klass, bytes);
     }
 
-    public static NativeObject newNativeBytes(final SqueakImageContext img, final ClassObject klass, final int size) {
-        return newNativeBytes(img, klass, new byte[size]);
+    public static NativeObject newNativeBytes(final ClassObject klass, final int size) {
+        return newNativeBytes(klass, new byte[size]);
     }
 
     public static NativeObject newNativeInts(final SqueakImageChunk chunk) {
         return new NativeObject(chunk.getHeader(), chunk.getSqueakClass(), UnsafeUtils.toInts(chunk.getBytes()));
     }
 
-    public static NativeObject newNativeInts(final SqueakImageContext img, final ClassObject klass, final int size) {
-        return newNativeInts(img, klass, new int[size]);
+    public static NativeObject newNativeInts(final ClassObject klass, final int size) {
+        return newNativeInts(klass, new int[size]);
     }
 
-    public static NativeObject newNativeInts(final SqueakImageContext img, final ClassObject klass, final int[] words) {
-        return new NativeObject(img, klass, words);
+    public static NativeObject newNativeInts(final ClassObject klass, final int[] words) {
+        return new NativeObject(klass, words);
     }
 
     public static NativeObject newNativeLongs(final SqueakImageChunk chunk) {
         return new NativeObject(chunk.getHeader(), chunk.getSqueakClass(), UnsafeUtils.toLongs(chunk.getBytes()));
     }
 
-    public static NativeObject newNativeLongs(final SqueakImageContext img, final ClassObject klass, final int size) {
-        return newNativeLongs(img, klass, new long[size]);
+    public static NativeObject newNativeLongs(final ClassObject klass, final int size) {
+        return newNativeLongs(klass, new long[size]);
     }
 
-    public static NativeObject newNativeLongs(final SqueakImageContext img, final ClassObject klass, final long[] longs) {
-        return new NativeObject(img, klass, longs);
+    public static NativeObject newNativeLongs(final ClassObject klass, final long[] longs) {
+        return new NativeObject(klass, longs);
     }
 
     public static NativeObject newNativeShorts(final SqueakImageChunk chunk) {
         return new NativeObject(chunk.getHeader(), chunk.getSqueakClass(), UnsafeUtils.toShorts(chunk.getBytes()));
     }
 
-    public static NativeObject newNativeShorts(final SqueakImageContext img, final ClassObject klass, final int size) {
-        return newNativeShorts(img, klass, new short[size]);
+    public static NativeObject newNativeShorts(final ClassObject klass, final int size) {
+        return newNativeShorts(klass, new short[size]);
     }
 
-    public static NativeObject newNativeShorts(final SqueakImageContext img, final ClassObject klass, final short[] shorts) {
-        return new NativeObject(img, klass, shorts);
+    public static NativeObject newNativeShorts(final ClassObject klass, final short[] shorts) {
+        return new NativeObject(klass, shorts);
     }
 
     @Override

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/PointersObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/PointersObject.java
@@ -35,8 +35,8 @@ public final class PointersObject extends AbstractPointersObject {
         super(header, klass);
     }
 
-    public PointersObject(final SqueakImageContext image, final ClassObject classObject, final ObjectLayout layout) {
-        super(image, classObject, layout);
+    public PointersObject(final ClassObject classObject, final ObjectLayout layout) {
+        super(classObject, layout);
     }
 
     private PointersObject(final PointersObject original) {
@@ -44,7 +44,7 @@ public final class PointersObject extends AbstractPointersObject {
     }
 
     public static PointersObject newHandleWithHiddenObject(final SqueakImageContext image, final Object hiddenObject) {
-        final PointersObject handle = new PointersObject(image, image.pointClass, null);
+        final PointersObject handle = new PointersObject(image.pointClass, null);
         handle.object2 = hiddenObject;
         return handle;
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/VariablePointersObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/VariablePointersObject.java
@@ -8,7 +8,6 @@ package de.hpi.swa.trufflesqueak.model;
 
 import org.graalvm.collections.UnmodifiableEconomicMap;
 
-import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
 import de.hpi.swa.trufflesqueak.image.SqueakImageWriter;
 import de.hpi.swa.trufflesqueak.model.layout.ObjectLayout;
 import de.hpi.swa.trufflesqueak.util.ArrayUtils;
@@ -20,8 +19,8 @@ public final class VariablePointersObject extends AbstractVariablePointersObject
         super(header, classObject);
     }
 
-    public VariablePointersObject(final SqueakImageContext image, final ClassObject classObject, final ObjectLayout layout, final int variableSize) {
-        super(image, classObject, layout, variableSize);
+    public VariablePointersObject(final ClassObject classObject, final ObjectLayout layout, final int variableSize) {
+        super(classObject, layout, variableSize);
     }
 
     private VariablePointersObject(final VariablePointersObject original) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/WeakVariablePointersObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/WeakVariablePointersObject.java
@@ -28,8 +28,8 @@ public final class WeakVariablePointersObject extends AbstractVariablePointersOb
         super(header, classObject);
     }
 
-    public WeakVariablePointersObject(final SqueakImageContext image, final ClassObject classObject, final ObjectLayout layout, final int variableSize) {
-        super(image, classObject, layout, variableSize);
+    public WeakVariablePointersObject(final ClassObject classObject, final ObjectLayout layout, final int variableSize) {
+        super(classObject, layout, variableSize);
     }
 
     private WeakVariablePointersObject(final WeakVariablePointersObject original) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/accessing/ContextObjectNodes.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/accessing/ContextObjectNodes.java
@@ -113,7 +113,7 @@ public final class ContextObjectNodes {
 
         @Specialization(guards = "index == METHOD")
         protected static final void doMethod(final ContextObject context, @SuppressWarnings("unused") final long index, final CompiledCodeObject value) {
-            context.setCodeObject(value);
+            context.overwriteCodeObject(value);
         }
 
         @Specialization(guards = {"index == CLOSURE_OR_NIL"})

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/accessing/FloatObjectNodes.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/accessing/FloatObjectNodes.java
@@ -37,8 +37,8 @@ public final class FloatObjectNodes {
         }
 
         @Specialization(guards = "!isFinite(value)")
-        protected final FloatObject doNaNOrInfinite(final double value) {
-            return new FloatObject(getContext(), value);
+        protected static final FloatObject doNaNOrInfinite(final double value) {
+            return new FloatObject(value);
         }
     }
 }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/context/GetOrCreateContextWithFrameNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/context/GetOrCreateContextWithFrameNode.java
@@ -51,7 +51,7 @@ public abstract class GetOrCreateContextWithFrameNode extends AbstractNode {
             }
             return context;
         } else {
-            return new ContextObject(getContext(node), frame.materialize());
+            return new ContextObject(frame.materialize());
         }
     }
 }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/context/GetOrCreateContextWithoutFrameNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/context/GetOrCreateContextWithoutFrameNode.java
@@ -41,7 +41,7 @@ public abstract class GetOrCreateContextWithoutFrameNode extends AbstractNode {
         if (hasContextProfile.profile(node, context != null)) {
             return context;
         } else {
-            return new ContextObject(getContext(node), frame);
+            return new ContextObject(frame);
         }
     }
 }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterSistaV1Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterSistaV1Node.java
@@ -363,7 +363,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                     }
                     case BC.EXT_PUSH_PSEUDO_VARIABLE: {
                         if (extB == 0) {
-                            push(frame, sp++, getOrCreateContext(frame, currentPC, image));
+                            push(frame, sp++, getOrCreateContext(frame, currentPC));
                         } else {
                             throw unknownBytecode();
                         }
@@ -375,27 +375,27 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                         break;
                     }
                     case BC.RETURN_RECEIVER: {
-                        returnValue = handleReturn(frame, currentPC, image, loopCounter.value, pc, sp, FrameAccess.getReceiver(frame));
+                        returnValue = handleReturn(frame, currentPC, loopCounter.value, pc, sp, FrameAccess.getReceiver(frame));
                         pc = LOCAL_RETURN_PC;
                         break;
                     }
                     case BC.RETURN_TRUE: {
-                        returnValue = handleReturn(frame, currentPC, image, loopCounter.value, pc, sp, BooleanObject.TRUE);
+                        returnValue = handleReturn(frame, currentPC, loopCounter.value, pc, sp, BooleanObject.TRUE);
                         pc = LOCAL_RETURN_PC;
                         break;
                     }
                     case BC.RETURN_FALSE: {
-                        returnValue = handleReturn(frame, currentPC, image, loopCounter.value, pc, sp, BooleanObject.FALSE);
+                        returnValue = handleReturn(frame, currentPC, loopCounter.value, pc, sp, BooleanObject.FALSE);
                         pc = LOCAL_RETURN_PC;
                         break;
                     }
                     case BC.RETURN_NIL: {
-                        returnValue = handleReturn(frame, currentPC, image, loopCounter.value, pc, sp, NilObject.SINGLETON);
+                        returnValue = handleReturn(frame, currentPC, loopCounter.value, pc, sp, NilObject.SINGLETON);
                         pc = LOCAL_RETURN_PC;
                         break;
                     }
                     case BC.RETURN_TOP_FROM_METHOD: {
-                        returnValue = handleReturn(frame, currentPC, image, loopCounter.value, pc, sp, top(frame, sp));
+                        returnValue = handleReturn(frame, currentPC, loopCounter.value, pc, sp, top(frame, sp));
                         pc = LOCAL_RETURN_PC;
                         break;
                     }
@@ -781,7 +781,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                         } else {
                             values = ArrayUtils.withAll(arraySize, NilObject.SINGLETON);
                         }
-                        push(frame, sp++, ArrayObject.createWithStorage(image, image.arrayClass, values));
+                        push(frame, sp++, ArrayObject.createWithStorage(image.arrayClass, values));
                         break;
                     }
                     case BC.EXT_PUSH_INTEGER: {
@@ -935,9 +935,9 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                         sp -= numCopied;
                         final boolean ignoreContext = (byteB & 0x40) != 0;
                         final boolean receiverOnStack = (byteB & 0x80) != 0;
-                        final ContextObject outerContext = ignoreContext ? null : getOrCreateContext(frame, currentPC, image);
+                        final ContextObject outerContext = ignoreContext ? null : getOrCreateContext(frame, currentPC);
                         final Object receiver = receiverOnStack ? pop(frame, --sp) : FrameAccess.getReceiver(frame);
-                        push(frame, sp++, new BlockClosureObject(image, image.getFullBlockClosureClass(), block, blockInitialPC, blockNumArgs, copiedValues, receiver, outerContext));
+                        push(frame, sp++, new BlockClosureObject(image.getFullBlockClosureClass(), block, blockInitialPC, blockNumArgs, copiedValues, receiver, outerContext));
                         extA = 0;
                         break;
                     }
@@ -946,7 +946,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                         final int numCopied = (byteA >> 3 & 0x7) + Math.floorDiv(extA, 16) * 8;
                         final Object[] copiedValues = popN(frame, sp, numCopied);
                         sp -= numCopied;
-                        push(frame, sp++, uncheckedCast(data[currentPC], PushClosureNode.class).execute(frame, copiedValues, getOrCreateContext(frame, currentPC, image)));
+                        push(frame, sp++, uncheckedCast(data[currentPC], PushClosureNode.class).execute(frame, copiedValues, getOrCreateContext(frame, currentPC)));
                         final int blockSize = getByteExtended(bc, pc++, extB);
                         pc += blockSize;
                         extA = extB = 0;

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterV3PlusClosuresNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterV3PlusClosuresNode.java
@@ -382,27 +382,27 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                         break;
                     }
                     case BC.RETURN_RECEIVER: {
-                        returnValue = handleReturn(frame, currentPC, image, loopCounter.value, pc, sp, FrameAccess.getReceiver(frame));
+                        returnValue = handleReturn(frame, currentPC, loopCounter.value, pc, sp, FrameAccess.getReceiver(frame));
                         pc = LOCAL_RETURN_PC;
                         break;
                     }
                     case BC.RETURN_TRUE: {
-                        returnValue = handleReturn(frame, currentPC, image, loopCounter.value, pc, sp, BooleanObject.TRUE);
+                        returnValue = handleReturn(frame, currentPC, loopCounter.value, pc, sp, BooleanObject.TRUE);
                         pc = LOCAL_RETURN_PC;
                         break;
                     }
                     case BC.RETURN_FALSE: {
-                        returnValue = handleReturn(frame, currentPC, image, loopCounter.value, pc, sp, BooleanObject.FALSE);
+                        returnValue = handleReturn(frame, currentPC, loopCounter.value, pc, sp, BooleanObject.FALSE);
                         pc = LOCAL_RETURN_PC;
                         break;
                     }
                     case BC.RETURN_NIL: {
-                        returnValue = handleReturn(frame, currentPC, image, loopCounter.value, pc, sp, NilObject.SINGLETON);
+                        returnValue = handleReturn(frame, currentPC, loopCounter.value, pc, sp, NilObject.SINGLETON);
                         pc = LOCAL_RETURN_PC;
                         break;
                     }
                     case BC.RETURN_TOP_FROM_METHOD: {
-                        returnValue = handleReturn(frame, currentPC, image, loopCounter.value, pc, sp, top(frame, sp));
+                        returnValue = handleReturn(frame, currentPC, loopCounter.value, pc, sp, top(frame, sp));
                         pc = LOCAL_RETURN_PC;
                         break;
                     }
@@ -584,7 +584,7 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                         break;
                     }
                     case BC.PUSH_ACTIVE_CONTEXT: {
-                        push(frame, sp++, getOrCreateContext(frame, currentPC, image));
+                        push(frame, sp++, getOrCreateContext(frame, currentPC));
                         break;
                     }
                     case BC.PUSH_NEW_ARRAY: {
@@ -597,7 +597,7 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                         } else {
                             values = ArrayUtils.withAll(arraySize, NilObject.SINGLETON);
                         }
-                        push(frame, sp++, ArrayObject.createWithStorage(image, image.arrayClass, values));
+                        push(frame, sp++, ArrayObject.createWithStorage(image.arrayClass, values));
                         break;
                     }
                     case BC.CALL_PRIMITIVE: {
@@ -633,7 +633,7 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                         final int numCopied = numArgsNumCopied >> 4 & 0xF;
                         final Object[] copiedValues = popN(frame, sp, numCopied);
                         sp -= numCopied;
-                        push(frame, sp++, uncheckedCast(data[currentPC], PushClosureNode.class).execute(frame, copiedValues, getOrCreateContext(frame, currentPC, image)));
+                        push(frame, sp++, uncheckedCast(data[currentPC], PushClosureNode.class).execute(frame, copiedValues, getOrCreateContext(frame, currentPC)));
                         pc += blockSizeHigh << 8 | blockSizeLow;
                         break;
                     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/Float64ArrayPlugin.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/Float64ArrayPlugin.java
@@ -91,8 +91,8 @@ public class Float64ArrayPlugin extends AbstractPrimitiveFactoryHolder {
         }
 
         @Specialization(guards = {"receiver.isLongType()", "index <= receiver.getLongLength()"})
-        protected final FloatObject doFloat(final NativeObject receiver, final long index, final FloatObject value) {
-            return FloatObject.valueOf(getContext(), doDouble(receiver, index, value.getValue()));
+        protected static final FloatObject doFloat(final NativeObject receiver, final long index, final FloatObject value) {
+            return FloatObject.valueOf(doDouble(receiver, index, value.getValue()));
         }
 
         @Specialization(guards = {"receiver.isLongType()", "index <= receiver.getLongLength()"})

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/FloatArrayPlugin.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/FloatArrayPlugin.java
@@ -92,8 +92,8 @@ public class FloatArrayPlugin extends AbstractPrimitiveFactoryHolder {
         }
 
         @Specialization(guards = {"receiver.isIntType()", "index <= receiver.getIntLength()"})
-        protected final FloatObject doFloat(final NativeObject receiver, final long index, final FloatObject value) {
-            return FloatObject.valueOf(getContext(), doDouble(receiver, index, value.getValue()));
+        protected static final FloatObject doFloat(final NativeObject receiver, final long index, final FloatObject value) {
+            return FloatObject.valueOf(doDouble(receiver, index, value.getValue()));
         }
 
         @Specialization(guards = {"receiver.isIntType()", "index <= receiver.getIntLength()"})

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/LargeIntegers.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/LargeIntegers.java
@@ -1039,7 +1039,7 @@ public final class LargeIntegers extends AbstractPrimitiveFactoryHolder {
     /* Utilities */
 
     public static NativeObject createLongMinOverflowResult(final SqueakImageContext image) {
-        return NativeObject.newNativeBytes(image, image.largePositiveIntegerClass, LONG_MIN_OVERFLOW_RESULT_BYTES.clone());
+        return NativeObject.newNativeBytes(image.largePositiveIntegerClass, LONG_MIN_OVERFLOW_RESULT_BYTES.clone());
     }
 
     private static int highBitOfLargeInt(final NativeObject value) {
@@ -1120,7 +1120,7 @@ public final class LargeIntegers extends AbstractPrimitiveFactoryHolder {
 
         final ClassObject squeakClass = isNegative ? image.largeNegativeIntegerClass : image.largePositiveIntegerClass;
         final byte[] result = byteLen < byteSize ? largeIntGrowTo(bytes, byteLen) : bytes;
-        return NativeObject.newNativeBytes(image, squeakClass, result);
+        return NativeObject.newNativeBytes(squeakClass, result);
     }
 
     /**
@@ -1240,7 +1240,7 @@ public final class LargeIntegers extends AbstractPrimitiveFactoryHolder {
     }
 
     public static NativeObject toNativeObject(final SqueakImageContext image, final BigInteger result) {
-        return NativeObject.newNativeBytes(image, result.signum() >= 0 ? image.largePositiveIntegerClass : image.largeNegativeIntegerClass, toByteArray(result));
+        return NativeObject.newNativeBytes(result.signum() >= 0 ? image.largePositiveIntegerClass : image.largeNegativeIntegerClass, toByteArray(result));
     }
 
     @TruffleBoundary

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/SqueakFFIPrims.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/SqueakFFIPrims.java
@@ -310,9 +310,9 @@ public final class SqueakFFIPrims extends AbstractPrimitiveFactoryHolder {
             } catch (final UnsupportedMessageException e) {
                 CompilerDirectives.transferToInterpreter();
                 LogUtils.MAIN.warning(e.toString());
-                return newExternalAddress(image, receiver, 0L);
+                return newExternalAddress(receiver, 0L);
             }
-            return newExternalAddress(image, receiver, pointer);
+            return newExternalAddress(receiver, pointer);
         }
 
         @TruffleBoundary
@@ -320,8 +320,8 @@ public final class SqueakFFIPrims extends AbstractPrimitiveFactoryHolder {
             return Source.newBuilder("nfi", String.format("load \"%s\"", getPathOrFail(image, moduleName)), "native").build();
         }
 
-        private static NativeObject newExternalAddress(final SqueakImageContext image, final ClassObject externalAddressClass, final long pointer) {
-            return NativeObject.newNativeBytes(image, externalAddressClass,
+        private static NativeObject newExternalAddress(final ClassObject externalAddressClass, final long pointer) {
+            return NativeObject.newNativeBytes(externalAddressClass,
                             new byte[]{(byte) pointer, (byte) (pointer >> 8), (byte) (pointer >> 16), (byte) (pointer >> 24), (byte) (pointer >> 32), (byte) (pointer >> 40),
                                             (byte) (pointer >> 48), (byte) (pointer >> 56)});
         }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/ffi/InterpreterProxy.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/ffi/InterpreterProxy.java
@@ -301,8 +301,8 @@ public final class InterpreterProxy {
         return boolToObject(bool != 0);
     }
 
-    private Object floatToObject(final double value) {
-        return new FloatObject(context, value);
+    private static Object floatToObject(final double value) {
+        return new FloatObject(value);
     }
 
     private NativeObject charPointerToByteString(final Object charPointer) {
@@ -508,7 +508,7 @@ public final class InterpreterProxy {
     private long instantiateClassIndexableSize(final long classPointer, final long size) {
         final Object object = objectRegistryGet(classPointer);
         if (object instanceof final ClassObject classObject) {
-            final AbstractSqueakObject newObject = SqueakObjectNewNode.executeUncached(context, classObject, MiscUtils.toIntExact(size));
+            final AbstractSqueakObject newObject = SqueakObjectNewNode.executeUncached(classObject, MiscUtils.toIntExact(size));
             return oopFor(newObject);
         } else {
             LogUtils.INTERPRETER_PROXY.severe(() -> "instantiateClassIndexableSize called with non-ClassObject: " + object);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ArithmeticPrimitives.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ArithmeticPrimitives.java
@@ -1259,7 +1259,7 @@ public final class ArithmeticPrimitives extends AbstractPrimitiveFactoryHolder {
             if (isFiniteProfile.profile(node, receiver.isFinite())) {
                 return Math.sin(receiver.getValue());
             } else {
-                return FloatObject.valueOf(getContext(node), Double.NaN);
+                return FloatObject.valueOf(Double.NaN);
             }
         }
     }
@@ -1291,13 +1291,13 @@ public final class ArithmeticPrimitives extends AbstractPrimitiveFactoryHolder {
                         @Cached final InlinedConditionProfile isPositiveInfinityProfile,
                         @Cached final InlinedConditionProfile isNegativeInfinityOrNaNProfile) {
             if (isZeroProfile.profile(node, receiver.isZero())) {
-                return FloatObject.valueOf(getContext(node), Double.NEGATIVE_INFINITY);
+                return FloatObject.valueOf(Double.NEGATIVE_INFINITY);
             } else if (isFiniteProfile.profile(node, receiver.isFinite())) {
                 return Math.log(receiver.getValue());
             } else if (isPositiveInfinityProfile.profile(node, receiver.isPositiveInfinity())) {
                 return receiver.shallowCopy();
             } else if (isNegativeInfinityOrNaNProfile.profile(node, receiver.isNegativeInfinity() || receiver.isNaN())) {
-                return FloatObject.valueOf(getContext(node), Double.NaN);
+                return FloatObject.valueOf(Double.NaN);
             } else {
                 throw PrimitiveFailed.andTransferToInterpreter();
             }
@@ -1737,13 +1737,13 @@ public final class ArithmeticPrimitives extends AbstractPrimitiveFactoryHolder {
         }
 
         @Specialization(guards = "isZero(receiver)")
-        protected final FloatObject doFloatZero(@SuppressWarnings("unused") final double receiver) {
-            return FloatObject.valueOf(getContext(), Double.NEGATIVE_INFINITY);
+        protected static final FloatObject doFloatZero(@SuppressWarnings("unused") final double receiver) {
+            return FloatObject.valueOf(Double.NEGATIVE_INFINITY);
         }
 
         @Specialization(guards = "isLessThanZero(receiver)")
-        protected final FloatObject doDoubleNegative(@SuppressWarnings("unused") final double receiver) {
-            return FloatObject.valueOf(getContext(), Double.NaN);
+        protected static final FloatObject doDoubleNegative(@SuppressWarnings("unused") final double receiver) {
+            return FloatObject.valueOf(Double.NaN);
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/StoragePrimitives.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/StoragePrimitives.java
@@ -116,7 +116,7 @@ public final class StoragePrimitives extends AbstractPrimitiveFactoryHolder {
                         @Cached("receiver.withEnsuredBehaviorHash()") final ClassObject cachedReceiver,
                         @Exclusive @Cached final SqueakObjectNewNode newNode) {
             try {
-                return newNode.execute(node, getContext(node), cachedReceiver);
+                return newNode.execute(node, cachedReceiver);
             } catch (final OutOfMemoryError e) {
                 CompilerDirectives.transferToInterpreter();
                 throw PrimitiveFailed.INSUFFICIENT_OBJECT_MEMORY;
@@ -130,7 +130,7 @@ public final class StoragePrimitives extends AbstractPrimitiveFactoryHolder {
                         @Exclusive @Cached final SqueakObjectNewNode newNode) {
             receiver.ensureBehaviorHash();
             try {
-                return newNode.execute(node, getContext(node), receiver);
+                return newNode.execute(node, receiver);
             } catch (final OutOfMemoryError e) {
                 CompilerDirectives.transferToInterpreter();
                 throw PrimitiveFailed.INSUFFICIENT_OBJECT_MEMORY;
@@ -148,7 +148,7 @@ public final class StoragePrimitives extends AbstractPrimitiveFactoryHolder {
                         @Cached("receiver.withEnsuredBehaviorHash()") final ClassObject cachedReceiver,
                         @Exclusive @Cached final SqueakObjectNewNode newNode) {
             try {
-                return newNode.execute(node, getContext(node), cachedReceiver, sizeProfile.profile(node, (int) size));
+                return newNode.execute(node, cachedReceiver, sizeProfile.profile(node, (int) size));
             } catch (final OutOfMemoryError e) {
                 CompilerDirectives.transferToInterpreter();
                 throw PrimitiveFailed.INSUFFICIENT_OBJECT_MEMORY;
@@ -162,7 +162,7 @@ public final class StoragePrimitives extends AbstractPrimitiveFactoryHolder {
                         @Exclusive @Cached final SqueakObjectNewNode newNode) {
             receiver.ensureBehaviorHash();
             try {
-                return newNode.execute(node, getContext(node), receiver, (int) size);
+                return newNode.execute(node, receiver, (int) size);
             } catch (final OutOfMemoryError e) {
                 CompilerDirectives.transferToInterpreter();
                 throw PrimitiveFailed.INSUFFICIENT_OBJECT_MEMORY;
@@ -288,7 +288,7 @@ public final class StoragePrimitives extends AbstractPrimitiveFactoryHolder {
             final SqueakImageContext image = getContext();
             assert receiver.getBasicInstanceSize() == 0;
             assert receiver.getSuperclassOrNull() == image.compiledMethodClass.getSuperclassOrNull() : "Receiver must be subclass of CompiledCode";
-            final CompiledCodeObject newMethod = CompiledCodeObject.newOfSize(image, (int) bytecodeCount, receiver);
+            final CompiledCodeObject newMethod = CompiledCodeObject.newOfSize((int) bytecodeCount, receiver);
             newMethod.initializeHeader(header);
             return newMethod;
         }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/FrameAccess.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/FrameAccess.java
@@ -59,7 +59,7 @@ import de.hpi.swa.trufflesqueak.nodes.context.GetOrCreateContextWithoutFrameNode
  *                            | copiedValue(nCopied-1)          |
  *                            +---------------------------------+
  * </pre>
- *
+ * <p>
  * TruffleSqueak frame slot layout.
  *
  * <pre>
@@ -75,24 +75,27 @@ import de.hpi.swa.trufflesqueak.nodes.context.GetOrCreateContextWithoutFrameNode
  * </pre>
  */
 public final class FrameAccess {
-    private enum ArgumentIndicies {
-        SENDER, // 0
-        CLOSURE_OR_NULL, // 1
-        RECEIVER, // 2
-        ARGUMENTS_START, // 3
+
+    private static final class ArgumentIndicies {
+        private static final int SENDER = 0;
+        private static final int CLOSURE_OR_NULL = 1;
+        private static final int RECEIVER = 2;
+        private static final int ARGUMENTS_START = 3;
     }
 
-    private enum SlotIndicies {
-        THIS_CONTEXT,
-        INSTRUCTION_POINTER,
-        STACK_POINTER,
-        STACK_START,
+    private static final class SlotIndicies {
+        private static final int THIS_CONTEXT = 0;
+        private static final int INSTRUCTION_POINTER = 1;
+        private static final int STACK_POINTER = 2;
+        private static final int STACK_START = 3;
     }
 
     private FrameAccess() {
     }
 
-    /** Creates a new {@link FrameDescriptor} according to {@link SlotIndicies}. */
+    /**
+     * Creates a new {@link FrameDescriptor} according to {@link SlotIndicies}.
+     */
     public static FrameDescriptor newFrameDescriptor(final CompiledCodeObject code) {
         final int numStackSlots = code.getMaxNumStackSlots();
         final Builder builder = FrameDescriptor.newBuilder(4 + numStackSlots);
@@ -125,7 +128,7 @@ public final class FrameAccess {
     }
 
     public static AbstractSqueakObject getSender(final Frame frame) {
-        return (AbstractSqueakObject) frame.getArguments()[ArgumentIndicies.SENDER.ordinal()];
+        return (AbstractSqueakObject) frame.getArguments()[ArgumentIndicies.SENDER];
     }
 
     public static ContextObject getSenderContext(final Frame frame) {
@@ -133,52 +136,52 @@ public final class FrameAccess {
     }
 
     public static void setSender(final Frame frame, final AbstractSqueakObject value) {
-        frame.getArguments()[ArgumentIndicies.SENDER.ordinal()] = value;
+        frame.getArguments()[ArgumentIndicies.SENDER] = value;
     }
 
     public static BlockClosureObject getClosure(final Frame frame) {
-        return (BlockClosureObject) frame.getArguments()[ArgumentIndicies.CLOSURE_OR_NULL.ordinal()];
+        return (BlockClosureObject) frame.getArguments()[ArgumentIndicies.CLOSURE_OR_NULL];
     }
 
     public static boolean hasClosure(final Frame frame) {
-        return frame.getArguments()[ArgumentIndicies.CLOSURE_OR_NULL.ordinal()] instanceof BlockClosureObject;
+        return frame.getArguments()[ArgumentIndicies.CLOSURE_OR_NULL] instanceof BlockClosureObject;
     }
 
     public static void setClosure(final Frame frame, final BlockClosureObject closure) {
-        frame.getArguments()[ArgumentIndicies.CLOSURE_OR_NULL.ordinal()] = closure;
+        frame.getArguments()[ArgumentIndicies.CLOSURE_OR_NULL] = closure;
     }
 
     public static Object[] storeParentFrameInArguments(final VirtualFrame parentFrame) {
         assert !hasClosure(parentFrame);
         final Object[] arguments = parentFrame.getArguments();
-        arguments[ArgumentIndicies.CLOSURE_OR_NULL.ordinal()] = parentFrame;
+        arguments[ArgumentIndicies.CLOSURE_OR_NULL] = parentFrame;
         return arguments;
     }
 
     public static Frame restoreParentFrameFromArguments(final Object[] arguments) {
-        final Object frame = arguments[ArgumentIndicies.CLOSURE_OR_NULL.ordinal()];
-        arguments[ArgumentIndicies.CLOSURE_OR_NULL.ordinal()] = null;
+        final Object frame = arguments[ArgumentIndicies.CLOSURE_OR_NULL];
+        arguments[ArgumentIndicies.CLOSURE_OR_NULL] = null;
         return (Frame) frame;
     }
 
     public static Object getReceiver(final Frame frame) {
-        return frame.getArguments()[ArgumentIndicies.RECEIVER.ordinal()];
+        return frame.getArguments()[ArgumentIndicies.RECEIVER];
     }
 
     public static void setReceiver(final Frame frame, final Object receiver) {
-        frame.getArguments()[ArgumentIndicies.RECEIVER.ordinal()] = receiver;
+        frame.getArguments()[ArgumentIndicies.RECEIVER] = receiver;
     }
 
     public static Object getArgument(final Frame frame, final int index) {
-        return frame.getArguments()[ArgumentIndicies.RECEIVER.ordinal() + index];
+        return frame.getArguments()[ArgumentIndicies.RECEIVER + index];
     }
 
     public static int getReceiverStartIndex() {
-        return ArgumentIndicies.RECEIVER.ordinal();
+        return ArgumentIndicies.RECEIVER;
     }
 
     public static int getArgumentStartIndex() {
-        return ArgumentIndicies.ARGUMENTS_START.ordinal();
+        return ArgumentIndicies.ARGUMENTS_START;
     }
 
     public static int getNumArguments(final Frame frame) {
@@ -191,7 +194,7 @@ public final class FrameAccess {
     }
 
     public static ContextObject getContext(final Frame frame) {
-        return (ContextObject) frame.getObjectStatic(SlotIndicies.THIS_CONTEXT.ordinal());
+        return (ContextObject) frame.getObjectStatic(SlotIndicies.THIS_CONTEXT);
     }
 
     public static boolean hasModifiedSender(final VirtualFrame frame) {
@@ -201,11 +204,11 @@ public final class FrameAccess {
 
     public static void setContext(final Frame frame, final ContextObject context) {
         assert getContext(frame) == null : "ContextObject already allocated";
-        frame.setObjectStatic(SlotIndicies.THIS_CONTEXT.ordinal(), context);
+        frame.setObjectStatic(SlotIndicies.THIS_CONTEXT, context);
     }
 
     public static int getInstructionPointer(final Frame frame) {
-        return frame.getIntStatic(SlotIndicies.INSTRUCTION_POINTER.ordinal());
+        return frame.getIntStatic(SlotIndicies.INSTRUCTION_POINTER);
     }
 
     public static boolean isDead(final Frame frame) {
@@ -213,11 +216,11 @@ public final class FrameAccess {
     }
 
     public static void setInstructionPointer(final Frame frame, final int value) {
-        frame.setIntStatic(SlotIndicies.INSTRUCTION_POINTER.ordinal(), value);
+        frame.setIntStatic(SlotIndicies.INSTRUCTION_POINTER, value);
     }
 
     public static int getStackPointer(final Frame frame) {
-        return frame.getIntStatic(SlotIndicies.STACK_POINTER.ordinal());
+        return frame.getIntStatic(SlotIndicies.STACK_POINTER);
     }
 
     @NeverDefault
@@ -226,16 +229,16 @@ public final class FrameAccess {
     }
 
     public static void setStackPointer(final Frame frame, final int value) {
-        frame.setIntStatic(SlotIndicies.STACK_POINTER.ordinal(), value);
+        frame.setIntStatic(SlotIndicies.STACK_POINTER, value);
     }
 
     public static int toStackSlotIndex(final Frame frame, final int index) {
         assert frame.getArguments().length - getArgumentStartIndex() <= index;
-        return SlotIndicies.STACK_START.ordinal() + index;
+        return SlotIndicies.STACK_START + index;
     }
 
     public static int toStackSlotIndex(final int index) {
-        return SlotIndicies.STACK_START.ordinal() + index;
+        return SlotIndicies.STACK_START + index;
     }
 
     public static Object getStackValue(final Frame frame, final int stackIndex, final int numArguments) {
@@ -247,7 +250,7 @@ public final class FrameAccess {
     }
 
     public static int getNumStackSlots(final Frame frame) {
-        return frame.getFrameDescriptor().getNumberOfSlots() - SlotIndicies.STACK_START.ordinal();
+        return frame.getFrameDescriptor().getNumberOfSlots() - SlotIndicies.STACK_START;
     }
 
     public static boolean slotsAreNotNilled(final Frame frame) {
@@ -278,7 +281,7 @@ public final class FrameAccess {
         if (slotsAreNotNilled(frame)) {
             setSlotsAreNilled(frame);
             final FrameDescriptor frameDescriptor = frame.getFrameDescriptor();
-            for (int slotIndex = SlotIndicies.STACK_START.ordinal(); slotIndex < frameDescriptor.getNumberOfSlots(); slotIndex++) {
+            for (int slotIndex = SlotIndicies.STACK_START; slotIndex < frameDescriptor.getNumberOfSlots(); slotIndex++) {
                 frame.setObjectStatic(slotIndex, null);
             }
             for (int auxSlotIndex = 0; auxSlotIndex < frameDescriptor.getNumberOfAuxiliarySlots(); auxSlotIndex++) {
@@ -292,7 +295,7 @@ public final class FrameAccess {
         if (isDead(frame)) {
             clearStackSlots(frame);
         } else {
-            for (int slotIndex = SlotIndicies.STACK_START.ordinal(); slotIndex < frame.getFrameDescriptor().getNumberOfSlots(); slotIndex++) {
+            for (int slotIndex = SlotIndicies.STACK_START; slotIndex < frame.getFrameDescriptor().getNumberOfSlots(); slotIndex++) {
                 action.accept(slotIndex);
             }
         }
@@ -306,7 +309,7 @@ public final class FrameAccess {
             }
         } else {
             final FrameDescriptor frameDescriptor = frame.getFrameDescriptor();
-            for (int slotIndex = SlotIndicies.STACK_START.ordinal(); slotIndex < frameDescriptor.getNumberOfSlots(); slotIndex++) {
+            for (int slotIndex = SlotIndicies.STACK_START; slotIndex < frameDescriptor.getNumberOfSlots(); slotIndex++) {
                 action.accept(frame.getObjectStatic(slotIndex));
             }
             for (int auxSlotIndex = 0; auxSlotIndex < frameDescriptor.getNumberOfAuxiliarySlots(); auxSlotIndex++) {
@@ -326,7 +329,7 @@ public final class FrameAccess {
             }
         } else {
             final FrameDescriptor frameDescriptor = frame.getFrameDescriptor();
-            for (int slotIndex = SlotIndicies.STACK_START.ordinal(); slotIndex < frameDescriptor.getNumberOfSlots(); slotIndex++) {
+            for (int slotIndex = SlotIndicies.STACK_START; slotIndex < frameDescriptor.getNumberOfSlots(); slotIndex++) {
                 final Object replacement = action.apply(frame.getObjectStatic(slotIndex));
                 if (replacement != null) {
                     frame.setObjectStatic(slotIndex, replacement);
@@ -364,7 +367,7 @@ public final class FrameAccess {
     public static void setStackSlot(final Frame frame, final int stackIndex, final Object value) {
         assert value != null;
         assert 0 <= stackIndex && stackIndex <= getCodeObject(frame).getSqueakContextSize();
-        setSlotValue(frame, SlotIndicies.STACK_START.ordinal() + stackIndex, value);
+        setSlotValue(frame, SlotIndicies.STACK_START + stackIndex, value);
     }
 
     public static boolean hasUnusedAuxiliarySlots(final Frame frame) {
@@ -382,105 +385,105 @@ public final class FrameAccess {
     }
 
     public static boolean isTruffleSqueakFrame(final Frame frame) {
-        return frame.getArguments().length >= ArgumentIndicies.RECEIVER.ordinal() && frame.getFrameDescriptor().getInfo() instanceof CompiledCodeObject;
+        return frame.getArguments().length >= ArgumentIndicies.RECEIVER && frame.getFrameDescriptor().getInfo() instanceof CompiledCodeObject;
     }
 
     public static Object[] newWith(final AbstractSqueakObject sender, final BlockClosureObject closure, final Object[] receiverAndArguments) {
         final int receiverAndArgumentsLength = receiverAndArguments.length;
-        final Object[] frameArguments = new Object[ArgumentIndicies.RECEIVER.ordinal() + receiverAndArgumentsLength];
+        final Object[] frameArguments = new Object[ArgumentIndicies.RECEIVER + receiverAndArgumentsLength];
         assert sender != null : "Sender should never be null";
         assert receiverAndArgumentsLength > 0 : "At least a receiver must be provided";
         assert receiverAndArguments[0] != null : "Receiver should never be null";
-        frameArguments[ArgumentIndicies.SENDER.ordinal()] = sender;
-        frameArguments[ArgumentIndicies.CLOSURE_OR_NULL.ordinal()] = closure;
-        ArrayUtils.arraycopy(receiverAndArguments, 0, frameArguments, ArgumentIndicies.RECEIVER.ordinal(), receiverAndArgumentsLength);
+        frameArguments[ArgumentIndicies.SENDER] = sender;
+        frameArguments[ArgumentIndicies.CLOSURE_OR_NULL] = closure;
+        ArrayUtils.arraycopy(receiverAndArguments, 0, frameArguments, ArgumentIndicies.RECEIVER, receiverAndArgumentsLength);
         return frameArguments;
     }
 
     public static Object[] newWith(final AbstractSqueakObject sender, final BlockClosureObject closure, final Object receiver) {
         assert sender != null && receiver != null : "Sender and receiver should never be null";
-        final Object[] frameArguments = new Object[ArgumentIndicies.ARGUMENTS_START.ordinal()];
-        frameArguments[ArgumentIndicies.SENDER.ordinal()] = sender;
-        frameArguments[ArgumentIndicies.CLOSURE_OR_NULL.ordinal()] = closure;
-        frameArguments[ArgumentIndicies.RECEIVER.ordinal()] = receiver;
+        final Object[] frameArguments = new Object[ArgumentIndicies.ARGUMENTS_START];
+        frameArguments[ArgumentIndicies.SENDER] = sender;
+        frameArguments[ArgumentIndicies.CLOSURE_OR_NULL] = closure;
+        frameArguments[ArgumentIndicies.RECEIVER] = receiver;
         return frameArguments;
     }
 
     public static Object[] newWith(final AbstractSqueakObject sender, final BlockClosureObject closure, final Object receiver, final Object arg1) {
         assert sender != null && receiver != null : "Sender and receiver should never be null";
-        final Object[] frameArguments = new Object[ArgumentIndicies.ARGUMENTS_START.ordinal() + 1];
-        frameArguments[ArgumentIndicies.SENDER.ordinal()] = sender;
-        frameArguments[ArgumentIndicies.CLOSURE_OR_NULL.ordinal()] = closure;
-        frameArguments[ArgumentIndicies.RECEIVER.ordinal()] = receiver;
-        frameArguments[ArgumentIndicies.ARGUMENTS_START.ordinal()] = arg1;
+        final Object[] frameArguments = new Object[ArgumentIndicies.ARGUMENTS_START + 1];
+        frameArguments[ArgumentIndicies.SENDER] = sender;
+        frameArguments[ArgumentIndicies.CLOSURE_OR_NULL] = closure;
+        frameArguments[ArgumentIndicies.RECEIVER] = receiver;
+        frameArguments[ArgumentIndicies.ARGUMENTS_START] = arg1;
         return frameArguments;
     }
 
     public static Object[] newWith(final AbstractSqueakObject sender, final BlockClosureObject closure, final Object receiver, final Object arg1, final Object arg2) {
         assert sender != null && receiver != null : "Sender and receiver should never be null";
-        final Object[] frameArguments = new Object[ArgumentIndicies.ARGUMENTS_START.ordinal() + 2];
-        frameArguments[ArgumentIndicies.SENDER.ordinal()] = sender;
-        frameArguments[ArgumentIndicies.CLOSURE_OR_NULL.ordinal()] = closure;
-        frameArguments[ArgumentIndicies.RECEIVER.ordinal()] = receiver;
-        frameArguments[ArgumentIndicies.ARGUMENTS_START.ordinal()] = arg1;
-        frameArguments[ArgumentIndicies.ARGUMENTS_START.ordinal() + 1] = arg2;
+        final Object[] frameArguments = new Object[ArgumentIndicies.ARGUMENTS_START + 2];
+        frameArguments[ArgumentIndicies.SENDER] = sender;
+        frameArguments[ArgumentIndicies.CLOSURE_OR_NULL] = closure;
+        frameArguments[ArgumentIndicies.RECEIVER] = receiver;
+        frameArguments[ArgumentIndicies.ARGUMENTS_START] = arg1;
+        frameArguments[ArgumentIndicies.ARGUMENTS_START + 1] = arg2;
         return frameArguments;
     }
 
     public static Object[] newWith(final AbstractSqueakObject sender, final BlockClosureObject closure, final Object receiver, final Object arg1, final Object arg2, final Object arg3) {
         assert sender != null && receiver != null : "Sender and receiver should never be null";
-        final Object[] frameArguments = new Object[ArgumentIndicies.ARGUMENTS_START.ordinal() + 3];
-        frameArguments[ArgumentIndicies.SENDER.ordinal()] = sender;
-        frameArguments[ArgumentIndicies.CLOSURE_OR_NULL.ordinal()] = closure;
-        frameArguments[ArgumentIndicies.RECEIVER.ordinal()] = receiver;
-        frameArguments[ArgumentIndicies.ARGUMENTS_START.ordinal()] = arg1;
-        frameArguments[ArgumentIndicies.ARGUMENTS_START.ordinal() + 1] = arg2;
-        frameArguments[ArgumentIndicies.ARGUMENTS_START.ordinal() + 2] = arg3;
+        final Object[] frameArguments = new Object[ArgumentIndicies.ARGUMENTS_START + 3];
+        frameArguments[ArgumentIndicies.SENDER] = sender;
+        frameArguments[ArgumentIndicies.CLOSURE_OR_NULL] = closure;
+        frameArguments[ArgumentIndicies.RECEIVER] = receiver;
+        frameArguments[ArgumentIndicies.ARGUMENTS_START] = arg1;
+        frameArguments[ArgumentIndicies.ARGUMENTS_START + 1] = arg2;
+        frameArguments[ArgumentIndicies.ARGUMENTS_START + 2] = arg3;
         return frameArguments;
     }
 
     public static Object[] newWith(final AbstractSqueakObject sender, final BlockClosureObject closure, final Object receiver, final Object arg1, final Object arg2, final Object arg3,
                     final Object arg4) {
         assert sender != null && receiver != null : "Sender and receiver should never be null";
-        final Object[] frameArguments = new Object[ArgumentIndicies.ARGUMENTS_START.ordinal() + 4];
-        frameArguments[ArgumentIndicies.SENDER.ordinal()] = sender;
-        frameArguments[ArgumentIndicies.CLOSURE_OR_NULL.ordinal()] = closure;
-        frameArguments[ArgumentIndicies.RECEIVER.ordinal()] = receiver;
-        frameArguments[ArgumentIndicies.ARGUMENTS_START.ordinal()] = arg1;
-        frameArguments[ArgumentIndicies.ARGUMENTS_START.ordinal() + 1] = arg2;
-        frameArguments[ArgumentIndicies.ARGUMENTS_START.ordinal() + 2] = arg3;
-        frameArguments[ArgumentIndicies.ARGUMENTS_START.ordinal() + 3] = arg4;
+        final Object[] frameArguments = new Object[ArgumentIndicies.ARGUMENTS_START + 4];
+        frameArguments[ArgumentIndicies.SENDER] = sender;
+        frameArguments[ArgumentIndicies.CLOSURE_OR_NULL] = closure;
+        frameArguments[ArgumentIndicies.RECEIVER] = receiver;
+        frameArguments[ArgumentIndicies.ARGUMENTS_START] = arg1;
+        frameArguments[ArgumentIndicies.ARGUMENTS_START + 1] = arg2;
+        frameArguments[ArgumentIndicies.ARGUMENTS_START + 2] = arg3;
+        frameArguments[ArgumentIndicies.ARGUMENTS_START + 3] = arg4;
         return frameArguments;
     }
 
     public static Object[] newWith(final AbstractSqueakObject sender, final BlockClosureObject closure, final Object receiver, final Object arg1, final Object arg2, final Object arg3,
                     final Object arg4, final Object arg5) {
         assert sender != null && receiver != null : "Sender and receiver should never be null";
-        final Object[] frameArguments = new Object[ArgumentIndicies.ARGUMENTS_START.ordinal() + 5];
-        frameArguments[ArgumentIndicies.SENDER.ordinal()] = sender;
-        frameArguments[ArgumentIndicies.CLOSURE_OR_NULL.ordinal()] = closure;
-        frameArguments[ArgumentIndicies.RECEIVER.ordinal()] = receiver;
-        frameArguments[ArgumentIndicies.ARGUMENTS_START.ordinal()] = arg1;
-        frameArguments[ArgumentIndicies.ARGUMENTS_START.ordinal() + 1] = arg2;
-        frameArguments[ArgumentIndicies.ARGUMENTS_START.ordinal() + 2] = arg3;
-        frameArguments[ArgumentIndicies.ARGUMENTS_START.ordinal() + 3] = arg4;
-        frameArguments[ArgumentIndicies.ARGUMENTS_START.ordinal() + 4] = arg5;
+        final Object[] frameArguments = new Object[ArgumentIndicies.ARGUMENTS_START + 5];
+        frameArguments[ArgumentIndicies.SENDER] = sender;
+        frameArguments[ArgumentIndicies.CLOSURE_OR_NULL] = closure;
+        frameArguments[ArgumentIndicies.RECEIVER] = receiver;
+        frameArguments[ArgumentIndicies.ARGUMENTS_START] = arg1;
+        frameArguments[ArgumentIndicies.ARGUMENTS_START + 1] = arg2;
+        frameArguments[ArgumentIndicies.ARGUMENTS_START + 2] = arg3;
+        frameArguments[ArgumentIndicies.ARGUMENTS_START + 3] = arg4;
+        frameArguments[ArgumentIndicies.ARGUMENTS_START + 4] = arg5;
         return frameArguments;
     }
 
     public static Object[] newWith(final AbstractSqueakObject sender, final BlockClosureObject closure, final Object receiver, final Object[] arguments) {
         assert sender != null && receiver != null : "Sender and receiver should never be null";
-        final Object[] frameArguments = new Object[ArgumentIndicies.ARGUMENTS_START.ordinal() + arguments.length];
-        frameArguments[ArgumentIndicies.SENDER.ordinal()] = sender;
-        frameArguments[ArgumentIndicies.CLOSURE_OR_NULL.ordinal()] = closure;
-        frameArguments[ArgumentIndicies.RECEIVER.ordinal()] = receiver;
-        ArrayUtils.arraycopy(arguments, 0, frameArguments, ArgumentIndicies.ARGUMENTS_START.ordinal(), arguments.length);
+        final Object[] frameArguments = new Object[ArgumentIndicies.ARGUMENTS_START + arguments.length];
+        frameArguments[ArgumentIndicies.SENDER] = sender;
+        frameArguments[ArgumentIndicies.CLOSURE_OR_NULL] = closure;
+        frameArguments[ArgumentIndicies.RECEIVER] = receiver;
+        ArrayUtils.arraycopy(arguments, 0, frameArguments, ArgumentIndicies.ARGUMENTS_START, arguments.length);
         return frameArguments;
     }
 
     public static Object[] newWith(final int numArgs) {
-        final Object[] frameArguments = new Object[ArgumentIndicies.ARGUMENTS_START.ordinal() + numArgs];
-        frameArguments[ArgumentIndicies.SENDER.ordinal()] = NilObject.SINGLETON;
+        final Object[] frameArguments = new Object[ArgumentIndicies.ARGUMENTS_START + numArgs];
+        frameArguments[ArgumentIndicies.SENDER] = NilObject.SINGLETON;
         return frameArguments;
     }
 
@@ -497,12 +500,12 @@ public final class FrameAccess {
         final Object[] copied = closure.getCopiedValues();
         final int numCopied = copied.length;
         assert closure.getNumArgs() == numArgs : "number of required and provided block arguments do not match";
-        final Object[] arguments = new Object[ArgumentIndicies.ARGUMENTS_START.ordinal() + numArgs + numCopied];
-        arguments[ArgumentIndicies.SENDER.ordinal()] = sender;
-        arguments[ArgumentIndicies.CLOSURE_OR_NULL.ordinal()] = closure;
-        arguments[ArgumentIndicies.RECEIVER.ordinal()] = closure.getReceiver();
-        assert arguments[ArgumentIndicies.RECEIVER.ordinal()] != null;
-        ArrayUtils.arraycopy(copied, 0, arguments, ArgumentIndicies.ARGUMENTS_START.ordinal() + numArgs, numCopied);
+        final Object[] arguments = new Object[ArgumentIndicies.ARGUMENTS_START + numArgs + numCopied];
+        arguments[ArgumentIndicies.SENDER] = sender;
+        arguments[ArgumentIndicies.CLOSURE_OR_NULL] = closure;
+        arguments[ArgumentIndicies.RECEIVER] = closure.getReceiver();
+        assert arguments[ArgumentIndicies.RECEIVER] != null;
+        ArrayUtils.arraycopy(copied, 0, arguments, ArgumentIndicies.ARGUMENTS_START + numArgs, numCopied);
         return arguments;
     }
 
@@ -518,7 +521,7 @@ public final class FrameAccess {
     }
 
     public static int expectedArgumentSize(final int numArgsAndCopied) {
-        return ArgumentIndicies.ARGUMENTS_START.ordinal() + numArgsAndCopied;
+        return ArgumentIndicies.ARGUMENTS_START + numArgsAndCopied;
     }
 
     public static void assertSenderNotNull(final Frame frame) {


### PR DESCRIPTION
Rearranged `AbstractSqueakObjectWithHash` `squeakHashAndFlags` and added four generic boolean flags (for use in subclasses) and a flag indicating whether the mark bit is valid.

This change means that the default constructor can be used (zero means all flags false and uninitialized hash) and that `image` is no longer needed to create an object.

In `ContextObject`, removed the `hasModifiedSender` boolean and implemented it (plus unwind-marked and exception-handler-marked flags) in the generic boolean flags in `squeakHashAndFlags`.