### PR TITLE
prevent access to out of bounds stack slots

### DIFF
--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ContextPrimitives.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ContextPrimitives.java
@@ -149,7 +149,7 @@ public class ContextPrimitives extends AbstractPrimitiveFactoryHolder {
     @GenerateNodeFactory
     @SqueakPrimitive(indices = 210)
     protected abstract static class PrimContextAtNode extends AbstractPrimitiveNode implements Primitive1WithFallback {
-        @Specialization(guards = {"index <= receiver.getStackPointer()"})
+        @Specialization(guards = {"1 <= index", "index <= receiver.getStackPointer()"})
         protected static final Object doContextObject(final ContextObject receiver, final long index,
                         @Bind final Node node,
                         @Cached final ContextObjectReadNode readNode) {
@@ -160,7 +160,7 @@ public class ContextPrimitives extends AbstractPrimitiveFactoryHolder {
     @GenerateNodeFactory
     @SqueakPrimitive(indices = 211)
     protected abstract static class PrimContextAtPutNode extends AbstractPrimitiveNode implements Primitive2WithFallback {
-        @Specialization(guards = "index <= receiver.getStackPointer()")
+        @Specialization(guards = {"1 <= index", "index <= receiver.getStackPointer()"})
         protected static final Object doContextObject(final ContextObject receiver, final long index, final Object value,
                         @Bind final Node node,
                         @Cached final ContextObjectWriteNode writeNode) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ContextPrimitives.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ContextPrimitives.java
@@ -149,7 +149,7 @@ public class ContextPrimitives extends AbstractPrimitiveFactoryHolder {
     @GenerateNodeFactory
     @SqueakPrimitive(indices = 210)
     protected abstract static class PrimContextAtNode extends AbstractPrimitiveNode implements Primitive1WithFallback {
-        @Specialization(guards = {"index <= receiver.size()"})
+        @Specialization(guards = {"index <= receiver.getStackPointer()"})
         protected static final Object doContextObject(final ContextObject receiver, final long index,
                         @Bind final Node node,
                         @Cached final ContextObjectReadNode readNode) {
@@ -160,7 +160,7 @@ public class ContextPrimitives extends AbstractPrimitiveFactoryHolder {
     @GenerateNodeFactory
     @SqueakPrimitive(indices = 211)
     protected abstract static class PrimContextAtPutNode extends AbstractPrimitiveNode implements Primitive2WithFallback {
-        @Specialization(guards = "index <= receiver.size()")
+        @Specialization(guards = "index <= receiver.getStackPointer()")
         protected static final Object doContextObject(final ContextObject receiver, final long index, final Object value,
                         @Bind final Node node,
                         @Cached final ContextObjectWriteNode writeNode) {
@@ -172,6 +172,12 @@ public class ContextPrimitives extends AbstractPrimitiveFactoryHolder {
     @GenerateNodeFactory
     @SqueakPrimitive(indices = 212)
     protected abstract static class PrimContextSizeNode extends AbstractPrimitiveNode implements Primitive0WithFallback {
+        /*
+         * "Note that it is impossible to determine the real object size of a Context except by
+         * asking for the frameSize of its method. Any fields above the stack pointer (stackp) are
+         * truly invisible even (and especially!) to the garbage collector. Any store into stackp
+         * other than by the primitive method stackp: is potentially fatal."
+         */
         @Specialization(guards = "receiver.hasTruffleFrame()")
         protected static final long doSize(final ContextObject receiver) {
             return receiver.getStackPointer();
@@ -179,6 +185,7 @@ public class ContextPrimitives extends AbstractPrimitiveFactoryHolder {
 
         @Specialization(guards = "!receiver.hasTruffleFrame()")
         protected static final long doSizeWithoutFrame(final ContextObject receiver) {
+            // ToDo: Is this correct? From the definition above, it should be zero...
             return receiver.size() - receiver.instsize();
         }
     }


### PR DESCRIPTION
The bounds check on Context stack access is too permissive and can crash the interpreter. From the comments in the Smalltalk source code, it appears that the access primitives should fail if accessing slots above the stack pointer. It should also fail if accessing slots less than 1.

Since we now make smaller stack frames than requested by the CompiledMethod flags, we may need to revisit the primitive that sets the stack pointer to resize the stack frame if the stack pointer is moved algorithmically to a value larger than the deepest stack the method's evaluation would reach.