### PR TITLE
Merge extA and extB into a single long extBA

### DIFF
--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/DecoderSistaV1.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/DecoderSistaV1.java
@@ -208,7 +208,16 @@ public final class DecoderSistaV1 extends AbstractDecoder {
             if (b == 0xE0) {
                 extA = (extA << 8) | byteValue;
             } else {
-                extB = (extB == 0 && byteValue > 127) ? byteValue - 256 : (extB << 8) | byteValue;
+                // See InterpreterSistaV1Node.execute(). Search for: BC_EXT_B_LOGIC
+                if (extB == 0) {
+                    /* leading byte is signed */
+                    final int signedByteValue = bc[index + offset + 1];
+                    /* make sure new extB is non-zero for next byte processing */
+                    extB = signedByteValue == 0 ? 0x80000000 : signedByteValue;
+                } else {
+                    /* subsequent bytes are unsigned */
+                    extB = (extB << 8) | byteValue;
+                }
             }
             offset += 2;
             b = Byte.toUnsignedInt(bc[index + offset]);


### PR DESCRIPTION
In preparation for the One Compilation per Bytecode Handler implementation, this PR merges `extA` and `extB` (`int`s) into a single variable `extBA` (`long`). This will reduce the register pressure on the threaded interpreter.

Changes:

- accessing `extA` and `extB` are now through helpers `getExtA(extBA)` and `getExtB(extBA)`
- zeroing either `extA` or `extB` individually now zeroes both
- decoding the **EXT_B** byte code now handles multibyte sequences properly

OSVM maintains a counter (`numExtB`) to determine whether an **EXT_B** byte code is the first in a series. Instead, we have been using `extB == 0` to indicate that the byte code is the first. At the moment, Squeak only emits single **EXT_B** byte codes, so this method will always work.

However, when the image starts using _sequences_ of **EXT_B** byte codes and the value being encoded is a positive integer with positions 7, 15 or 23 as the highest set bit, the decoded value will be interpreted as a negative integer. For example, the
emitted sequence for the value 0x8765 would be 0x00, 0x87, 0x65 and the second byte would be interpreted as a signed value in the current implementation.

If we assume that the encoder in the image will never try to encode the value 0 (which is safe since that is the default value without any emitted **EXT_B** byte codes), we can detect the case of the leading zero byte by setting the upper byte of `extB` and
relying on the next byte to shift that byte out of the register.