### PR TITLE
implement ShadowBlockMetadata

### DIFF
--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/CompiledCodeObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/CompiledCodeObject.java
@@ -415,7 +415,7 @@ public final class CompiledCodeObject extends AbstractSqueakObjectWithClassAndHa
     }
 
     public int getMaxNumStackSlots() {
-        return getInitialSP() + getDecoder().determineMaxNumStackSlots(this, getStartPCZeroBased(), getMaxPCZeroBased());
+        return getDecoder().determineMaxNumStackSlots(this, getStartPCZeroBased(), getMaxPCZeroBased(), getInitialSP());
     }
 
     public boolean getSignFlag() {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractDecoder.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractDecoder.java
@@ -28,7 +28,7 @@ public abstract class AbstractDecoder {
 
     public abstract int pcPreviousTo(CompiledCodeObject code, int pc);
 
-    public abstract int determineMaxNumStackSlots(CompiledCodeObject code, int initialPC, int maxPC);
+    public abstract int determineMaxNumStackSlots(CompiledCodeObject code, int initialPC, int maxPC, int initialSP);
 
     protected abstract int decodeNumBytes(CompiledCodeObject code, int index);
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractInterpreterNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractInterpreterNode.java
@@ -77,10 +77,11 @@ public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrum
         this.code = code;
         isBlock = code.isCompiledBlock() || code.isShadowBlock();
         numArguments = -1;
-        final int maxPC = BytecodeUtils.trailerPosition(code);
-        data = new Object[maxPC];
-        profiles = new byte[maxPC];
-        processBytecode(maxPC);
+        final int startPC = code.getStartPCZeroBased();
+        final int endPC = code.getMaxPCZeroBased();
+        data = new Object[endPC];
+        profiles = new byte[endPC];
+        processBytecode(startPC, endPC);
     }
 
     @SuppressWarnings("this-escape")
@@ -90,14 +91,15 @@ public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrum
         isBlock = original.isBlock;
         numArguments = original.numArguments;
         // fresh fields
-        final int maxPC = BytecodeUtils.trailerPosition(code);
-        data = new Object[maxPC];
-        profiles = new byte[maxPC];
-        processBytecode(maxPC);
+        final int startPC = code.getStartPCZeroBased();
+        final int endPC = code.getMaxPCZeroBased();
+        data = new Object[endPC];
+        profiles = new byte[endPC];
+        processBytecode(startPC, endPC);
         osrMetadata = null;
     }
 
-    protected abstract void processBytecode(int maxPC);
+    protected abstract void processBytecode(int startPC, int endPC);
 
     @Override
     public abstract Object execute(VirtualFrame frame, int startPC, int startSP);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/DecoderSistaV1.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/DecoderSistaV1.java
@@ -256,7 +256,7 @@ public final class DecoderSistaV1 extends AbstractDecoder {
      * allows dead code (at least the one for SistaV1), which simplifies the implementation.
      */
     @Override
-    public int determineMaxNumStackSlots(final CompiledCodeObject code, final int initialPC, final int maxPC) {
+    public int determineMaxNumStackSlots(final CompiledCodeObject code, final int initialPC, final int maxPC, final int initialSP) {
         final SqueakImageContext image = code.getSqueakClass().getImage();
         final int contextSize = code.getSqueakContextSize();
         final byte[] joins = new byte[maxPC];
@@ -290,15 +290,14 @@ public final class DecoderSistaV1 extends AbstractDecoder {
                 index += decodeNextPCDelta(code, index, extension, true);
             }
 
-            assert 0 <= currentStackPointer - SP_BIAS && currentStackPointer - SP_BIAS <= contextSize : "Stack pointer out of range: " + (currentStackPointer - SP_BIAS) + " (Context size: " +
-                            contextSize + ")";
             if (currentStackPointer > maxStackPointer) {
                 maxStackPointer = currentStackPointer;
             }
         }
 
-        assert 0 <= maxStackPointer - SP_BIAS && maxStackPointer - SP_BIAS <= contextSize : "Stack pointer out of range: " + (maxStackPointer - SP_BIAS) + " (Context size: " + contextSize + ")";
-        return maxStackPointer - SP_BIAS;
+        final int finalMaxStackPointer = maxStackPointer - SP_BIAS + initialSP;
+        assert initialSP <= finalMaxStackPointer && finalMaxStackPointer <= contextSize : "Stack pointer out of range: " + finalMaxStackPointer + " (Context size: " + contextSize + ")";
+        return finalMaxStackPointer;
     }
 
     private static int decodeStackPointer(final byte[] bc, final int index, final DecodedExtension extension, final int sp, final byte[] joins) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/DecoderV3PlusClosures.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/DecoderV3PlusClosures.java
@@ -249,7 +249,7 @@ public final class DecoderV3PlusClosures extends AbstractDecoder {
      * allows dead code (at least the one for SistaV1), which simplifies the implementation.
      */
     @Override
-    public int determineMaxNumStackSlots(final CompiledCodeObject code, final int initialPC, final int maxPC) {
+    public int determineMaxNumStackSlots(final CompiledCodeObject code, final int initialPC, final int maxPC, final int initialSP) {
         final SqueakImageContext image = code.getSqueakClass().getImage();
         final int contextSize = code.getSqueakContextSize();
         final byte[] joins = new byte[maxPC];
@@ -280,15 +280,14 @@ public final class DecoderV3PlusClosures extends AbstractDecoder {
                 index += decodeNumBytesSkipOverBlocks(bc, index);
             }
 
-            assert 0 <= currentStackPointer - SP_BIAS && currentStackPointer - SP_BIAS <= contextSize : "Stack pointer out of range: " + (currentStackPointer - SP_BIAS) + " (Context size: " +
-                            contextSize + ")";
             if (currentStackPointer > maxStackPointer) {
                 maxStackPointer = currentStackPointer;
             }
         }
 
-        assert 0 <= maxStackPointer - SP_BIAS && maxStackPointer - SP_BIAS <= contextSize : "Stack pointer out of range: " + (maxStackPointer - SP_BIAS) + " (Context size: " + contextSize + ")";
-        return maxStackPointer - SP_BIAS;
+        final int finalMaxStackPointer = maxStackPointer - SP_BIAS + initialSP;
+        assert initialSP <= finalMaxStackPointer && finalMaxStackPointer <= contextSize : "Stack pointer out of range: " + finalMaxStackPointer + " (Context size: " + contextSize + ")";
+        return finalMaxStackPointer;
     }
 
     private static int decodeStackPointer(final byte[] bc, final int index, final int sp, final byte[] joins) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterSistaV1Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterSistaV1Node.java
@@ -72,12 +72,11 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
     }
 
     @Override
-    protected void processBytecode(final int maxPC) {
+    protected void processBytecode(final int startPC, final int endPC) {
         final byte[] bc = code.getBytes();
         final SqueakImageContext image = SqueakImageContext.getSlow();
 
-        int pc = code.isShadowBlock() ? code.getOuterMethodStartPCZeroBased() : 0;
-        final int endPC = maxPC; // FIXME: should use block size in blocks
+        int pc = startPC;
         assert pc < endPC;
         int extA = 0;
         int extB = 0;

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterV3PlusClosuresNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterV3PlusClosuresNode.java
@@ -69,19 +69,11 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
     }
 
     @Override
-    protected void processBytecode(final int maxPC) {
+    protected void processBytecode(final int startPC, final int endPC) {
         final byte[] bc = code.getBytes();
         final SqueakImageContext image = SqueakImageContext.getSlow();
 
-        int pc;
-        final int endPC;
-        if (code.isShadowBlock()) {
-            pc = code.getOuterMethodStartPCZeroBased();
-            endPC = pc + getBlockSize(bc, pc - 2, pc - 1);
-        } else {
-            pc = 0;
-            endPC = maxPC;
-        }
+        int pc = startPC;
 
         while (pc < endPC) {
             final int currentPC = pc++;


### PR DESCRIPTION
Move all shadow block information into a new object inside the `ExecutionData`.

Remove most references to `isShadowBlock()` by providing common accessor functions for the shadow-block versus non-shadow-block cases.