### PR TITLE
🤖 Fixes for SDL3 on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         os: [ubuntu-22.04, ubuntu-22.04-arm, windows-2022, macos-14]
         type: [jvm]
     env:
-      VM_ARGS: "--vm.ea --vm.Xmx6G --headless --experimental-options --smalltalk.resource-summary=true --compiler.TreatPerformanceWarningsAsErrors=call,instanceof,store,trivial --compiler.DeoptCycleDetectionThreshold=-1 --engine.CompilationFailureAction=Diagnose --engine.CompilationStatistics"
+      VM_ARGS: "--vm.ea --vm.Xmx6G --experimental-options --smalltalk.resource-summary=true --compiler.TreatPerformanceWarningsAsErrors=call,instanceof,store,trivial --compiler.DeoptCycleDetectionThreshold=-1 --engine.CompilationFailureAction=Diagnose --engine.CompilationStatistics"
     name: build ${{ matrix.type }} ${{ matrix.os }}
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
@@ -127,6 +127,11 @@ jobs:
         trufflesqueak-polyglot-get -v ${{ env.GRAALVM_VERSION }} -a js
         trufflesqueak --code "Polyglot eval: 'js' string: 'new Object({hello_world: 42})'" images/test-64bit.image
       if: ${{ matrix.type == 'jvm' && ! endsWith(env.GRAALVM_VERSION, '-ea') }}
+    - name: Start Xvfb in background
+      run: |
+        Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+        echo "DISPLAY=:99" >> $GITHUB_ENV
+      if: ${{ runner.os == 'Linux' }}
     - name: Run Cuis 7.3 tests on TruffleSqueak standalone
       run: |
         mx.trufflesqueak/utils.sh download-cuis-7-3-test-image
@@ -204,16 +209,21 @@ jobs:
       shell: bash
       run: |
         trufflesqueak --code "(String streamContents: [:s | SystemReporter basicNew reportImage: s; reportVM: s; reportVMParameters: s]) withUnixLineEndings" images/test-64bit.image
+    - name: Start Xvfb in background
+      run: |
+        Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+        echo "DISPLAY=:99" >> $GITHUB_ENV
+      if: ${{ runner.os == 'Linux' }}
     - name: Run Cuis 7.3 tests on instrumented TruffleSqueak standalone
       run: |
         mx.trufflesqueak/utils.sh download-cuis-7-3-test-image
-        trufflesqueak --headless --engine.Mode=default --vm.XX:ProfilesDumpFile=${{ env.PGO_FILE_CUIS }} --vm.XX:ProfilesLCOVFile=${{ env.PGO_LCOV_FILE_CUIS }} images/Cuis?.?-????.image -s src/image-tests/runCuisTests.st
+        trufflesqueak --engine.Mode=default --vm.XX:ProfilesDumpFile=${{ env.PGO_FILE_CUIS }} --vm.XX:ProfilesLCOVFile=${{ env.PGO_LCOV_FILE_CUIS }} images/Cuis?.?-????.image -s src/image-tests/runCuisTests.st
       timeout-minutes: 10
       if: ${{ matrix.os == 'ubuntu-22.04' }}
     - name: Run Squeak/Smalltalk tests on instrumented TruffleSqueak standalone
       shell: bash
       run: |
-        trufflesqueak --headless --engine.Mode=default --vm.XX:ProfilesDumpFile=${{ env.PGO_FILE_SQUEAK }} --vm.XX:ProfilesLCOVFile=${{ env.PGO_LCOV_FILE_SQUEAK }} images/test-64bit.image $(pwd)/src/image-tests/runSqueakTests.st
+        trufflesqueak --engine.Mode=default --vm.XX:ProfilesDumpFile=${{ env.PGO_FILE_SQUEAK }} --vm.XX:ProfilesLCOVFile=${{ env.PGO_LCOV_FILE_SQUEAK }} images/test-64bit.image $(pwd)/src/image-tests/runSqueakTests.st
       timeout-minutes: 30
     - name: Report code coverage
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,7 @@ jobs:
         java-version: '${{ env.GRAALVM_VERSION }}'
         distribution: 'graalvm'
         github-token: ${{ secrets.GITHUB_TOKEN }}
+        native-image-job-reports: true
     - name: Enable Oracle GraalVM
       shell: bash
       run: echo "BOOTSTRAP_GRAALVM=$JAVA_HOME" >> $GITHUB_ENV
@@ -259,6 +260,7 @@ jobs:
         java-version: '${{ env.GRAALVM_VERSION }}'
         distribution: 'graalvm'
         github-token: ${{ secrets.GITHUB_TOKEN }}
+        native-image-job-reports: true
     - name: Enable Oracle GraalVM
       shell: bash
       run: echo "BOOTSTRAP_GRAALVM=$JAVA_HOME" >> $GITHUB_ENV

--- a/mx.trufflesqueak/suite.py
+++ b/mx.trufflesqueak/suite.py
@@ -219,6 +219,9 @@ suite = {
                 "de.hpi.swa.trufflesqueak.sdl3",
                 "sdk:GRAAL_SDK",
             ],
+            "requires": [
+                "java.net.http",
+            ],
             "checkstyle": "de.hpi.swa.trufflesqueak",
             "jacoco": "include",
             "javaCompliance": "24+",

--- a/src/de.hpi.swa.trufflesqueak.sdl3/README.md
+++ b/src/de.hpi.swa.trufflesqueak.sdl3/README.md
@@ -1,0 +1,11 @@
+# SDL3 Bindings
+
+To regenerate the checked-in SDL3 bindings:
+
+1. Download the [SDL3 sources](https://github.com/libsdl-org/SDL/archive/refs/tags/release-3.4.2.zip) and extract them in TruffleSqueak's `src/` directory.
+2. Download [jextract](https://jdk.java.net/jextract/) and run it with:
+
+    ```bash
+    jextract @./src/de.hpi.swa.trufflesqueak.sdl3/jextract.args
+    ```
+3. Re-apply [this Windows `size_t` compatibility fix](https://github.com/hpi-swa/trufflesqueak/commit/efea90e2202613d3c6da8f3d54a65f26c86a1ec7).

--- a/src/de.hpi.swa.trufflesqueak.sdl3/jextract.args
+++ b/src/de.hpi.swa.trufflesqueak.sdl3/jextract.args
@@ -67,7 +67,9 @@ src/SDL-release-3.4.2/include/SDL3/SDL.h
 --include-function SDL_StartTextInput
 --include-function SDL_CreateColorCursor
 --include-function SDL_DestroyCursor
+--include-function SDL_HideCursor
 --include-function SDL_SetCursor
+--include-function SDL_ShowCursor
 --include-struct SDL_Rect
 --include-function SDL_CreateRenderer
 --include-function SDL_CreateTexture

--- a/src/de.hpi.swa.trufflesqueak.sdl3/jextract.args
+++ b/src/de.hpi.swa.trufflesqueak.sdl3/jextract.args
@@ -12,7 +12,6 @@ src/SDL-release-3.4.2/include/SDL3/SDL.h
 --include-function SDL_SetClipboardText
 --include-function SDL_GetError
 --include-struct SDL_DropEvent
---include-union SDL_Event
 --include-struct SDL_KeyboardEvent
 --include-struct SDL_MouseButtonEvent
 --include-struct SDL_MouseMotionEvent
@@ -26,6 +25,7 @@ src/SDL-release-3.4.2/include/SDL3/SDL.h
 --include-struct SDL_AudioDeviceEvent
 --include-struct SDL_CameraDeviceEvent
 --include-struct SDL_ClipboardEvent
+--include-union SDL_Event
 --include-struct SDL_CommonEvent
 --include-struct SDL_DisplayEvent
 --include-struct SDL_GamepadAxisEvent

--- a/src/de.hpi.swa.trufflesqueak.sdl3/src/de/hpi/swa/trufflesqueak/sdl3/bindings/SDL_h$shared.java
+++ b/src/de.hpi.swa.trufflesqueak.sdl3/src/de/hpi/swa/trufflesqueak/sdl3/bindings/SDL_h$shared.java
@@ -27,7 +27,9 @@ public class SDL_h$shared {
     public static final ValueLayout.OfDouble C_DOUBLE = (ValueLayout.OfDouble) Linker.nativeLinker().canonicalLayouts().get("double");
     public static final AddressLayout C_POINTER = ((AddressLayout) Linker.nativeLinker().canonicalLayouts().get("void*"))
             .withTargetLayout(MemoryLayout.sequenceLayout(java.lang.Long.MAX_VALUE, C_CHAR));
-    public static final ValueLayout.OfLong C_LONG = (ValueLayout.OfLong) Linker.nativeLinker().canonicalLayouts().get("long");
+    // Windows uses LLP64, so C `long` is 32-bit there even on 64-bit builds.
+    public static final ValueLayout C_LONG = (ValueLayout) Linker.nativeLinker().canonicalLayouts().get("long");
+    public static final ValueLayout C_SIZE_T = (ValueLayout) Linker.nativeLinker().canonicalLayouts().get("size_t");
 
     static final boolean TRACE_DOWNCALLS = Boolean.getBoolean("jextract.trace.downcalls");
 

--- a/src/de.hpi.swa.trufflesqueak.sdl3/src/de/hpi/swa/trufflesqueak/sdl3/bindings/SDL_h.java
+++ b/src/de.hpi.swa.trufflesqueak.sdl3/src/de/hpi/swa/trufflesqueak/sdl3/bindings/SDL_h.java
@@ -1467,6 +1467,124 @@ public class SDL_h extends SDL_h$shared {
         } catch (Error | RuntimeException ex) {
            throw ex;
         } catch (Throwable ex$) {
+            throw new AssertionError("should not reach here", ex$);
+        }
+    }
+
+    private static class SDL_ShowCursor {
+        public static final FunctionDescriptor DESC = FunctionDescriptor.of(
+            SDL_h.C_BOOL
+        );
+
+        public static final MemorySegment ADDR = SYMBOL_LOOKUP.findOrThrow("SDL_ShowCursor");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
+    }
+
+    /**
+     * Function descriptor for:
+     * {@snippet lang=c :
+     * extern bool SDL_ShowCursor()
+     * }
+     */
+    public static FunctionDescriptor SDL_ShowCursor$descriptor() {
+        return SDL_ShowCursor.DESC;
+    }
+
+    /**
+     * Downcall method handle for:
+     * {@snippet lang=c :
+     * extern bool SDL_ShowCursor()
+     * }
+     */
+    public static MethodHandle SDL_ShowCursor$handle() {
+        return SDL_ShowCursor.HANDLE;
+    }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * extern bool SDL_ShowCursor()
+     * }
+     */
+    public static MemorySegment SDL_ShowCursor$address() {
+        return SDL_ShowCursor.ADDR;
+    }
+
+    /**
+     * {@snippet lang=c :
+     * extern bool SDL_ShowCursor()
+     * }
+     */
+    public static boolean SDL_ShowCursor() {
+        var mh$ = SDL_ShowCursor.HANDLE;
+        try {
+            if (TRACE_DOWNCALLS) {
+                traceDowncall("SDL_ShowCursor");
+            }
+            return (boolean)mh$.invokeExact();
+        } catch (Error | RuntimeException ex) {
+           throw ex;
+        } catch (Throwable ex$) {
+           throw new AssertionError("should not reach here", ex$);
+        }
+    }
+
+    private static class SDL_HideCursor {
+        public static final FunctionDescriptor DESC = FunctionDescriptor.of(
+            SDL_h.C_BOOL
+        );
+
+        public static final MemorySegment ADDR = SYMBOL_LOOKUP.findOrThrow("SDL_HideCursor");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
+    }
+
+    /**
+     * Function descriptor for:
+     * {@snippet lang=c :
+     * extern bool SDL_HideCursor()
+     * }
+     */
+    public static FunctionDescriptor SDL_HideCursor$descriptor() {
+        return SDL_HideCursor.DESC;
+    }
+
+    /**
+     * Downcall method handle for:
+     * {@snippet lang=c :
+     * extern bool SDL_HideCursor()
+     * }
+     */
+    public static MethodHandle SDL_HideCursor$handle() {
+        return SDL_HideCursor.HANDLE;
+    }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * extern bool SDL_HideCursor()
+     * }
+     */
+    public static MemorySegment SDL_HideCursor$address() {
+        return SDL_HideCursor.ADDR;
+    }
+
+    /**
+     * {@snippet lang=c :
+     * extern bool SDL_HideCursor()
+     * }
+     */
+    public static boolean SDL_HideCursor() {
+        var mh$ = SDL_HideCursor.HANDLE;
+        try {
+            if (TRACE_DOWNCALLS) {
+                traceDowncall("SDL_HideCursor");
+            }
+            return (boolean)mh$.invokeExact();
+        } catch (Error | RuntimeException ex) {
+           throw ex;
+        } catch (Throwable ex$) {
            throw new AssertionError("should not reach here", ex$);
         }
     }
@@ -2661,4 +2779,3 @@ public class SDL_h extends SDL_h$shared {
         return Holder.SDL_PROP_APP_METADATA_IDENTIFIER_STRING;
     }
 }
-

--- a/src/de.hpi.swa.trufflesqueak.sdl3/src/de/hpi/swa/trufflesqueak/sdl3/bindings/SDL_h.java
+++ b/src/de.hpi.swa.trufflesqueak.sdl3/src/de/hpi/swa/trufflesqueak/sdl3/bindings/SDL_h.java
@@ -150,7 +150,7 @@ public class SDL_h extends SDL_h$shared {
         public static final FunctionDescriptor DESC = FunctionDescriptor.of(
             SDL_h.C_POINTER,
             SDL_h.C_POINTER,
-            SDL_h.C_LONG
+            SDL_h.C_SIZE_T
         );
 
         public static final MemorySegment ADDR = SYMBOL_LOOKUP.findOrThrow("SDL_IOFromMem");

--- a/src/de.hpi.swa.trufflesqueak.shared/src/de/hpi/swa/trufflesqueak/shared/ImageDownloadSupport.java
+++ b/src/de.hpi.swa.trufflesqueak.shared/src/de/hpi/swa/trufflesqueak/shared/ImageDownloadSupport.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2026 Software Architecture Group, Hasso Plattner Institute
+ * Copyright (c) 2026 Oracle and/or its affiliates
+ *
+ * Licensed under the MIT License.
+ */
+package de.hpi.swa.trufflesqueak.shared;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.Authenticator;
+import java.net.InetSocketAddress;
+import java.net.PasswordAuthentication;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+public final class ImageDownloadSupport {
+    private static final ProxySelector NO_PROXY_SELECTOR = new ProxySelector() {
+        @Override
+        public List<Proxy> select(final URI uri) {
+            return List.of(Proxy.NO_PROXY);
+        }
+
+        @Override
+        public void connectFailed(final URI uri, final java.net.SocketAddress sa, final IOException ioe) {
+        }
+    };
+
+    public enum ProxyMode {
+        DEFAULT,
+        DIRECT,
+        PROXY
+    }
+
+    public record ProxyConfiguration(ProxyMode mode, String host, int port, String username, String password) {
+    }
+
+    private ImageDownloadSupport() {
+    }
+
+    public static BufferedInputStream openStream(final URI uri) throws IOException {
+        return openStream(uri, System.getenv());
+    }
+
+    static BufferedInputStream openStream(final URI uri, final Map<String, String> environment) throws IOException {
+        final HttpClient.Builder builder = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL);
+        final ProxyConfiguration proxyConfiguration = proxyConfigurationFor(uri, environment);
+        switch (proxyConfiguration.mode()) {
+            case DIRECT -> builder.proxy(NO_PROXY_SELECTOR);
+            case PROXY -> {
+                builder.proxy(ProxySelector.of(new InetSocketAddress(proxyConfiguration.host(), proxyConfiguration.port())));
+                if (proxyConfiguration.username() != null) {
+                    builder.authenticator(new Authenticator() {
+                        @Override
+                        protected PasswordAuthentication getPasswordAuthentication() {
+                            if (getRequestorType() == RequestorType.PROXY &&
+                                            proxyConfiguration.host().equalsIgnoreCase(getRequestingHost()) &&
+                                            proxyConfiguration.port() == getRequestingPort()) {
+                                return new PasswordAuthentication(proxyConfiguration.username(), proxyConfiguration.password().toCharArray());
+                            }
+                            return null;
+                        }
+                    });
+                }
+            }
+            case DEFAULT -> {
+            }
+        }
+        final HttpRequest request = HttpRequest.newBuilder(uri).GET().build();
+        try {
+            final HttpResponse<InputStream> response = builder.build().send(request, HttpResponse.BodyHandlers.ofInputStream());
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                response.body().close();
+                throw new IOException("Failed to download " + uri + " (HTTP " + response.statusCode() + ")");
+            }
+            return new BufferedInputStream(response.body());
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while downloading " + uri, e);
+        } catch (final IllegalArgumentException e) {
+            throw new IOException("Invalid proxy configuration for " + uri + ": " + e.getMessage(), e);
+        }
+    }
+
+    public static ProxyConfiguration proxyConfigurationFor(final URI uri, final Map<String, String> environment) {
+        final String scheme = uri.getScheme();
+        if (scheme == null) {
+            return new ProxyConfiguration(ProxyMode.DEFAULT, null, -1, null, null);
+        }
+        final String host = uri.getHost();
+        final int port = effectivePort(uri);
+        final String noProxy = getEnvironmentValue(environment, "no_proxy", "NO_PROXY");
+        if (host != null && noProxy != null && matchesNoProxy(host, port, noProxy)) {
+            return new ProxyConfiguration(ProxyMode.DIRECT, null, -1, null, null);
+        }
+        final String proxyValue;
+        if ("https".equalsIgnoreCase(scheme)) {
+            proxyValue = getEnvironmentValue(environment, "https_proxy", "HTTPS_PROXY", "http_proxy", "HTTP_PROXY");
+        } else if ("http".equalsIgnoreCase(scheme)) {
+            proxyValue = getEnvironmentValue(environment, "http_proxy", "HTTP_PROXY");
+        } else {
+            proxyValue = null;
+        }
+        if (proxyValue == null || proxyValue.isBlank()) {
+            return new ProxyConfiguration(ProxyMode.DEFAULT, null, -1, null, null);
+        }
+        return parseProxyConfiguration(proxyValue);
+    }
+
+    public static boolean matchesNoProxy(final String host, final int port, final String noProxyValue) {
+        for (final String rawEntry : noProxyValue.split(",")) {
+            final String entry = rawEntry.trim();
+            if (!entry.isEmpty() && matchesNoProxyEntry(host, port, entry)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static ProxyConfiguration parseProxyConfiguration(final String proxyValue) {
+        final String normalizedProxyValue = proxyValue.contains("://") ? proxyValue : "http://" + proxyValue;
+        final URI proxyUri = URI.create(normalizedProxyValue);
+        final String host = proxyUri.getHost();
+        if (host == null || host.isBlank()) {
+            throw new IllegalArgumentException("missing proxy host");
+        }
+        final int port = proxyUri.getPort() != -1 ? proxyUri.getPort() : defaultPort(proxyUri.getScheme());
+        final String rawUserInfo = proxyUri.getRawUserInfo();
+        if (rawUserInfo == null) {
+            return new ProxyConfiguration(ProxyMode.PROXY, host, port, null, null);
+        }
+        final String[] parts = rawUserInfo.split(":", 2);
+        final String username = URLDecoder.decode(parts[0], StandardCharsets.UTF_8);
+        final String password = parts.length > 1 ? URLDecoder.decode(parts[1], StandardCharsets.UTF_8) : "";
+        return new ProxyConfiguration(ProxyMode.PROXY, host, port, username, password);
+    }
+
+    private static boolean matchesNoProxyEntry(final String host, final int port, final String entry) {
+        if ("*".equals(entry)) {
+            return true;
+        }
+        final HostAndPort hostAndPort = parseHostAndPort(entry);
+        if (hostAndPort.port() != -1 && hostAndPort.port() != port) {
+            return false;
+        }
+        final String normalizedHost = host.toLowerCase(Locale.ROOT);
+        final String normalizedEntryHost = hostAndPort.host().toLowerCase(Locale.ROOT);
+        if (normalizedEntryHost.startsWith(".")) {
+            final String suffix = normalizedEntryHost.substring(1);
+            return normalizedHost.equals(suffix) || normalizedHost.endsWith(normalizedEntryHost);
+        }
+        return normalizedHost.equals(normalizedEntryHost) || normalizedHost.endsWith("." + normalizedEntryHost);
+    }
+
+    private static HostAndPort parseHostAndPort(final String value) {
+        if (value.startsWith("[") && value.contains("]")) {
+            final int endBracket = value.indexOf(']');
+            final String host = value.substring(1, endBracket);
+            if (endBracket + 1 < value.length() && value.charAt(endBracket + 1) == ':') {
+                return new HostAndPort(host, Integer.parseInt(value.substring(endBracket + 2)));
+            }
+            return new HostAndPort(host, -1);
+        }
+        final int firstColon = value.indexOf(':');
+        final int lastColon = value.lastIndexOf(':');
+        if (firstColon != -1 && firstColon == lastColon) {
+            final String portPart = value.substring(lastColon + 1);
+            if (portPart.chars().allMatch(Character::isDigit)) {
+                return new HostAndPort(value.substring(0, lastColon), Integer.parseInt(portPart));
+            }
+        }
+        return new HostAndPort(value, -1);
+    }
+
+    private static int effectivePort(final URI uri) {
+        return uri.getPort() != -1 ? uri.getPort() : defaultPort(uri.getScheme());
+    }
+
+    private static int defaultPort(final String scheme) {
+        return "https".equalsIgnoreCase(scheme) ? 443 : 80;
+    }
+
+    private static String getEnvironmentValue(final Map<String, String> environment, final String... names) {
+        for (final String name : names) {
+            final String value = environment.get(name);
+            if (value != null && !value.isBlank()) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private record HostAndPort(String host, int port) {
+    }
+}

--- a/src/de.hpi.swa.trufflesqueak.shared/src/de/hpi/swa/trufflesqueak/shared/ImageDownloadSupport.java
+++ b/src/de.hpi.swa.trufflesqueak.shared/src/de/hpi/swa/trufflesqueak/shared/ImageDownloadSupport.java
@@ -33,6 +33,7 @@ public final class ImageDownloadSupport {
 
         @Override
         public void connectFailed(final URI uri, final java.net.SocketAddress sa, final IOException ioe) {
+            // Intentionally ignored because this selector always forces direct connections.
         }
     };
 
@@ -75,6 +76,7 @@ public final class ImageDownloadSupport {
             }
             case DEFAULT -> {
             }
+            default -> throw new IllegalStateException("Unhandled proxy mode: " + proxyConfiguration.mode());
         }
         final HttpRequest request = HttpRequest.newBuilder(uri).GET().build();
         try {

--- a/src/de.hpi.swa.trufflesqueak.shared/src/de/hpi/swa/trufflesqueak/shared/SqueakImageLocator.java
+++ b/src/de.hpi.swa.trufflesqueak.shared/src/de/hpi/swa/trufflesqueak/shared/SqueakImageLocator.java
@@ -99,8 +99,7 @@ public final class SqueakImageLocator {
     }
 
     private static void downloadAndUnzip(final String url, final File destDirectory) {
-        try {
-            final BufferedInputStream bis = new BufferedInputStream(URI.create(url).toURL().openStream());
+        try (BufferedInputStream bis = ImageDownloadSupport.openStream(URI.create(url))) {
             unzip(bis, destDirectory);
         } catch (final IOException e) {
             throw new RuntimeException(e);

--- a/src/de.hpi.swa.trufflesqueak.test/src/de/hpi/swa/trufflesqueak/test/ImageDownloadSupportTest.java
+++ b/src/de.hpi.swa.trufflesqueak.test/src/de/hpi/swa/trufflesqueak/test/ImageDownloadSupportTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 Software Architecture Group, Hasso Plattner Institute
+ * Copyright (c) 2026 Oracle and/or its affiliates
+ *
+ * Licensed under the MIT License.
+ */
+package de.hpi.swa.trufflesqueak.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URI;
+import java.util.Map;
+
+import org.junit.Test;
+
+import de.hpi.swa.trufflesqueak.shared.ImageDownloadSupport;
+
+@SuppressWarnings("static-method")
+public final class ImageDownloadSupportTest {
+    @Test
+    public void testHttpsProxyIsSelectedFromEnvironment() {
+        final ImageDownloadSupport.ProxyConfiguration configuration = ImageDownloadSupport.proxyConfigurationFor(
+                        URI.create("https://github.com/hpi-swa/trufflesqueak/releases/download/25.0.1/TruffleSqueakImage-25.0.1.zip"),
+                        Map.of("https_proxy", "http://proxy.example.com:8443"));
+
+        assertEquals(ImageDownloadSupport.ProxyMode.PROXY, configuration.mode());
+        assertEquals("proxy.example.com", configuration.host());
+        assertEquals(8443, configuration.port());
+    }
+
+    @Test
+    public void testHttpProxyFallsBackForHttps() {
+        final ImageDownloadSupport.ProxyConfiguration configuration = ImageDownloadSupport.proxyConfigurationFor(
+                        URI.create("https://files.squeak.org/6.0/Squeak6.0-22148-64bit/Squeak6.0-22148-64bit.zip"),
+                        Map.of("http_proxy", "proxy.example.com:3128"));
+
+        assertEquals(ImageDownloadSupport.ProxyMode.PROXY, configuration.mode());
+        assertEquals("proxy.example.com", configuration.host());
+        assertEquals(3128, configuration.port());
+    }
+
+    @Test
+    public void testNoProxyBypassesProxyForDomainSuffix() {
+        final ImageDownloadSupport.ProxyConfiguration configuration = ImageDownloadSupport.proxyConfigurationFor(
+                        URI.create("https://github.com/hpi-swa/trufflesqueak/releases/download/25.0.1/TruffleSqueakImage-25.0.1.zip"),
+                        Map.of(
+                                        "https_proxy", "http://proxy.example.com:8443",
+                                        "no_proxy", ".github.com"));
+
+        assertEquals(ImageDownloadSupport.ProxyMode.DIRECT, configuration.mode());
+    }
+
+    @Test
+    public void testNoProxyCanMatchSpecificPort() {
+        assertTrue(ImageDownloadSupport.matchesNoProxy("files.squeak.org", 443, "files.squeak.org:443"));
+    }
+
+    @Test
+    public void testProxyCredentialsAreDecoded() {
+        final ImageDownloadSupport.ProxyConfiguration configuration = ImageDownloadSupport.proxyConfigurationFor(
+                        URI.create("https://example.com/archive.zip"),
+                        Map.of("HTTPS_PROXY", "http://user%40example:pa%3Ass@proxy.example.com:8080"));
+
+        assertEquals(ImageDownloadSupport.ProxyMode.PROXY, configuration.mode());
+        assertEquals("user@example", configuration.username());
+        assertEquals("pa:ss", configuration.password());
+    }
+}

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/io/SqueakDisplay.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/io/SqueakDisplay.java
@@ -102,6 +102,7 @@ import static de.hpi.swa.trufflesqueak.sdl3.bindings.SDL_h.SDL_GetDesktopDisplay
 import static de.hpi.swa.trufflesqueak.sdl3.bindings.SDL_h.SDL_GetPrimaryDisplay;
 import static de.hpi.swa.trufflesqueak.sdl3.bindings.SDL_h.SDL_GetWindowDisplayScale;
 import static de.hpi.swa.trufflesqueak.sdl3.bindings.SDL_h.SDL_HasClipboardText;
+import static de.hpi.swa.trufflesqueak.sdl3.bindings.SDL_h.SDL_HideCursor;
 import static de.hpi.swa.trufflesqueak.sdl3.bindings.SDL_h.SDL_IOFromMem;
 import static de.hpi.swa.trufflesqueak.sdl3.bindings.SDL_h.SDL_LoadPNG_IO;
 import static de.hpi.swa.trufflesqueak.sdl3.bindings.SDL_h.SDL_LockSurface;
@@ -117,6 +118,7 @@ import static de.hpi.swa.trufflesqueak.sdl3.bindings.SDL_h.SDL_SetWindowFullscre
 import static de.hpi.swa.trufflesqueak.sdl3.bindings.SDL_h.SDL_SetWindowIcon;
 import static de.hpi.swa.trufflesqueak.sdl3.bindings.SDL_h.SDL_SetWindowSize;
 import static de.hpi.swa.trufflesqueak.sdl3.bindings.SDL_h.SDL_SetWindowTitle;
+import static de.hpi.swa.trufflesqueak.sdl3.bindings.SDL_h.SDL_ShowCursor;
 import static de.hpi.swa.trufflesqueak.sdl3.bindings.SDL_h.SDL_StartTextInput;
 import static de.hpi.swa.trufflesqueak.sdl3.bindings.SDL_h.SDL_UnlockSurface;
 import static de.hpi.swa.trufflesqueak.sdl3.bindings.SDL_h.SDL_UpdateTexture;
@@ -281,6 +283,11 @@ public final class SqueakDisplay {
             cursor = MemorySegment.NULL;
         }
 
+        if (isBlankMaskedCursor(data)) {
+            checkSdlError(SDL_HideCursor());
+            return;
+        }
+
         final int w = data.width;
         final int h = data.height;
 
@@ -351,6 +358,7 @@ public final class SqueakDisplay {
             cursor = checkSdlError(SDL_CreateColorCursor(surface, data.offsetX, data.offsetY));
             if (cursor != MemorySegment.NULL) {
                 checkSdlError(SDL_SetCursor(cursor));
+                checkSdlError(SDL_ShowCursor());
             }
         } finally {
             SDL_DestroySurface(surface);
@@ -376,6 +384,27 @@ public final class SqueakDisplay {
     public static SqueakDisplay create(final SqueakImageContext image) {
         CompilerAsserts.neverPartOfCompilation();
         return new SqueakDisplay(image);
+    }
+
+    private static boolean isBlankMaskedCursor(final CursorData data) {
+        return data.depth == 1 &&
+                        data.maskWords != null &&
+                        data.width == SqueakIOConstants.CURSOR_WIDTH &&
+                        data.height == SqueakIOConstants.CURSOR_HEIGHT &&
+                        areAllWordsZero(data.cursorWords, data.height) &&
+                        areAllWordsZero(data.maskWords, data.height);
+    }
+
+    private static boolean areAllWordsZero(final int[] words, final int expectedLength) {
+        if (words == null || words.length < expectedLength) {
+            return false;
+        }
+        for (int i = 0; i < expectedLength; i++) {
+            if (words[i] != 0) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private void ensureStagingPixels(final int w, final int h) {

--- a/src/image-tests/runSqueakTests.st
+++ b/src/image-tests/runSqueakTests.st
@@ -179,7 +179,6 @@
         BitBltSimulationTest -> #(#testRgbMulDepth16 #testRgbMulDepth1to8).
         CompilerExceptionsTest -> #(#testUnknownSelector).
         HelpBrowserTest -> #(#testRegistration).
-        MorphicToolBuilderTests -> #(#testGetButtonColor).
         ObjectTest -> #(#testEvaluateWheneverChangeIn #testEvaluateWheneverChangeInTransparent "become EmptyObject->PointersObject not yet supported" #testPinning "not yet supported").
         PackageDependencyTest -> #(#testBalloon #testPreferenceBrowser #testSUnit).
         SequenceableCollectionTest -> #(#testDoWithIndexDeprecation).
@@ -208,6 +207,7 @@
         MCDictionaryRepositoryTest -> #(#testIncludesName #testStoreAndLoad).
         MCSnapshotTest -> #(#testInstanceReuse).
         MethodHighlightingTests -> #(#testMethodHighlighting).
+        MorphicToolBuilderTests -> #(#testGetButtonColor).
         PCCByCompilationTest -> #(#testSwitchPrimCallOffOn).
         PCCByLiteralsTest -> #(#testSwitchPrimCallOffOn).
         SequenceableCollectionTest -> #(#testCollectWithIndexDeprecation).


### PR DESCRIPTION
## Summary
This branch currently contains three commits:

1. `Fix Windows SDL size_t binding`
   - adjusts the SDL3 Java binding so `size_t` is mapped correctly on Windows
   - fixes the generated binding signature in the shared SDL binding code used by TruffleSqueak

2. `Honor proxy env vars for image downloads`
   - adds proxy-aware image download support in the shared image locator/download path
   - wires the image download code to honor proxy environment variables
   - adds test coverage for the new download behavior

3. `Hide blank SDL cursor instead of drawing it`
   - adds `SDL_HideCursor` and `SDL_ShowCursor` to the SDL3 jextract inputs and generated Java bindings
   - detects the special legacy 16x16 masked-cursor case where both cursor bits and mask bits are all zero and hides the host cursor instead of building a transparent ARGB cursor
   - preserves the existing black fallback for the unsupported XOR/invert masked-cursor pixels and shows the host cursor again when a non-blank cursor is installed

## Testing
- rebuilt the JVM standalone with `mx --env jvm build`
- verified locally that the blank drag cursor no longer appears as a black square on Windows