### PR TITLE
Eliminate nilling when popping stack; nil unreachable stack before GC

### DIFF
--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
@@ -847,12 +847,12 @@ public final class SqueakImageContext {
         return env.getInternalLanguages().containsKey("nfi");
     }
 
-    public InterpreterProxy getInterpreterProxy(final MaterializedFrame frame, final int numReceiverAndArguments) {
+    public InterpreterProxy getInterpreterProxy(final int numReceiverAndArguments, final Object[] receiverAndArguments) {
         if (interpreterProxy == null) {
             CompilerDirectives.transferToInterpreterAndInvalidate();
             interpreterProxy = new InterpreterProxy(this);
         }
-        return interpreterProxy.instanceFor(frame, numReceiverAndArguments);
+        return interpreterProxy.instanceFor(numReceiverAndArguments, receiverAndArguments);
     }
 
     public PointersObject getScheduler() {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
@@ -24,7 +24,6 @@ import com.oracle.truffle.api.TruffleFile;
 import com.oracle.truffle.api.TruffleLanguage.ContextReference;
 import com.oracle.truffle.api.TruffleLanguage.ParsingRequest;
 import com.oracle.truffle.api.dsl.Bind.DefaultExpression;
-import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.library.Message;
@@ -847,12 +846,12 @@ public final class SqueakImageContext {
         return env.getInternalLanguages().containsKey("nfi");
     }
 
-    public InterpreterProxy getInterpreterProxy(final int numReceiverAndArguments, final Object[] receiverAndArguments) {
+    public InterpreterProxy getInterpreterProxy(final Object[] receiverAndArguments) {
         if (interpreterProxy == null) {
             CompilerDirectives.transferToInterpreterAndInvalidate();
             interpreterProxy = new InterpreterProxy(this);
         }
-        return interpreterProxy.instanceFor(numReceiverAndArguments, receiverAndArguments);
+        return interpreterProxy.instanceFor(receiverAndArguments);
     }
 
     public PointersObject getScheduler() {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
@@ -309,6 +309,10 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
         FrameAccess.setInstructionPointer(getTruffleFrame(), NIL_PC_STACK_NOT_NIL_VALUE);
     }
 
+    public int getStackPointerOrZero() {
+        return hasTruffleFrame() ? FrameAccess.getStackPointer(getTruffleFrame()) : 0;
+    }
+
     public int getStackPointer() {
         return FrameAccess.getStackPointer(getTruffleFrame());
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
@@ -37,6 +37,13 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
 
     private static final Class<?> CONCRETE_MATERIALIZED_FRAME_CLASS = Truffle.getRuntime().createMaterializedFrame(new Object[0]).getClass();
 
+    public enum FrameHandling {
+        /** Enumerate live objects in Truffle frames (Read-Only). */
+        SCAN,
+        /** Enumerate live objects and nil dead objects in Truffle frames (Read-Write). */
+        SCRUB
+    }
+
     private Object senderOrFrameOrSize;
 
     public ContextObject(final SqueakImageChunk chunk) {
@@ -399,7 +406,7 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
         FrameAccess.setClosure(frame, value);
         // Cannot use copyTo here as frame descriptors may be different
         // ToDo: This does not handle any stack slots held in auxiliarySlots.
-        FrameAccess.iterateStackSlots(oldFrame, slotIndex -> {
+        FrameAccess.iterateStackSlots(oldFrame, sp, slotIndex -> {
             final Object stackValue = oldFrame.getObjectStatic(slotIndex);
             if (stackValue != null) {
                 frame.setObjectStatic(slotIndex, stackValue);
@@ -415,6 +422,15 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
         FrameAccess.setReceiver(getOrCreateTruffleFrame(), value);
     }
 
+    /**
+     * Accesses a temporary variable or stack value at the given 0-based index.
+     * <p>
+     * If the index falls within the range of the initial arguments/copied values, it is retrieved
+     * from the frame arguments. Otherwise, it is fetched from the actual stack slots.
+     *
+     * @param index the 0-based index of the temporary variable to retrieve.
+     * @return the object at the specified index, or {@link NilObject#SINGLETON} if null.
+     */
     @TruffleBoundary
     public Object atTemp(final int index) {
         final MaterializedFrame frame = getTruffleFrame();
@@ -426,6 +442,16 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
         }
     }
 
+    /**
+     * Sets a temporary variable or stack value at the given 0-based index.
+     * <p>
+     * This method performs a dual-write if the index falls within the range of initial arguments or
+     * copied values. It updates the value in the {@code frame.getArguments()} array and
+     * consistently updates the corresponding indexed stack slot in the Truffle frame.
+     *
+     * @param index the 0-based index of the temporary variable or stack slot to update.
+     * @param value the object to store at the specified index.
+     */
     @TruffleBoundary
     public void atTempPut(final int index, final Object value) {
         final MaterializedFrame frame = getOrCreateTruffleFrame();
@@ -614,7 +640,9 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
             final MaterializedFrame frame = getTruffleFrame();
             tracer.addIfUnmarked(FrameAccess.getCodeObject(frame));
             tracer.addAllIfUnmarked(frame.getArguments());
-            FrameAccess.iterateStackObjects(frame, true, tracer::addIfUnmarked);
+            FrameAccess.iterateStackObjects(frame, tracer.frameHandling, tracer::addIfUnmarked);
+        } else {
+            tracer.addIfUnmarked(senderOrFrameOrSize);
         }
     }
 
@@ -626,7 +654,9 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
             getSender(); /* May materialize sender. */
             writer.traceIfNecessary(FrameAccess.getCodeObject(frame));
             writer.traceAllIfNecessary(frame.getArguments());
-            FrameAccess.iterateStackObjects(frame, true, writer::traceIfNecessary);
+            FrameAccess.iterateStackObjects(frame, FrameHandling.SCRUB, writer::traceIfNecessary);
+        } else if (senderOrFrameOrSize instanceof AbstractSqueakObject o) {
+            writer.traceIfNecessary(o);
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ResumeContextRootNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ResumeContextRootNode.java
@@ -37,8 +37,10 @@ public final class ResumeContextRootNode extends AbstractRootNode {
     @Override
     public Object execute(final VirtualFrame frame) {
         assert !activeContext.isDead() : "Terminated contexts cannot be resumed";
-        // Make it so ObjectGraphUtils can find the active context when executing
-        // strictly within the active context.
+        /*
+         * Make it so ObjectGraphUtils can find the active context when executing strictly within
+         * the active context.
+         */
         FrameAccess.setContext(frame, activeContext);
         activeContext.clearModifiedSender();
         final int pc = instructionPointerProfile.profile(activeContext.getInstructionPointerForBytecodeLoop());

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ResumeContextRootNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ResumeContextRootNode.java
@@ -15,6 +15,7 @@ import com.oracle.truffle.api.profiles.IntValueProfile;
 
 import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
 import de.hpi.swa.trufflesqueak.model.ContextObject;
+import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
 public final class ResumeContextRootNode extends AbstractRootNode {
     private ContextObject activeContext;
@@ -36,6 +37,9 @@ public final class ResumeContextRootNode extends AbstractRootNode {
     @Override
     public Object execute(final VirtualFrame frame) {
         assert !activeContext.isDead() : "Terminated contexts cannot be resumed";
+        // Make it so ObjectGraphUtils can find the active context when executing
+        // strictly within the active context.
+        FrameAccess.setContext(frame, activeContext);
         activeContext.clearModifiedSender();
         final int pc = instructionPointerProfile.profile(activeContext.getInstructionPointerForBytecodeLoop());
         final int sp = stackPointerProfile.profile(activeContext.getStackPointer());

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractInterpreterNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractInterpreterNode.java
@@ -370,7 +370,6 @@ public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrum
     }
 
     protected static final Object pop(final VirtualFrame frame, final int sp) {
-        /* Unreachable stack entries are lazily nilled in FrameAccess.iterateStackObjects */
         final int slotIndex = FrameAccess.getStackStart() + sp;
         return frame.getObjectStatic(slotIndex);
     }
@@ -385,7 +384,6 @@ public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrum
 
     @ExplodeLoop
     private static Object[] popNExploded(final VirtualFrame frame, final int sp, final int numPop) {
-        /* Unreachable stack entries are lazily nilled in FrameAccess.iterateStackObjects */
         final int firstSlotIndex = FrameAccess.getStackStart() + sp - numPop;
         final Object[] stackValues = new Object[numPop];
         for (int i = 0; i < numPop; i++) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractInterpreterNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractInterpreterNode.java
@@ -295,7 +295,7 @@ public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrum
         if (homeContext.canBeReturnedTo()) {
             final ContextObject firstMarkedContext = firstUnwindMarkedOrThrowNLR(FrameAccess.getSender(frame), homeContext, result);
             if (firstMarkedContext != null) {
-                externalizePCAndSP(frame, pc, sp);
+                FrameAccess.externalizePCAndSP(frame, pc, sp);
                 if (data[currentPC] == null) {
                     CompilerDirectives.transferToInterpreterAndInvalidate();
                     data[currentPC] = insert(Dispatch2NodeGen.create(getContext().aboutToReturnSelector));
@@ -303,7 +303,7 @@ public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrum
                 ((Dispatch2NodeGen) data[currentPC]).execute(frame, getOrCreateContext(frame, currentPC), result, firstMarkedContext);
             }
         }
-        throw cannotReturn(frame, result);
+        throw cannotReturn(frame, pc, sp, result);
     }
 
     /**
@@ -336,9 +336,10 @@ public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrum
         return null;
     }
 
-    private static CannotReturnToTarget cannotReturn(final VirtualFrame frame, final Object returnValue) {
+    private static CannotReturnToTarget cannotReturn(final VirtualFrame frame, final int pc, final int sp, final Object returnValue) {
         CompilerDirectives.transferToInterpreter();
         LogUtils.SCHEDULING.info("sendCannotReturn");
+        FrameAccess.externalizePCAndSP(frame, pc, sp);
         throw new CannotReturnToTarget(returnValue, GetOrCreateContextWithFrameNode.executeUncached(frame));
     }
 
@@ -397,21 +398,6 @@ public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrum
         return FrameAccess.getStackValue(frame, sp - 1);
     }
 
-    protected static final void externalizePCAndSP(final VirtualFrame frame, final int pc, final int sp) {
-        FrameAccess.setInstructionPointer(frame, pc);
-        FrameAccess.setStackPointer(frame, sp);
-    }
-
-    protected static final int internalizePC(final VirtualFrame frame, final int pc) {
-        final int framePC = FrameAccess.getInstructionPointer(frame);
-        if (pc != framePC) {
-            CompilerDirectives.transferToInterpreter();
-            return framePC;
-        } else {
-            return pc;
-        }
-    }
-
     protected final Object getErrorObject() {
         final SqueakImageContext image = getContext();
         final int primFailCode = image.getPrimFailCode();
@@ -425,7 +411,7 @@ public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrum
 
     protected final void sendMustBeBooleanInInterpreter(final VirtualFrame frame, final int pc, final int sp, final Object stackValue) {
         CompilerDirectives.transferToInterpreter();
-        externalizePCAndSP(frame, pc, sp);
+        FrameAccess.externalizePCAndSP(frame, pc, sp);
         final SqueakImageContext image = getContext();
         image.mustBeBooleanSelector.executeAsSymbolSlow(image, frame, stackValue);
         throw SqueakException.create("Should not be reached");

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractInterpreterNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractInterpreterNode.java
@@ -37,7 +37,6 @@ import de.hpi.swa.trufflesqueak.model.ArrayObject;
 import de.hpi.swa.trufflesqueak.model.BlockClosureObject;
 import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
 import de.hpi.swa.trufflesqueak.model.ContextObject;
-import de.hpi.swa.trufflesqueak.model.NilObject;
 import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.ASSOCIATION;
 import de.hpi.swa.trufflesqueak.nodes.AbstractNode;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectAt0NodeGen;
@@ -424,9 +423,9 @@ public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrum
         }
     }
 
-    protected final void sendMustBeBooleanInInterpreter(final VirtualFrame frame, final int pc, final Object stackValue) {
+    protected final void sendMustBeBooleanInInterpreter(final VirtualFrame frame, final int pc, final int sp, final Object stackValue) {
         CompilerDirectives.transferToInterpreter();
-        FrameAccess.setInstructionPointer(frame, pc);
+        externalizePCAndSP(frame, pc, sp);
         final SqueakImageContext image = getContext();
         image.mustBeBooleanSelector.executeAsSymbolSlow(image, frame, stackValue);
         throw SqueakException.create("Should not be reached");

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractInterpreterNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractInterpreterNode.java
@@ -370,10 +370,9 @@ public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrum
     }
 
     protected static final Object pop(final VirtualFrame frame, final int sp) {
+        /* Unreachable stack entries are lazily nilled in FrameAccess.iterateStackObjects */
         final int slotIndex = FrameAccess.getStackStart() + sp;
-        final Object result = frame.getObjectStatic(slotIndex);
-        frame.setObjectStatic(slotIndex, NilObject.SINGLETON);
-        return result;
+        return frame.getObjectStatic(slotIndex);
     }
 
     protected static final Object popReceiver(final VirtualFrame frame, final int sp) {
@@ -386,12 +385,11 @@ public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrum
 
     @ExplodeLoop
     private static Object[] popNExploded(final VirtualFrame frame, final int sp, final int numPop) {
+        /* Unreachable stack entries are lazily nilled in FrameAccess.iterateStackObjects */
         final int firstSlotIndex = FrameAccess.getStackStart() + sp - numPop;
         final Object[] stackValues = new Object[numPop];
         for (int i = 0; i < numPop; i++) {
-            final int slotIndex = firstSlotIndex + i;
-            stackValues[i] = frame.getObjectStatic(slotIndex);
-            frame.setObjectStatic(slotIndex, NilObject.SINGLETON);
+            stackValues[i] = frame.getObjectStatic(firstSlotIndex + i);
         }
         return stackValues;
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterSistaV1Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterSistaV1Node.java
@@ -726,7 +726,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                                 pc += calculateShortOffset(b);
                             }
                         } else {
-                            sendMustBeBooleanInInterpreter(frame, pc, stackValue);
+                            sendMustBeBooleanInInterpreter(frame, pc, sp, stackValue);
                         }
                         break;
                     }
@@ -737,7 +737,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                                 pc += calculateShortOffset(b);
                             }
                         } else {
-                            sendMustBeBooleanInInterpreter(frame, pc, stackValue);
+                            sendMustBeBooleanInInterpreter(frame, pc, sp, stackValue);
                         }
                         break;
                     }
@@ -887,7 +887,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                                 pc += offset;
                             }
                         } else {
-                            sendMustBeBooleanInInterpreter(frame, pc, stackValue);
+                            sendMustBeBooleanInInterpreter(frame, pc, sp, stackValue);
                         }
                         extA = extB = 0;
                         break;
@@ -900,7 +900,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                                 pc += offset;
                             }
                         } else {
-                            sendMustBeBooleanInInterpreter(frame, pc, stackValue);
+                            sendMustBeBooleanInInterpreter(frame, pc, sp, stackValue);
                         }
                         extA = extB = 0;
                         break;

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterSistaV1Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterSistaV1Node.java
@@ -714,7 +714,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                                 }
                             }
                             if (data[currentPC] instanceof final CheckForInterruptsInLoopNode checkForInterruptsNode) {
-                                checkForInterruptsNode.execute(frame, pc);
+                                checkForInterruptsNode.execute(frame, pc, sp);
                             }
                         }
                         break;
@@ -873,7 +873,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                                 }
                             }
                             if (data[currentPC] instanceof final CheckForInterruptsInLoopNode checkForInterruptsNode) {
-                                checkForInterruptsNode.execute(frame, pc);
+                                checkForInterruptsNode.execute(frame, pc, sp);
                             }
                         }
                         extA = extB = 0;

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterSistaV1Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterSistaV1Node.java
@@ -446,9 +446,9 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                             result = PrimSmallFloatAddNode.doDouble(lhs, rhs);
                         } else {
                             enter(currentPC, state, BRANCH1);
-                            externalizePCAndSP(frame, pc, sp);
+                            FrameAccess.externalizePCAndSP(frame, pc, sp);
                             result = send(frame, currentPC, receiver, arg);
-                            pc = internalizePC(frame, pc);
+                            pc = FrameAccess.internalizePC(frame, pc);
                         }
                         push(frame, sp++, result);
                         break;
@@ -474,9 +474,9 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                             result = PrimSmallFloatSubtractNode.doDouble(lhs, rhs);
                         } else {
                             enter(currentPC, state, BRANCH1);
-                            externalizePCAndSP(frame, pc, sp);
+                            FrameAccess.externalizePCAndSP(frame, pc, sp);
                             result = send(frame, currentPC, receiver, arg);
-                            pc = internalizePC(frame, pc);
+                            pc = FrameAccess.internalizePC(frame, pc);
                         }
                         push(frame, sp++, result);
                         break;
@@ -494,9 +494,9 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                             result = PrimSmallFloatLessThanNode.doDouble(lhs, rhs);
                         } else {
                             enter(currentPC, state, BRANCH1);
-                            externalizePCAndSP(frame, pc, sp);
+                            FrameAccess.externalizePCAndSP(frame, pc, sp);
                             result = send(frame, currentPC, receiver, arg);
-                            pc = internalizePC(frame, pc);
+                            pc = FrameAccess.internalizePC(frame, pc);
                         }
                         push(frame, sp++, result);
                         break;
@@ -514,9 +514,9 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                             result = PrimSmallFloatGreaterThanNode.doDouble(lhs, rhs);
                         } else {
                             enter(currentPC, state, BRANCH1);
-                            externalizePCAndSP(frame, pc, sp);
+                            FrameAccess.externalizePCAndSP(frame, pc, sp);
                             result = send(frame, currentPC, receiver, arg);
-                            pc = internalizePC(frame, pc);
+                            pc = FrameAccess.internalizePC(frame, pc);
                         }
                         push(frame, sp++, result);
                         break;
@@ -534,9 +534,9 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                             result = PrimSmallFloatLessOrEqualNode.doDouble(lhs, rhs);
                         } else {
                             enter(currentPC, state, BRANCH1);
-                            externalizePCAndSP(frame, pc, sp);
+                            FrameAccess.externalizePCAndSP(frame, pc, sp);
                             result = send(frame, currentPC, receiver, arg);
-                            pc = internalizePC(frame, pc);
+                            pc = FrameAccess.internalizePC(frame, pc);
                         }
                         push(frame, sp++, result);
                         break;
@@ -554,9 +554,9 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                             result = PrimSmallFloatGreaterOrEqualNode.doDouble(lhs, rhs);
                         } else {
                             enter(currentPC, state, BRANCH1);
-                            externalizePCAndSP(frame, pc, sp);
+                            FrameAccess.externalizePCAndSP(frame, pc, sp);
                             result = send(frame, currentPC, receiver, arg);
-                            pc = internalizePC(frame, pc);
+                            pc = FrameAccess.internalizePC(frame, pc);
                         }
                         push(frame, sp++, result);
                         break;
@@ -574,9 +574,9 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                             result = PrimSmallFloatEqualNode.doDouble(lhs, rhs);
                         } else {
                             enter(currentPC, state, BRANCH1);
-                            externalizePCAndSP(frame, pc, sp);
+                            FrameAccess.externalizePCAndSP(frame, pc, sp);
                             result = send(frame, currentPC, receiver, arg);
-                            pc = internalizePC(frame, pc);
+                            pc = FrameAccess.internalizePC(frame, pc);
                         }
                         push(frame, sp++, result);
                         break;
@@ -594,9 +594,9 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                             result = PrimSmallFloatNotEqualNode.doDouble(lhs, rhs);
                         } else {
                             enter(currentPC, state, BRANCH1);
-                            externalizePCAndSP(frame, pc, sp);
+                            FrameAccess.externalizePCAndSP(frame, pc, sp);
                             result = send(frame, currentPC, receiver, arg);
-                            pc = internalizePC(frame, pc);
+                            pc = FrameAccess.internalizePC(frame, pc);
                         }
                         push(frame, sp++, result);
                         break;
@@ -611,9 +611,9 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                             result = PrimBitAndNode.doLong(lhs, rhs);
                         } else {
                             enter(currentPC, state, BRANCH1);
-                            externalizePCAndSP(frame, pc, sp);
+                            FrameAccess.externalizePCAndSP(frame, pc, sp);
                             result = send(frame, currentPC, receiver, arg);
-                            pc = internalizePC(frame, pc);
+                            pc = FrameAccess.internalizePC(frame, pc);
                         }
                         push(frame, sp++, result);
                         break;
@@ -628,9 +628,9 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                             result = PrimBitOrNode.doLong(lhs, rhs);
                         } else {
                             enter(currentPC, state, BRANCH1);
-                            externalizePCAndSP(frame, pc, sp);
+                            FrameAccess.externalizePCAndSP(frame, pc, sp);
                             result = send(frame, currentPC, receiver, arg);
-                            pc = internalizePC(frame, pc);
+                            pc = FrameAccess.internalizePC(frame, pc);
                         }
                         push(frame, sp++, result);
                         break;
@@ -656,9 +656,9 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                         BC.SEND_LIT_SEL0_0, BC.SEND_LIT_SEL0_1, BC.SEND_LIT_SEL0_2, BC.SEND_LIT_SEL0_3, BC.SEND_LIT_SEL0_4, BC.SEND_LIT_SEL0_5, BC.SEND_LIT_SEL0_6, BC.SEND_LIT_SEL0_7, //
                         BC.SEND_LIT_SEL0_8, BC.SEND_LIT_SEL0_9, BC.SEND_LIT_SEL0_A, BC.SEND_LIT_SEL0_B, BC.SEND_LIT_SEL0_C, BC.SEND_LIT_SEL0_D, BC.SEND_LIT_SEL0_E, BC.SEND_LIT_SEL0_F: {
                         final Object receiver = popReceiver(frame, --sp);
-                        externalizePCAndSP(frame, pc, sp);
+                        FrameAccess.externalizePCAndSP(frame, pc, sp);
                         push(frame, sp++, send(frame, currentPC, receiver));
-                        pc = internalizePC(frame, pc);
+                        pc = FrameAccess.internalizePC(frame, pc);
                         break;
                     }
                     case BC.BYTECODE_PRIM_MULTIPLY, BC.BYTECODE_PRIM_DIVIDE, BC.BYTECODE_PRIM_MOD, BC.BYTECODE_PRIM_MAKE_POINT, BC.BYTECODE_PRIM_BIT_SHIFT, //
@@ -667,9 +667,9 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                         BC.SEND_LIT_SEL1_8, BC.SEND_LIT_SEL1_9, BC.SEND_LIT_SEL1_A, BC.SEND_LIT_SEL1_B, BC.SEND_LIT_SEL1_C, BC.SEND_LIT_SEL1_D, BC.SEND_LIT_SEL1_E, BC.SEND_LIT_SEL1_F: {
                         final Object arg = pop(frame, --sp);
                         final Object receiver = popReceiver(frame, --sp);
-                        externalizePCAndSP(frame, pc, sp);
+                        FrameAccess.externalizePCAndSP(frame, pc, sp);
                         push(frame, sp++, send(frame, currentPC, receiver, arg));
-                        pc = internalizePC(frame, pc);
+                        pc = FrameAccess.internalizePC(frame, pc);
                         break;
                     }
                     case BC.BYTECODE_PRIM_AT_PUT, //
@@ -678,9 +678,9 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                         final Object arg2 = pop(frame, --sp);
                         final Object arg1 = pop(frame, --sp);
                         final Object receiver = popReceiver(frame, --sp);
-                        externalizePCAndSP(frame, pc, sp);
+                        FrameAccess.externalizePCAndSP(frame, pc, sp);
                         push(frame, sp++, send(frame, currentPC, receiver, arg1, arg2));
-                        pc = internalizePC(frame, pc);
+                        pc = FrameAccess.internalizePC(frame, pc);
                         break;
                     }
                     case BC.SHORT_UJUMP_0, BC.SHORT_UJUMP_1, BC.SHORT_UJUMP_2, BC.SHORT_UJUMP_3, BC.SHORT_UJUMP_4, BC.SHORT_UJUMP_5, BC.SHORT_UJUMP_6, BC.SHORT_UJUMP_7: {
@@ -813,9 +813,9 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                         final Object[] arguments = popN(frame, sp, numArgs);
                         sp -= numArgs;
                         final Object receiver = popReceiver(frame, --sp);
-                        externalizePCAndSP(frame, pc, sp);
+                        FrameAccess.externalizePCAndSP(frame, pc, sp);
                         push(frame, sp++, sendNary(frame, currentPC, receiver, arguments));
-                        pc = internalizePC(frame, pc);
+                        pc = FrameAccess.internalizePC(frame, pc);
                         extA = extB = 0;
                         break;
                     }
@@ -835,10 +835,10 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                         final Object[] arguments = popN(frame, sp, numArgs);
                         sp -= numArgs;
                         final Object receiver = popReceiver(frame, --sp);
-                        externalizePCAndSP(frame, pc, sp);
+                        FrameAccess.externalizePCAndSP(frame, pc, sp);
                         CompilerAsserts.partialEvaluationConstant(isDirected);
                         pushFollowed(frame, currentPC, sp++, sendSuper(frame, isDirected, currentPC, lookupClass, receiver, arguments));
-                        pc = internalizePC(frame, pc);
+                        pc = FrameAccess.internalizePC(frame, pc);
                         extA = extB = 0;
                         break;
                     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterV3PlusClosuresNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterV3PlusClosuresNode.java
@@ -674,7 +674,7 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                                 }
                             }
                             if (data[currentPC] instanceof final CheckForInterruptsInLoopNode checkForInterruptsNode) {
-                                checkForInterruptsNode.execute(frame, pc);
+                                checkForInterruptsNode.execute(frame, pc, sp);
                             }
                         }
                         break;
@@ -721,7 +721,7 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                                 }
                             }
                             if (data[currentPC] instanceof final CheckForInterruptsInLoopNode checkForInterruptsNode) {
-                                checkForInterruptsNode.execute(frame, pc);
+                                checkForInterruptsNode.execute(frame, pc, sp);
                             }
                         }
                         break;

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterV3PlusClosuresNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterV3PlusClosuresNode.java
@@ -424,7 +424,8 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                         CompilerAsserts.partialEvaluationConstant(variableType);
                         switch (variableType) {
                             case 0: {
-                                FrameAccess.externalizePCAndSP(frame, pc, sp); // for ContextObject access
+                                FrameAccess.externalizePCAndSP(frame, pc, sp); // for ContextObject
+                                                                               // access
                                 pushFollowed(frame, currentPC, sp++, uncheckedCast(data[currentPC], SqueakObjectAt0NodeGen.class).execute(this, FrameAccess.getReceiver(frame), variableIndex));
                                 break;
                             }
@@ -530,7 +531,8 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                                 break;
                             }
                             case 2: {
-                                FrameAccess.externalizePCAndSP(frame, pc, sp); // for ContextObject access
+                                FrameAccess.externalizePCAndSP(frame, pc, sp); // for ContextObject
+                                                                               // access
                                 pushFollowed(frame, currentPC, sp++, uncheckedCast(data[currentPC], SqueakObjectAt0NodeGen.class).execute(this, FrameAccess.getReceiver(frame), byte3));
                                 break;
                             }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterV3PlusClosuresNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterV3PlusClosuresNode.java
@@ -686,7 +686,7 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                                 pc += calculateShortOffset(b);
                             }
                         } else {
-                            sendMustBeBooleanInInterpreter(frame, pc, stackValue);
+                            sendMustBeBooleanInInterpreter(frame, pc, sp, stackValue);
                         }
                         break;
                     }
@@ -734,7 +734,7 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                                 pc += offset;
                             }
                         } else {
-                            sendMustBeBooleanInInterpreter(frame, pc, stackValue);
+                            sendMustBeBooleanInInterpreter(frame, pc, sp, stackValue);
                         }
                         break;
                     }
@@ -746,7 +746,7 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                                 pc += offset;
                             }
                         } else {
-                            sendMustBeBooleanInInterpreter(frame, pc, stackValue);
+                            sendMustBeBooleanInInterpreter(frame, pc, sp, stackValue);
                         }
                         break;
                     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterV3PlusClosuresNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterV3PlusClosuresNode.java
@@ -318,7 +318,7 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                 switch (b) {
                     case BC.PUSH_RCVR_VAR_0, BC.PUSH_RCVR_VAR_1, BC.PUSH_RCVR_VAR_2, BC.PUSH_RCVR_VAR_3, BC.PUSH_RCVR_VAR_4, BC.PUSH_RCVR_VAR_5, BC.PUSH_RCVR_VAR_6, BC.PUSH_RCVR_VAR_7, //
                         BC.PUSH_RCVR_VAR_8, BC.PUSH_RCVR_VAR_9, BC.PUSH_RCVR_VAR_A, BC.PUSH_RCVR_VAR_B, BC.PUSH_RCVR_VAR_C, BC.PUSH_RCVR_VAR_D, BC.PUSH_RCVR_VAR_E, BC.PUSH_RCVR_VAR_F: {
-                        externalizePCAndSP(frame, pc, sp); // for ContextObject access
+                        FrameAccess.externalizePCAndSP(frame, pc, sp); // for ContextObject access
                         pushFollowed(frame, currentPC, sp++, uncheckedCast(data[currentPC], SqueakObjectAt0NodeGen.class).execute(this, FrameAccess.getReceiver(frame), b & 0xF));
                         break;
                     }
@@ -424,7 +424,7 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                         CompilerAsserts.partialEvaluationConstant(variableType);
                         switch (variableType) {
                             case 0: {
-                                externalizePCAndSP(frame, pc, sp); // for ContextObject access
+                                FrameAccess.externalizePCAndSP(frame, pc, sp); // for ContextObject access
                                 pushFollowed(frame, currentPC, sp++, uncheckedCast(data[currentPC], SqueakObjectAt0NodeGen.class).execute(this, FrameAccess.getReceiver(frame), variableIndex));
                                 break;
                             }
@@ -498,9 +498,9 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                         final Object[] arguments = popN(frame, sp, numArgs);
                         sp -= numArgs;
                         final Object receiver = popReceiver(frame, --sp);
-                        externalizePCAndSP(frame, pc, sp);
+                        FrameAccess.externalizePCAndSP(frame, pc, sp);
                         push(frame, sp++, sendNary(frame, currentPC, receiver, arguments));
-                        pc = internalizePC(frame, pc);
+                        pc = FrameAccess.internalizePC(frame, pc);
                         break;
                     }
                     case BC.DOUBLE_EXTENDED_DO_ANYTHING: {
@@ -514,9 +514,9 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                                 final Object[] arguments = popN(frame, sp, numArgs);
                                 sp -= numArgs;
                                 final Object receiver = popReceiver(frame, --sp);
-                                externalizePCAndSP(frame, pc, sp);
+                                FrameAccess.externalizePCAndSP(frame, pc, sp);
                                 push(frame, sp++, sendNary(frame, currentPC, receiver, arguments));
-                                pc = internalizePC(frame, pc);
+                                pc = FrameAccess.internalizePC(frame, pc);
                                 break;
                             }
                             case 1: {
@@ -524,13 +524,13 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                                 final Object[] arguments = popN(frame, sp, numArgs);
                                 sp -= numArgs;
                                 final Object receiver = AbstractSqueakObjectWithClassAndHash.resolveForwardingPointer(popReceiver(frame, --sp));
-                                externalizePCAndSP(frame, pc, sp);
+                                FrameAccess.externalizePCAndSP(frame, pc, sp);
                                 pushFollowed(frame, currentPC, sp++, sendSuper(frame, currentPC, receiver, arguments));
-                                pc = internalizePC(frame, pc);
+                                pc = FrameAccess.internalizePC(frame, pc);
                                 break;
                             }
                             case 2: {
-                                externalizePCAndSP(frame, pc, sp); // for ContextObject access
+                                FrameAccess.externalizePCAndSP(frame, pc, sp); // for ContextObject access
                                 pushFollowed(frame, currentPC, sp++, uncheckedCast(data[currentPC], SqueakObjectAt0NodeGen.class).execute(this, FrameAccess.getReceiver(frame), byte3));
                                 break;
                             }
@@ -565,9 +565,9 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                         final Object[] arguments = popN(frame, sp, numArgs);
                         sp -= numArgs;
                         final Object receiver = AbstractSqueakObjectWithClassAndHash.resolveForwardingPointer(popReceiver(frame, --sp));
-                        externalizePCAndSP(frame, pc, sp);
+                        FrameAccess.externalizePCAndSP(frame, pc, sp);
                         pushFollowed(frame, currentPC, sp++, sendSuper(frame, currentPC, receiver, arguments));
-                        pc = internalizePC(frame, pc);
+                        pc = FrameAccess.internalizePC(frame, pc);
                         break;
                     }
                     case BC.SECOND_EXTENDED_SEND: {
@@ -575,9 +575,9 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                         final Object[] arguments = popN(frame, sp, numArgs);
                         sp -= numArgs;
                         final Object receiver = popReceiver(frame, --sp);
-                        externalizePCAndSP(frame, pc, sp);
+                        FrameAccess.externalizePCAndSP(frame, pc, sp);
                         push(frame, sp++, sendNary(frame, currentPC, receiver, arguments));
-                        pc = internalizePC(frame, pc);
+                        pc = FrameAccess.internalizePC(frame, pc);
                         break;
                     }
                     case BC.POP_STACK: {
@@ -771,9 +771,9 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                             result = PrimSmallFloatAddNode.doDouble(lhs, rhs);
                         } else {
                             enter(currentPC, state, BRANCH1);
-                            externalizePCAndSP(frame, pc, sp);
+                            FrameAccess.externalizePCAndSP(frame, pc, sp);
                             result = send(frame, currentPC, receiver, arg);
-                            pc = internalizePC(frame, pc);
+                            pc = FrameAccess.internalizePC(frame, pc);
                         }
                         push(frame, sp++, result);
                         break;
@@ -799,9 +799,9 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                             result = PrimSmallFloatSubtractNode.doDouble(lhs, rhs);
                         } else {
                             enter(currentPC, state, BRANCH1);
-                            externalizePCAndSP(frame, pc, sp);
+                            FrameAccess.externalizePCAndSP(frame, pc, sp);
                             result = send(frame, currentPC, receiver, arg);
-                            pc = internalizePC(frame, pc);
+                            pc = FrameAccess.internalizePC(frame, pc);
                         }
                         push(frame, sp++, result);
                         break;
@@ -819,9 +819,9 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                             result = PrimSmallFloatLessThanNode.doDouble(lhs, rhs);
                         } else {
                             enter(currentPC, state, BRANCH1);
-                            externalizePCAndSP(frame, pc, sp);
+                            FrameAccess.externalizePCAndSP(frame, pc, sp);
                             result = send(frame, currentPC, receiver, arg);
-                            pc = internalizePC(frame, pc);
+                            pc = FrameAccess.internalizePC(frame, pc);
                         }
                         push(frame, sp++, result);
                         break;
@@ -839,9 +839,9 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                             result = PrimSmallFloatGreaterThanNode.doDouble(lhs, rhs);
                         } else {
                             enter(currentPC, state, BRANCH1);
-                            externalizePCAndSP(frame, pc, sp);
+                            FrameAccess.externalizePCAndSP(frame, pc, sp);
                             result = send(frame, currentPC, receiver, arg);
-                            pc = internalizePC(frame, pc);
+                            pc = FrameAccess.internalizePC(frame, pc);
                         }
                         push(frame, sp++, result);
                         break;
@@ -859,9 +859,9 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                             result = PrimSmallFloatLessOrEqualNode.doDouble(lhs, rhs);
                         } else {
                             enter(currentPC, state, BRANCH1);
-                            externalizePCAndSP(frame, pc, sp);
+                            FrameAccess.externalizePCAndSP(frame, pc, sp);
                             result = send(frame, currentPC, receiver, arg);
-                            pc = internalizePC(frame, pc);
+                            pc = FrameAccess.internalizePC(frame, pc);
                         }
                         push(frame, sp++, result);
                         break;
@@ -879,9 +879,9 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                             result = PrimSmallFloatGreaterOrEqualNode.doDouble(lhs, rhs);
                         } else {
                             enter(currentPC, state, BRANCH1);
-                            externalizePCAndSP(frame, pc, sp);
+                            FrameAccess.externalizePCAndSP(frame, pc, sp);
                             result = send(frame, currentPC, receiver, arg);
-                            pc = internalizePC(frame, pc);
+                            pc = FrameAccess.internalizePC(frame, pc);
                         }
                         push(frame, sp++, result);
                         break;
@@ -899,9 +899,9 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                             result = PrimSmallFloatEqualNode.doDouble(lhs, rhs);
                         } else {
                             enter(currentPC, state, BRANCH1);
-                            externalizePCAndSP(frame, pc, sp);
+                            FrameAccess.externalizePCAndSP(frame, pc, sp);
                             result = send(frame, currentPC, receiver, arg);
-                            pc = internalizePC(frame, pc);
+                            pc = FrameAccess.internalizePC(frame, pc);
                         }
                         push(frame, sp++, result);
                         break;
@@ -919,9 +919,9 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                             result = PrimSmallFloatNotEqualNode.doDouble(lhs, rhs);
                         } else {
                             enter(currentPC, state, BRANCH1);
-                            externalizePCAndSP(frame, pc, sp);
+                            FrameAccess.externalizePCAndSP(frame, pc, sp);
                             result = send(frame, currentPC, receiver, arg);
-                            pc = internalizePC(frame, pc);
+                            pc = FrameAccess.internalizePC(frame, pc);
                         }
                         push(frame, sp++, result);
                         break;
@@ -936,9 +936,9 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                             result = PrimBitAndNode.doLong(lhs, rhs);
                         } else {
                             enter(currentPC, state, BRANCH1);
-                            externalizePCAndSP(frame, pc, sp);
+                            FrameAccess.externalizePCAndSP(frame, pc, sp);
                             result = send(frame, currentPC, receiver, arg);
-                            pc = internalizePC(frame, pc);
+                            pc = FrameAccess.internalizePC(frame, pc);
                         }
                         push(frame, sp++, result);
                         break;
@@ -953,9 +953,9 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                             result = PrimBitOrNode.doLong(lhs, rhs);
                         } else {
                             enter(currentPC, state, BRANCH1);
-                            externalizePCAndSP(frame, pc, sp);
+                            FrameAccess.externalizePCAndSP(frame, pc, sp);
                             result = send(frame, currentPC, receiver, arg);
-                            pc = internalizePC(frame, pc);
+                            pc = FrameAccess.internalizePC(frame, pc);
                         }
                         push(frame, sp++, result);
                         break;
@@ -981,9 +981,9 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                         BC.SEND_LIT_SEL0_0, BC.SEND_LIT_SEL0_1, BC.SEND_LIT_SEL0_2, BC.SEND_LIT_SEL0_3, BC.SEND_LIT_SEL0_4, BC.SEND_LIT_SEL0_5, BC.SEND_LIT_SEL0_6, BC.SEND_LIT_SEL0_7, //
                         BC.SEND_LIT_SEL0_8, BC.SEND_LIT_SEL0_9, BC.SEND_LIT_SEL0_A, BC.SEND_LIT_SEL0_B, BC.SEND_LIT_SEL0_C, BC.SEND_LIT_SEL0_D, BC.SEND_LIT_SEL0_E, BC.SEND_LIT_SEL0_F: {
                         final Object receiver = popReceiver(frame, --sp);
-                        externalizePCAndSP(frame, pc, sp);
+                        FrameAccess.externalizePCAndSP(frame, pc, sp);
                         push(frame, sp++, send(frame, currentPC, receiver));
-                        pc = internalizePC(frame, pc);
+                        pc = FrameAccess.internalizePC(frame, pc);
                         break;
                     }
                     case BC.BYTECODE_PRIM_MULTIPLY, BC.BYTECODE_PRIM_DIVIDE, BC.BYTECODE_PRIM_MOD, BC.BYTECODE_PRIM_MAKE_POINT, BC.BYTECODE_PRIM_BIT_SHIFT, //
@@ -992,9 +992,9 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                         BC.SEND_LIT_SEL1_8, BC.SEND_LIT_SEL1_9, BC.SEND_LIT_SEL1_A, BC.SEND_LIT_SEL1_B, BC.SEND_LIT_SEL1_C, BC.SEND_LIT_SEL1_D, BC.SEND_LIT_SEL1_E, BC.SEND_LIT_SEL1_F: {
                         final Object arg = pop(frame, --sp);
                         final Object receiver = popReceiver(frame, --sp);
-                        externalizePCAndSP(frame, pc, sp);
+                        FrameAccess.externalizePCAndSP(frame, pc, sp);
                         push(frame, sp++, send(frame, currentPC, receiver, arg));
-                        pc = internalizePC(frame, pc);
+                        pc = FrameAccess.internalizePC(frame, pc);
                         break;
                     }
                     case BC.BYTECODE_PRIM_AT_PUT, //
@@ -1003,9 +1003,9 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                         final Object arg2 = pop(frame, --sp);
                         final Object arg1 = pop(frame, --sp);
                         final Object receiver = popReceiver(frame, --sp);
-                        externalizePCAndSP(frame, pc, sp);
+                        FrameAccess.externalizePCAndSP(frame, pc, sp);
                         push(frame, sp++, send(frame, currentPC, receiver, arg1, arg2));
-                        pc = internalizePC(frame, pc);
+                        pc = FrameAccess.internalizePC(frame, pc);
                         break;
                     }
                     default: {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interrupts/CheckForInterruptsInLoopNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interrupts/CheckForInterruptsInLoopNode.java
@@ -47,7 +47,7 @@ public final class CheckForInterruptsInLoopNode extends AbstractNode {
         return SINGLETON;
     }
 
-    public void execute(final VirtualFrame frame, final int pc) {
+    public void execute(final VirtualFrame frame, final int pc, final int sp) {
         final SqueakImageContext image = getContext();
         final CheckForInterruptsState istate = image.interrupt;
         if (istate.shouldSkip()) {
@@ -56,6 +56,7 @@ public final class CheckForInterruptsInLoopNode extends AbstractNode {
         /* Exclude interrupts case from compilation. */
         CompilerDirectives.transferToInterpreter();
         FrameAccess.setInstructionPointer(frame, pc);
+        FrameAccess.setStackPointer(frame, sp);
         final Object[] specialObjects = image.specialObjectsArray.getObjectStorage();
         boolean switchToNewProcess = false;
         if (istate.tryInterruptPending()) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interrupts/CheckForInterruptsInLoopNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interrupts/CheckForInterruptsInLoopNode.java
@@ -55,8 +55,7 @@ public final class CheckForInterruptsInLoopNode extends AbstractNode {
         }
         /* Exclude interrupts case from compilation. */
         CompilerDirectives.transferToInterpreter();
-        FrameAccess.setInstructionPointer(frame, pc);
-        FrameAccess.setStackPointer(frame, sp);
+        FrameAccess.externalizePCAndSP(frame, pc, sp);
         final Object[] specialObjects = image.specialObjectsArray.getObjectStorage();
         boolean switchToNewProcess = false;
         if (istate.tryInterruptPending()) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/ffi/InterpreterProxy.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/ffi/InterpreterProxy.java
@@ -12,7 +12,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import com.oracle.truffle.api.CompilerDirectives;
-import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.interop.ArityException;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.UnknownIdentifierException;
@@ -38,7 +37,6 @@ import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectNewNode;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectSizeNode;
 import de.hpi.swa.trufflesqueak.nodes.plugins.LargeIntegers;
 import de.hpi.swa.trufflesqueak.nodes.plugins.ffi.wrappers.NativeObjectStorage;
-import de.hpi.swa.trufflesqueak.util.FrameAccess;
 import de.hpi.swa.trufflesqueak.util.LogUtils;
 import de.hpi.swa.trufflesqueak.util.MiscUtils;
 import de.hpi.swa.trufflesqueak.util.NFIUtils;
@@ -177,10 +175,10 @@ public final class InterpreterProxy {
         };
     }
 
-    public InterpreterProxy instanceFor(final int currentNumReceiverAndArguments, final Object[] currentReceiverAndArguments) {
-        this.numReceiverAndArguments = currentNumReceiverAndArguments;
-        this.receiverAndArguments = currentReceiverAndArguments == null ? null : currentReceiverAndArguments.clone();
-        this.sp = currentNumReceiverAndArguments;
+    public InterpreterProxy instanceFor(final Object[] currentReceiverAndArguments) {
+        this.numReceiverAndArguments = currentReceiverAndArguments.length;
+        this.receiverAndArguments = currentReceiverAndArguments.clone();
+        this.sp = this.numReceiverAndArguments;
         return this;
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/ffi/InterpreterProxy.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/ffi/InterpreterProxy.java
@@ -50,8 +50,9 @@ public final class InterpreterProxy {
     private static final int BaseHeaderSize = 8;
 
     private final SqueakImageContext context;
-    private MaterializedFrame frame;
     private int numReceiverAndArguments;
+    private Object[] receiverAndArguments;
+    private int sp;
     private final ArrayList<NativeObjectStorage> postPrimitiveCleanups = new ArrayList<>();
     /*
      * should not be local, as the references are needed to keep the native closures alive since
@@ -176,10 +177,15 @@ public final class InterpreterProxy {
         };
     }
 
-    public InterpreterProxy instanceFor(final MaterializedFrame currentFrame, final int currentNumReceiverAndArguments) {
-        this.frame = currentFrame;
+    public InterpreterProxy instanceFor(final int currentNumReceiverAndArguments, final Object[] currentReceiverAndArguments) {
         this.numReceiverAndArguments = currentNumReceiverAndArguments;
+        this.receiverAndArguments = currentReceiverAndArguments == null ? null : currentReceiverAndArguments.clone();
+        this.sp = currentNumReceiverAndArguments;
         return this;
+    }
+
+    public Object getReturnValue() {
+        return receiverAndArguments[0];
     }
 
     /* MISCELLANEOUS */
@@ -220,20 +226,10 @@ public final class InterpreterProxy {
 
     /* STACK HELPERS */
 
-    private int getStackPointer() {
-        return FrameAccess.getStackPointer(frame);
-    }
-
-    private void setStackPointer(final int stackPointer) {
-        FrameAccess.setStackPointer(frame, stackPointer);
-    }
-
     private void pushObject(final Object object) {
-        final int stackPointer = getStackPointer();
-        setStackPointer(stackPointer + 1);
         // push to the original stack pointer, as it always points to the slot where the next object
         // is pushed
-        FrameAccess.setStackValue(frame, stackPointer, object);
+        receiverAndArguments[sp++] = object;
     }
 
     private Object getObjectOnStack(final long reverseStackIndex) {
@@ -243,21 +239,20 @@ public final class InterpreterProxy {
         }
         // the stack pointer is the index of the object that is pushed onto the stack next,
         // so we subtract 1 to get the index of the object that was last pushed onto the stack
-        final int stackIndex = getStackPointer() - 1 - (int) reverseStackIndex;
+        final int stackIndex = sp - 1 - (int) reverseStackIndex;
         if (stackIndex < 0) {
             primitiveFail();
             return null;
         }
-        final Object value = FrameAccess.getStackValue(frame, stackIndex);
+        final Object value = receiverAndArguments[stackIndex];
         assert value != null;
         return value;
     }
 
     private long methodReturnObject(final Object object) {
         assert hasSucceeded();
-        final int stackPointer = getStackPointer() - numReceiverAndArguments;
-        setStackPointer(stackPointer + 1);
-        FrameAccess.setStackValue(frame, stackPointer, object);
+        sp = 0;
+        receiverAndArguments[0] = object;
         return returnVoid();
     }
 
@@ -637,7 +632,10 @@ public final class InterpreterProxy {
     }
 
     private long pop(final long nItems) {
-        setStackPointer(getStackPointer() - (int) nItems);
+        if (sp < (int) nItems) {
+            return primitiveFail();
+        }
+        sp -= (int) nItems;
         return returnVoid();
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/ffi/PrimExternalCallNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/ffi/PrimExternalCallNode.java
@@ -175,6 +175,7 @@ public final class PrimExternalCallNode extends AbstractPrimitiveNode
 
     @TruffleBoundary
     private Object doExternalCall(final Object[] receiverAndArguments) {
+        assert receiverAndArguments.length == numReceiverAndArguments;
         /* InterpreterProxy uses receiverAndArguments as the stack. */
         final InterpreterProxy interpreterProxy = getContext().getInterpreterProxy(receiverAndArguments);
         try {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/ffi/PrimExternalCallNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/ffi/PrimExternalCallNode.java
@@ -33,6 +33,8 @@ import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive8;
 import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive9;
 import de.hpi.swa.trufflesqueak.util.NFIUtils;
 
+import static de.hpi.swa.trufflesqueak.util.ArrayUtils.EMPTY_ARRAY;
+
 public final class PrimExternalCallNode extends AbstractPrimitiveNode
                 implements Primitive0, Primitive1, Primitive2, Primitive3, Primitive4, Primitive5, Primitive6, Primitive7, Primitive8, Primitive9, Primitive10, Primitive11 {
     private final Object functionSymbol;
@@ -43,11 +45,6 @@ public final class PrimExternalCallNode extends AbstractPrimitiveNode
         this.functionSymbol = functionSymbol;
         this.functionInteropLibrary = functionInteropLibrary;
         this.numReceiverAndArguments = numReceiverAndArguments;
-    }
-
-    @Override
-    public boolean needsFrame() {
-        return false;
     }
 
     public static PrimExternalCallNode load(final String moduleName, final String functionName, final int numReceiverAndArguments) {
@@ -96,7 +93,7 @@ public final class PrimExternalCallNode extends AbstractPrimitiveNode
             }
             try {
                 final InteropLibrary moduleInteropLibrary = NFIUtils.getInteropLibrary(library);
-                moduleInteropLibrary.invokeMember(library, "setInterpreter", context.getInterpreterProxy(0, null).getPointer());
+                moduleInteropLibrary.invokeMember(library, "setInterpreter", context.getInterpreterProxy(EMPTY_ARRAY).getPointer());
             } catch (UnsupportedMessageException | ArityException | UnsupportedTypeException | UnknownIdentifierException e) {
                 throw CompilerDirectives.shouldNotReachHere(e);
             }
@@ -179,7 +176,7 @@ public final class PrimExternalCallNode extends AbstractPrimitiveNode
     @TruffleBoundary
     private Object doExternalCall(final Object[] receiverAndArguments) {
         /* InterpreterProxy uses receiverAndArguments as the stack. */
-        final InterpreterProxy interpreterProxy = getContext().getInterpreterProxy(numReceiverAndArguments, receiverAndArguments);
+        final InterpreterProxy interpreterProxy = getContext().getInterpreterProxy(receiverAndArguments);
         try {
             /*
              * return value is unused, the actual return value is pushed onto the stack (see below)

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/ffi/PrimExternalCallNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/ffi/PrimExternalCallNode.java
@@ -9,7 +9,6 @@ package de.hpi.swa.trufflesqueak.nodes.plugins.ffi;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.exception.AbstractTruffleException;
-import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.interop.ArityException;
 import com.oracle.truffle.api.interop.InteropLibrary;
@@ -32,7 +31,6 @@ import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive6;
 import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive7;
 import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive8;
 import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive9;
-import de.hpi.swa.trufflesqueak.util.FrameAccess;
 import de.hpi.swa.trufflesqueak.util.NFIUtils;
 
 public final class PrimExternalCallNode extends AbstractPrimitiveNode
@@ -49,7 +47,7 @@ public final class PrimExternalCallNode extends AbstractPrimitiveNode
 
     @Override
     public boolean needsFrame() {
-        return true;
+        return false;
     }
 
     public static PrimExternalCallNode load(final String moduleName, final String functionName, final int numReceiverAndArguments) {
@@ -98,7 +96,7 @@ public final class PrimExternalCallNode extends AbstractPrimitiveNode
             }
             try {
                 final InteropLibrary moduleInteropLibrary = NFIUtils.getInteropLibrary(library);
-                moduleInteropLibrary.invokeMember(library, "setInterpreter", context.getInterpreterProxy(null, 0).getPointer());
+                moduleInteropLibrary.invokeMember(library, "setInterpreter", context.getInterpreterProxy(0, null).getPointer());
             } catch (UnsupportedMessageException | ArityException | UnsupportedTypeException | UnknownIdentifierException e) {
                 throw CompilerDirectives.shouldNotReachHere(e);
             }
@@ -111,77 +109,77 @@ public final class PrimExternalCallNode extends AbstractPrimitiveNode
 
     @Override
     public Object execute(final VirtualFrame frame, final Object receiver) {
-        return call(frame, receiver);
+        return call(receiver);
     }
 
     @Override
     public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1) {
-        return call(frame, receiver, arg1);
+        return call(receiver, arg1);
     }
 
     @Override
     public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2) {
-        return call(frame, receiver, arg1, arg2);
+        return call(receiver, arg1, arg2);
     }
 
     @Override
     public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3) {
-        return call(frame, receiver, arg1, arg2, arg3);
+        return call(receiver, arg1, arg2, arg3);
     }
 
     @Override
     public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4) {
-        return call(frame, receiver, arg1, arg2, arg3, arg4);
+        return call(receiver, arg1, arg2, arg3, arg4);
     }
 
     @Override
     public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5) {
-        return call(frame, receiver, arg1, arg2, arg3, arg4, arg5);
+        return call(receiver, arg1, arg2, arg3, arg4, arg5);
     }
 
     @Override
     public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5, final Object arg6) {
-        return call(frame, receiver, arg1, arg2, arg3, arg4, arg5, arg6);
+        return call(receiver, arg1, arg2, arg3, arg4, arg5, arg6);
     }
 
     @Override
     public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5, final Object arg6,
                     final Object arg7) {
-        return call(frame, receiver, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+        return call(receiver, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
     }
 
     @Override
     public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5, final Object arg6,
                     final Object arg7, final Object arg8) {
-        return call(frame, receiver, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+        return call(receiver, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
     }
 
     @Override
     public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5, final Object arg6,
                     final Object arg7, final Object arg8, final Object arg9) {
-        return call(frame, receiver, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
+        return call(receiver, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
     }
 
     @Override
     public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5, final Object arg6,
                     final Object arg7, final Object arg8, final Object arg9, final Object arg10) {
-        return call(frame, receiver, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
+        return call(receiver, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
     }
 
     @Override
     public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5, final Object arg6,
                     final Object arg7, final Object arg8, final Object arg9, final Object arg10, final Object arg11) {
-        return call(frame, receiver, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
+        return call(receiver, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
     }
 
-    private Object call(final VirtualFrame frame, final Object... receiverAndArguments) {
-        return doExternalCall(frame.materialize(), receiverAndArguments);
+    private Object call(final Object... receiverAndArguments) {
+        return doExternalCall(receiverAndArguments);
     }
 
     @TruffleBoundary
-    private Object doExternalCall(final MaterializedFrame frame, final Object[] receiverAndArguments) {
-        restoreStackValues(frame, receiverAndArguments);
-        final InterpreterProxy interpreterProxy = getContext().getInterpreterProxy(frame, numReceiverAndArguments);
+    private Object doExternalCall(final Object[] receiverAndArguments) {
+        /* InterpreterProxy uses receiverAndArguments as the stack. */
+        final InterpreterProxy interpreterProxy = getContext().getInterpreterProxy(numReceiverAndArguments, receiverAndArguments);
         try {
             /*
              * return value is unused, the actual return value is pushed onto the stack (see below)
@@ -190,11 +188,9 @@ public final class PrimExternalCallNode extends AbstractPrimitiveNode
             /*
              * The return value is pushed onto the stack by the plugin via the InterpreterProxy, but
              * TruffleSqueak expects the return value to be returned by this function
-             * (AbstractSendNode.executeVoid). Pop the return value and return it.
+             * (AbstractSendNode.executeVoid). Fetch the return value and return it.
              */
-            final int stackPointer = FrameAccess.getStackPointer(frame) - 1;
-            final Object returnValue = FrameAccess.getStackValue(frame, stackPointer);
-            FrameAccess.setStackPointer(frame, stackPointer);
+            final Object returnValue = interpreterProxy.getReturnValue();
             final long failReason = interpreterProxy.failed();
             if (failReason == 0) {
                 return returnValue;
@@ -206,31 +202,5 @@ public final class PrimExternalCallNode extends AbstractPrimitiveNode
         } finally {
             interpreterProxy.postPrimitiveCleanups();
         }
-    }
-
-    private void restoreStackValues(final MaterializedFrame frame, final Object[] receiverAndArguments) {
-        /*
-         * A message send (AbstractSendNode.executeVoid) will pop and potentially clear stack
-         * values, and decrement the stack pointer by numReceiverAndArguments before transferring
-         * control. We need the values back on the stack and the stack pointer to point at the last
-         * argument, since the C code expects that. Therefore, we restore the stack values and
-         * pointer here.
-         */
-        assert numReceiverAndArguments == receiverAndArguments.length;
-        final int initialSP;
-        if (!FrameAccess.hasClosure(frame)) {
-            initialSP = FrameAccess.getCodeObject(frame).getNumTemps();
-        } else {
-            initialSP = FrameAccess.getClosure(frame).getInitialSP();
-        }
-        final int stackPointer = FrameAccess.getStackPointer(frame);
-        for (int i = 0; i < numReceiverAndArguments; i++) {
-            final int stackIndex = stackPointer + i;
-            /* Only values stored above initialSP are cleared */
-            if (stackIndex >= initialSP) {
-                FrameAccess.setStackValue(frame, stackIndex, receiverAndArguments[i]);
-            }
-        }
-        FrameAccess.setStackPointer(frame, stackPointer + numReceiverAndArguments);
     }
 }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ContextPrimitives.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ContextPrimitives.java
@@ -35,13 +35,20 @@ public class ContextPrimitives extends AbstractPrimitiveFactoryHolder {
     @GenerateNodeFactory
     @SqueakPrimitive(indices = 76)
     protected abstract static class PrimStoreStackPointerNode extends AbstractPrimitiveNode implements Primitive1WithFallback {
-        @Specialization(guards = {"0 <= newStackPointer", "newStackPointer <= receiver.size()"})
-        protected static final ContextObject store(final ContextObject receiver, final long newStackPointer) {
-            /*
-             * Not need to "nil any newly accessible cells" as cells are always nil-initialized and
-             * their values are cleared (overwritten with nil) on stack pop.
-             */
-            receiver.setStackPointer((int) newStackPointer);
+        @Specialization(guards = {"0 <= newStackPointerLong", "newStackPointerLong <= receiver.size()"})
+        protected static final ContextObject store(final ContextObject receiver, final long newStackPointerLong) {
+            final int oldStackPointer = receiver.getStackPointer();
+            final int newStackPointer = (int) newStackPointerLong;
+
+            /* Nil any newly accessible or newly hidden stack slots */
+            final int start = Math.min(oldStackPointer, newStackPointer);
+            final int end = Math.max(oldStackPointer, newStackPointer);
+
+            for (int i = start; i < end; i++) {
+                receiver.atTempPut(i, NilObject.SINGLETON);
+            }
+
+            receiver.setStackPointer(newStackPointer);
             return receiver;
         }
     }
@@ -149,7 +156,7 @@ public class ContextPrimitives extends AbstractPrimitiveFactoryHolder {
     @GenerateNodeFactory
     @SqueakPrimitive(indices = 210)
     protected abstract static class PrimContextAtNode extends AbstractPrimitiveNode implements Primitive1WithFallback {
-        @Specialization(guards = {"index <= receiver.size()"})
+        @Specialization(guards = {"1 <= index", "index <= receiver.getStackPointer()"})
         protected static final Object doContextObject(final ContextObject receiver, final long index,
                         @Bind final Node node,
                         @Cached final ContextObjectReadNode readNode) {
@@ -160,7 +167,7 @@ public class ContextPrimitives extends AbstractPrimitiveFactoryHolder {
     @GenerateNodeFactory
     @SqueakPrimitive(indices = 211)
     protected abstract static class PrimContextAtPutNode extends AbstractPrimitiveNode implements Primitive2WithFallback {
-        @Specialization(guards = "index <= receiver.size()")
+        @Specialization(guards = {"1 <= index", "index <= receiver.getStackPointer()"})
         protected static final Object doContextObject(final ContextObject receiver, final long index, final Object value,
                         @Bind final Node node,
                         @Cached final ContextObjectWriteNode writeNode) {
@@ -172,6 +179,12 @@ public class ContextPrimitives extends AbstractPrimitiveFactoryHolder {
     @GenerateNodeFactory
     @SqueakPrimitive(indices = 212)
     protected abstract static class PrimContextSizeNode extends AbstractPrimitiveNode implements Primitive0WithFallback {
+        /*
+         * "Note that it is impossible to determine the real object size of a Context except by
+         * asking for the frameSize of its method. Any fields above the stack pointer (stackp) are
+         * truly invisible even (and especially!) to the garbage collector. Any store into stackp
+         * other than by the primitive method stackp: is potentially fatal."
+         */
         @Specialization(guards = "receiver.hasTruffleFrame()")
         protected static final long doSize(final ContextObject receiver) {
             return receiver.getStackPointer();
@@ -179,6 +192,7 @@ public class ContextPrimitives extends AbstractPrimitiveFactoryHolder {
 
         @Specialization(guards = "!receiver.hasTruffleFrame()")
         protected static final long doSizeWithoutFrame(final ContextObject receiver) {
+            // ToDo: Is this correct? From the definition above, it should be zero...
             return receiver.size() - receiver.instsize();
         }
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ContextPrimitives.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ContextPrimitives.java
@@ -40,11 +40,7 @@ public class ContextPrimitives extends AbstractPrimitiveFactoryHolder {
             final int oldStackPointer = receiver.getStackPointerOrZero();
             final int newStackPointer = (int) newStackPointerLong;
 
-            /* Nil any newly accessible or newly hidden stack slots */
-            final int start = Math.min(oldStackPointer, newStackPointer);
-            final int end = Math.max(oldStackPointer, newStackPointer);
-
-            for (int i = start; i < end; i++) {
+            for (int i = oldStackPointer; i < newStackPointer; i++) {
                 receiver.atTempPut(i, NilObject.SINGLETON);
             }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ContextPrimitives.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ContextPrimitives.java
@@ -37,7 +37,7 @@ public class ContextPrimitives extends AbstractPrimitiveFactoryHolder {
     protected abstract static class PrimStoreStackPointerNode extends AbstractPrimitiveNode implements Primitive1WithFallback {
         @Specialization(guards = {"0 <= newStackPointerLong", "newStackPointerLong <= receiver.size()"})
         protected static final ContextObject store(final ContextObject receiver, final long newStackPointerLong) {
-            final int oldStackPointer = receiver.getStackPointer();
+            final int oldStackPointer = receiver.getStackPointerOrZero();
             final int newStackPointer = (int) newStackPointerLong;
 
             /* Nil any newly accessible or newly hidden stack slots */
@@ -191,9 +191,8 @@ public class ContextPrimitives extends AbstractPrimitiveFactoryHolder {
         }
 
         @Specialization(guards = "!receiver.hasTruffleFrame()")
-        protected static final long doSizeWithoutFrame(final ContextObject receiver) {
-            // ToDo: Is this correct? From the definition above, it should be zero...
-            return receiver.size() - receiver.instsize();
+        protected static final long doSizeWithoutFrame(@SuppressWarnings("unused") final ContextObject receiver) {
+            return 0;
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ControlPrimitives.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ControlPrimitives.java
@@ -305,9 +305,9 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
         @Specialization(guards = "isSemaphore(receiver)")
         protected static final Object doSignal(final VirtualFrame frame, final PointersObject receiver,
                         @Cached final SignalSemaphoreNode signalSemaphoreNode,
-                        @Cached("getIncrementedStackPointer(frame)") final int stackPointer) {
+                        @Cached final PushToStackNode pushNode) {
             if (signalSemaphoreNode.executeSignal(frame, receiver)) {
-                FrameAccess.setStackPointer(frame, stackPointer);
+                pushNode.execute(frame, receiver);
                 throw ProcessSwitch.SINGLETON;
             } else {
                 return receiver;
@@ -327,7 +327,7 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
                         @Cached final AddLastLinkToListNode addLastLinkToListNode,
                         @Cached final WakeHighestPriorityNode wakeHighestPriorityNode,
                         @Cached final GetActiveProcessNode getActiveProcessNode,
-                        @Cached("getIncrementedStackPointer(frame)") final int stackPointer) {
+                        @Cached final PushToStackNode pushNode) {
             assert isSemaphore(receiver);
             final long excessSignals = pointersReadNode.executeLong(receiver, SEMAPHORE.EXCESS_SIGNALS);
             if (excessSignals > 0) {
@@ -336,7 +336,7 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
             } else {
                 addLastLinkToListNode.execute(getActiveProcessNode.execute(node), receiver);
                 wakeHighestPriorityNode.executeWake(frame);
-                FrameAccess.setStackPointer(frame, stackPointer);
+                pushNode.execute(frame, receiver);
                 throw ProcessSwitch.SINGLETON;
             }
         }
@@ -349,13 +349,13 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
         protected static final Object doResume(final VirtualFrame frame, final PointersObject receiver,
                         @Cached final AbstractPointersObjectReadNode readNode,
                         @Cached final ResumeProcessNode resumeProcessNode,
-                        @Cached("getIncrementedStackPointer(frame)") final int stackPointer) {
+                        @Cached final PushToStackNode pushNode) {
             if (!(readNode.execute(receiver, PROCESS.SUSPENDED_CONTEXT) instanceof ContextObject)) {
                 CompilerDirectives.transferToInterpreter();
                 throw PrimitiveFailed.GENERIC_ERROR;
             }
             if (resumeProcessNode.executeResume(frame, receiver)) {
-                FrameAccess.setStackPointer(frame, stackPointer);
+                pushNode.execute(frame, receiver);
                 throw ProcessSwitch.SINGLETON;
             } else {
                 return receiver;
@@ -781,9 +781,7 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
         }
     }
 
-    @DenyReplace
-    @SqueakPrimitive(indices = 130)
-    public static final class PrimFullGCNode extends AbstractSingletonPrimitiveNode implements Primitive0 {
+    private static final class GCHelper {
         private static final MBeanServer SERVER = TruffleOptions.AOT ? null : ManagementFactory.getPlatformMBeanServer();
         private static final String OPERATION_NAME = "gcRun";
         private static final Object[] PARAMS = {null};
@@ -802,31 +800,18 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
             }
         }
 
-        @Override
-        public Object execute(final VirtualFrame frame, final Object receiver) {
-            final SqueakImageContext image = getContext();
-            return doGC(image);
-        }
-
         @TruffleBoundary
-        private static Object doGC(final SqueakImageContext image) {
-            /*
-             * We need to do two things: remove forwarding pointers, and remove spurious references
-             * from the stacks of dead frames. Any tracing of the object graph will remove the
-             * spurious references, so if an unfollow is needed to remove the forwarding pointers,
-             * we're done. Otherwise, we ask for all instances of an unknown class.
-             */
-            if (image.objectGraphUtils.isUnfollowNeeded()) {
-                image.objectGraphUtils.unfollow();
-            } else {
-                image.objectGraphUtils.allInstancesOf(null);
-            }
-            if (TruffleOptions.AOT) {
+        static Object doGC(final SqueakImageContext image, final boolean isFull) {
+            // Eliminate forwarding pointers and dead objects in stack frames.
+            image.objectGraphUtils.flushDeadReferences();
+
+            if (TruffleOptions.AOT || !isFull) {
                 /* System.gc() triggers full GC by default in SVM (see https://git.io/JvY7g). */
                 MiscUtils.systemGC();
             } else {
                 forceFullGC();
             }
+
             final boolean hasPendingFinalizations = LogUtils.GC_IS_LOGGABLE_FINE ? hasPendingFinalizationsWithLogging(image) : hasPendingFinalizations(image);
             final boolean hasPendingEphemerons = image.containsEphemerons && image.objectGraphUtils.checkEphemerons();
             if (hasPendingFinalizations || hasPendingEphemerons) {
@@ -866,14 +851,43 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
         }
     }
 
-    @DenyReplace
+    @GenerateNodeFactory
+    @SqueakPrimitive(indices = 130)
+    protected abstract static class PrimFullGCNode extends AbstractPrimitiveWithFrameNode implements Primitive0 {
+        @Specialization
+        protected final Object doGC(final VirtualFrame frame, @SuppressWarnings("unused") final Object receiver,
+                        @Cached final CheckForInterruptsFullNode interruptNode,
+                        @Cached final PushToStackNode pushNode) {
+
+            final Object result = GCHelper.doGC(getContext(), true);
+
+            try {
+                interruptNode.execute(frame);
+            } catch (final ProcessSwitch ps) {
+                pushNode.execute(frame, result);
+                throw ps;
+            }
+            return result;
+        }
+    }
+
+    @GenerateNodeFactory
     @SqueakPrimitive(indices = 131)
-    public static final class PrimIncrementalGCNode extends AbstractSingletonPrimitiveNode implements Primitive0 {
-        @Override
-        public Object execute(final VirtualFrame frame, final Object receiver) {
-            /* Cannot force incremental GC in Java, suggesting a normal GC instead. */
-            MiscUtils.systemGC();
-            return MiscUtils.runtimeFreeMemory();
+    protected abstract static class PrimIncrementalGCNode extends AbstractPrimitiveWithFrameNode implements Primitive0 {
+        @Specialization
+        protected final Object doGC(final VirtualFrame frame, @SuppressWarnings("unused") final Object receiver,
+                        @Cached final CheckForInterruptsFullNode interruptNode,
+                        @Cached final PushToStackNode pushNode) {
+
+            final Object result = GCHelper.doGC(getContext(), false);
+
+            try {
+                interruptNode.execute(frame);
+            } catch (final ProcessSwitch ps) {
+                pushNode.execute(frame, result);
+                throw ps;
+            }
+            return result;
         }
     }
 
@@ -901,7 +915,7 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
                         @Cached final AbstractPointersObjectReadNode pointersReadNode,
                         @Cached final AddLastLinkToListNode addLastLinkToListNode,
                         @Cached final WakeHighestPriorityNode wakeHighestPriorityNode,
-                        @Cached("getIncrementedStackPointer(frame)") final int stackPointer) {
+                        @Cached final PushToStackNode pushNode) {
             final PointersObject activeProcess = getActiveProcessNode.execute(node);
             final long priority = pointersReadNode.executeLong(activeProcess, PROCESS.PRIORITY);
             final ArrayObject processLists = pointersReadNode.executeArray(scheduler, PROCESS_SCHEDULER.PROCESS_LISTS);
@@ -911,7 +925,7 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
             }
             addLastLinkToListNode.execute(activeProcess, processList);
             wakeHighestPriorityNode.executeWake(frame);
-            FrameAccess.setStackPointer(frame, stackPointer);
+            pushNode.execute(frame, NilObject.SINGLETON);
             throw ProcessSwitch.SINGLETON;
         }
     }
@@ -955,11 +969,11 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
                             @Cached final AbstractPointersObjectReadNode readNode,
                             @Exclusive @Cached final AbstractPointersObjectWriteNode writeNode,
                             @Cached final ResumeProcessNode resumeProcessNode,
-                            @Cached("getIncrementedStackPointer(frame)") final int stackPointer) {
+                            @Cached final PushToStackNode pushNode) {
                 final PointersObject owningProcess = mutex.removeFirstLinkOfList(readNode, writeNode);
                 writeNode.execute(mutex, MUTEX.OWNER, owningProcess);
                 if (resumeProcessNode.executeResume(frame, owningProcess)) {
-                    FrameAccess.setStackPointer(frame, stackPointer);
+                    pushNode.execute(frame, mutex);
                     throw ProcessSwitch.SINGLETON;
                 } else {
                     return mutex;
@@ -1281,7 +1295,7 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
         @Specialization
         protected static final Object doRelinquish(final VirtualFrame frame, final Object receiver, final long timeMicroseconds,
                         @Cached final CheckForInterruptsFullNode interruptNode,
-                        @Cached("getIncrementedStackPointer(frame)") final int stackPointer) {
+                        @Cached final PushToStackNode pushNode) {
             MiscUtils.park(timeMicroseconds * 1000);
             /*
              * Perform interrupt check (even if interrupt handler is not active), otherwise
@@ -1290,7 +1304,7 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
             try {
                 interruptNode.execute(frame);
             } catch (final ProcessSwitch ps) {
-                FrameAccess.setStackPointer(frame, stackPointer);
+                pushNode.execute(frame, receiver);
                 throw ps;
             }
             return receiver;
@@ -1426,8 +1440,6 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
                         new PrimQuickReturnZeroNode(),
                         new PrimQuickReturnOneNode(),
                         new PrimQuickReturnTwoNode(),
-                        new PrimBytesLeftNode(),
-                        new PrimFullGCNode(),
-                        new PrimIncrementalGCNode());
+                        new PrimBytesLeftNode());
     }
 }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ControlPrimitives.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ControlPrimitives.java
@@ -855,12 +855,11 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
     @SqueakPrimitive(indices = 130)
     protected abstract static class PrimFullGCNode extends AbstractPrimitiveWithFrameNode implements Primitive0 {
         @Specialization
-        protected final Object doGC(final VirtualFrame frame, @SuppressWarnings("unused") final Object receiver,
+        protected static final Object doGC(final VirtualFrame frame, @SuppressWarnings("unused") final Object receiver,
+                        @Bind final SqueakImageContext image,
                         @Cached final CheckForInterruptsFullNode interruptNode,
                         @Cached final PushToStackNode pushNode) {
-
-            final Object result = GCHelper.doGC(getContext(), true);
-
+            final Object result = GCHelper.doGC(image, true);
             try {
                 interruptNode.execute(frame);
             } catch (final ProcessSwitch ps) {
@@ -875,12 +874,11 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
     @SqueakPrimitive(indices = 131)
     protected abstract static class PrimIncrementalGCNode extends AbstractPrimitiveWithFrameNode implements Primitive0 {
         @Specialization
-        protected final Object doGC(final VirtualFrame frame, @SuppressWarnings("unused") final Object receiver,
+        protected static final Object doGC(final VirtualFrame frame, @SuppressWarnings("unused") final Object receiver,
+                        @Bind final SqueakImageContext image,
                         @Cached final CheckForInterruptsFullNode interruptNode,
                         @Cached final PushToStackNode pushNode) {
-
-            final Object result = GCHelper.doGC(getContext(), false);
-
+            final Object result = GCHelper.doGC(image, false);
             try {
                 interruptNode.execute(frame);
             } catch (final ProcessSwitch ps) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/FrameAccess.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/FrameAccess.java
@@ -248,10 +248,6 @@ public final class FrameAccess {
             for (int slotIndex = SlotIndices.STACK_START; slotIndex < frameDescriptor.getNumberOfSlots(); slotIndex++) {
                 frame.setObjectStatic(slotIndex, null);
             }
-            // ToDo: determine if auxSlots are actually used and remove the following if not.
-            for (int auxSlotIndex = 0; auxSlotIndex < frameDescriptor.getNumberOfAuxiliarySlots(); auxSlotIndex++) {
-                frame.setAuxiliarySlot(auxSlotIndex, null);
-            }
         }
     }
 
@@ -287,8 +283,8 @@ public final class FrameAccess {
      * Iterates over the live stack objects of a given frame, passing them to the provided action.
      * <p>
      * <strong>Important boundary:</strong> The {@code action} is strictly applied to objects from
-     * the stack start up to the current stack pointer (exclusive), plus any auxiliary slots. It
-     * <em>does not</em> pass objects located at or beyond the stack pointer to the action.
+     * the stack start up to the current stack pointer (exclusive). It <em>does not</em> pass
+     * objects located at or beyond the stack pointer to the action.
      * <p>
      * <strong>Write Access Required:</strong> If {@code frameHandling} is set to
      * {@link FrameHandling#SCRUB}, this method will modify the frame by nilling out unreachable
@@ -319,10 +315,6 @@ public final class FrameAccess {
                     frame.setObjectStatic(slotIndex, null);
                 }
             }
-            // ToDo: determine if auxSlots are actually used and remove the following if not.
-            for (int auxSlotIndex = 0; auxSlotIndex < frameDescriptor.getNumberOfAuxiliarySlots(); auxSlotIndex++) {
-                action.accept(frame.getAuxiliarySlot(auxSlotIndex));
-            }
         }
     }
 
@@ -331,8 +323,8 @@ public final class FrameAccess {
      * optionally replace their values.
      * <p>
      * <strong>Important boundary:</strong> This method strictly iterates from the stack start up to
-     * the current stack pointer (exclusive), along with auxiliary slots. It <em>does not</em>
-     * evaluate or replace objects located at or beyond the stack pointer.
+     * the current stack pointer (exclusive). It <em>does not</em> evaluate or replace objects
+     * located at or beyond the stack pointer.
      * <p>
      * <strong>Write Access Required:</strong> Because this method explicitly modifies frame slots
      * (either by applying a replacement, or by clearing slots when {@code clearStackSlots} is
@@ -358,13 +350,6 @@ public final class FrameAccess {
                 final Object replacement = action.apply(frame.getObjectStatic(slotIndex));
                 if (replacement != null) {
                     frame.setObjectStatic(slotIndex, replacement);
-                }
-            }
-            // ToDo: determine if auxSlots are actually used and remove the following if not.
-            for (int auxSlotIndex = 0; auxSlotIndex < frameDescriptor.getNumberOfAuxiliarySlots(); auxSlotIndex++) {
-                final Object replacement = action.apply(frame.getAuxiliarySlot(auxSlotIndex));
-                if (replacement != null) {
-                    frame.setAuxiliarySlot(auxSlotIndex, replacement);
                 }
             }
         }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/FrameAccess.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/FrameAccess.java
@@ -209,6 +209,21 @@ public final class FrameAccess {
         frame.setIntStatic(SlotIndices.STACK_POINTER, value);
     }
 
+    public static  void externalizePCAndSP(final VirtualFrame frame, final int pc, final int sp) {
+        setInstructionPointer(frame, pc);
+        setStackPointer(frame, sp);
+    }
+
+    public static int internalizePC(final VirtualFrame frame, final int pc) {
+        final int framePC = getInstructionPointer(frame);
+        if (pc != framePC) {
+            CompilerDirectives.transferToInterpreter();
+            return framePC;
+        } else {
+            return pc;
+        }
+    }
+
     public static int getStackStart() {
         return SlotIndices.STACK_START;
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/FrameAccess.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/FrameAccess.java
@@ -14,7 +14,6 @@ import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.Truffle;
-import com.oracle.truffle.api.dsl.NeverDefault;
 import com.oracle.truffle.api.frame.Frame;
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.frame.FrameDescriptor.Builder;
@@ -29,6 +28,7 @@ import de.hpi.swa.trufflesqueak.model.ArrayObject;
 import de.hpi.swa.trufflesqueak.model.BlockClosureObject;
 import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
 import de.hpi.swa.trufflesqueak.model.ContextObject;
+import de.hpi.swa.trufflesqueak.model.ContextObject.FrameHandling;
 import de.hpi.swa.trufflesqueak.model.NativeObject;
 import de.hpi.swa.trufflesqueak.model.NilObject;
 import de.hpi.swa.trufflesqueak.model.PointersObject;
@@ -185,7 +185,7 @@ public final class FrameAccess {
     }
 
     public static void setContext(final Frame frame, final ContextObject context) {
-        assert getContext(frame) == null : "ContextObject already allocated";
+        assert getContext(frame) == null || getContext(frame) == context : "ContextObject already allocated";
         frame.setObjectStatic(SlotIndices.THIS_CONTEXT, context);
     }
 
@@ -203,11 +203,6 @@ public final class FrameAccess {
 
     public static int getStackPointer(final Frame frame) {
         return frame.getIntStatic(SlotIndices.STACK_POINTER);
-    }
-
-    @NeverDefault
-    public static int getIncrementedStackPointer(final VirtualFrame frame) {
-        return getStackPointer(frame) + 1;
     }
 
     public static void setStackPointer(final Frame frame, final int value) {
@@ -253,43 +248,100 @@ public final class FrameAccess {
             for (int slotIndex = SlotIndices.STACK_START; slotIndex < frameDescriptor.getNumberOfSlots(); slotIndex++) {
                 frame.setObjectStatic(slotIndex, null);
             }
+            // ToDo: determine if auxSlots are actually used and remove the following if not.
             for (int auxSlotIndex = 0; auxSlotIndex < frameDescriptor.getNumberOfAuxiliarySlots(); auxSlotIndex++) {
                 frame.setAuxiliarySlot(auxSlotIndex, null);
             }
         }
     }
 
-    /* Iterates used stack slots (may not be ordered). The stack of a dead frame is unreachable. */
-    public static void iterateStackSlots(final Frame frame, final Consumer<Integer> action) {
+    /**
+     * Iterates over the active stack slot indices of a given frame.
+     * <p>
+     * <strong>Important boundary:</strong> This method strictly iterates from the stack start up to
+     * the current stack pointer (exclusive). It <em>does not</em> yield indices at or beyond the
+     * active stack pointer.
+     * <p>
+     * <strong>Write Access Required:</strong> If the frame is dead (terminated), this method will
+     * modify the frame by explicitly clearing the remaining slots. Therefore, the {@code frame}
+     * must not be read-only in this state (e.g., it requires {@code READ_WRITE} access if obtained
+     * via a Truffle {@code FrameInstance}).
+     *
+     * @param frame the frame to inspect (must be writable if the frame is dead)
+     * @param sp the current stack pointer defining the upper boundary
+     * @param action the action to perform on each valid slot index
+     */
+    public static void iterateStackSlots(final Frame frame, final int sp, final Consumer<Integer> action) {
         if (isDead(frame)) {
             clearStackSlots(frame);
         } else {
-            for (int slotIndex = SlotIndices.STACK_START; slotIndex < frame.getFrameDescriptor().getNumberOfSlots(); slotIndex++) {
+            /* Iterate defined stack slots only. */
+            final int slotLimit = Integer.min(SlotIndices.STACK_START + sp, frame.getFrameDescriptor().getNumberOfSlots());
+            for (int slotIndex = SlotIndices.STACK_START; slotIndex < slotLimit; slotIndex++) {
                 action.accept(slotIndex);
             }
         }
     }
 
-    /* Iterate stack objects (may not be ordered). The stack of a dead frame is unreachable. */
-    public static void iterateStackObjects(final Frame frame, final boolean clearStackSlots, final Consumer<Object> action) {
+    /**
+     * Iterates over the live stack objects of a given frame, passing them to the provided action.
+     * <p>
+     * <strong>Important boundary:</strong> The {@code action} is strictly applied to objects from
+     * the stack start up to the current stack pointer (exclusive), plus any auxiliary slots. It
+     * <em>does not</em> pass objects located at or beyond the stack pointer to the action.
+     * <p>
+     * <strong>Write Access Required:</strong> If {@code frameHandling} is set to
+     * {@link FrameHandling#SCRUB}, this method will modify the frame by nilling out unreachable
+     * stack entries (or the entire stack if dead). The {@code frame} must not be read-only when
+     * scrubbing is enabled (e.g., it requires {@code READ_WRITE} access).
+     *
+     * @param frame the frame to inspect (must be writable if scrubbing)
+     * @param frameHandling the handling policy (e.g., SCAN or SCRUB)
+     * @param action the action to perform on each live stack object
+     */
+    public static void iterateStackObjects(final Frame frame, final FrameHandling frameHandling, final Consumer<Object> action) {
         if (isDead(frame)) {
-            if (clearStackSlots) {
+            if (frameHandling == FrameHandling.SCRUB) {
                 clearStackSlots(frame);
             }
         } else {
+            /* Iterate defined stack slots only. */
+            final int sp = getStackPointer(frame);
             final FrameDescriptor frameDescriptor = frame.getFrameDescriptor();
-            for (int slotIndex = SlotIndices.STACK_START; slotIndex < frameDescriptor.getNumberOfSlots(); slotIndex++) {
+            final int slotCount = frameDescriptor.getNumberOfSlots();
+            final int slotLimit = Integer.min(SlotIndices.STACK_START + sp, slotCount);
+            for (int slotIndex = SlotIndices.STACK_START; slotIndex < slotLimit; slotIndex++) {
                 action.accept(frame.getObjectStatic(slotIndex));
             }
+            /* Nil unreachable stack entries. */
+            if (frameHandling == FrameHandling.SCRUB) {
+                for (int slotIndex = slotLimit; slotIndex < slotCount; slotIndex++) {
+                    frame.setObjectStatic(slotIndex, null);
+                }
+            }
+            // ToDo: determine if auxSlots are actually used and remove the following if not.
             for (int auxSlotIndex = 0; auxSlotIndex < frameDescriptor.getNumberOfAuxiliarySlots(); auxSlotIndex++) {
                 action.accept(frame.getAuxiliarySlot(auxSlotIndex));
             }
         }
     }
 
-    /*
-     * Iterate stack objects (may not be ordered) with optional replacement. The stack of a dead
-     * frame is unreachable.
+    /**
+     * Iterates over the live stack objects of a given frame, allowing the provided function to
+     * optionally replace their values.
+     * <p>
+     * <strong>Important boundary:</strong> This method strictly iterates from the stack start up to
+     * the current stack pointer (exclusive), along with auxiliary slots. It <em>does not</em>
+     * evaluate or replace objects located at or beyond the stack pointer.
+     * <p>
+     * <strong>Write Access Required:</strong> Because this method explicitly modifies frame slots
+     * (either by applying a replacement, or by clearing slots when {@code clearStackSlots} is
+     * {@code true} on a dead frame), the {@code frame} must not be a read-only instance under any
+     * circumstances (e.g., it requires {@code READ_WRITE} access).
+     *
+     * @param frame the frame to inspect (must be writable)
+     * @param clearStackSlots whether to nil out the stack if the frame is dead
+     * @param action a function that returns the replacement object, or null to keep the original
      */
     public static void iterateStackObjectsWithReplacement(final Frame frame, final boolean clearStackSlots, final Function<Object, Object> action) {
         if (isDead(frame)) {
@@ -297,13 +349,18 @@ public final class FrameAccess {
                 clearStackSlots(frame);
             }
         } else {
+            /* Iterate defined stack slots only. */
+            final int sp = getStackPointer(frame);
             final FrameDescriptor frameDescriptor = frame.getFrameDescriptor();
-            for (int slotIndex = SlotIndices.STACK_START; slotIndex < frameDescriptor.getNumberOfSlots(); slotIndex++) {
+            final int slotCount = frameDescriptor.getNumberOfSlots();
+            final int slotLimit = Integer.min(SlotIndices.STACK_START + sp, slotCount);
+            for (int slotIndex = SlotIndices.STACK_START; slotIndex < slotLimit; slotIndex++) {
                 final Object replacement = action.apply(frame.getObjectStatic(slotIndex));
                 if (replacement != null) {
                     frame.setObjectStatic(slotIndex, replacement);
                 }
             }
+            // ToDo: determine if auxSlots are actually used and remove the following if not.
             for (int auxSlotIndex = 0; auxSlotIndex < frameDescriptor.getNumberOfAuxiliarySlots(); auxSlotIndex++) {
                 final Object replacement = action.apply(frame.getAuxiliarySlot(auxSlotIndex));
                 if (replacement != null) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/FrameAccess.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/FrameAccess.java
@@ -209,7 +209,7 @@ public final class FrameAccess {
         frame.setIntStatic(SlotIndices.STACK_POINTER, value);
     }
 
-    public static  void externalizePCAndSP(final VirtualFrame frame, final int pc, final int sp) {
+    public static void externalizePCAndSP(final VirtualFrame frame, final int pc, final int sp) {
         setInstructionPointer(frame, pc);
         setStackPointer(frame, sp);
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/ObjectGraphUtils.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/ObjectGraphUtils.java
@@ -36,6 +36,7 @@ import de.hpi.swa.trufflesqueak.model.AbstractSqueakObjectWithClassAndHash;
 import de.hpi.swa.trufflesqueak.model.AbstractSqueakObjectWithHash;
 import de.hpi.swa.trufflesqueak.model.ClassObject;
 import de.hpi.swa.trufflesqueak.model.ContextObject;
+import de.hpi.swa.trufflesqueak.model.ContextObject.FrameHandling;
 import de.hpi.swa.trufflesqueak.model.EphemeronObject;
 import de.hpi.swa.trufflesqueak.model.NilObject;
 
@@ -59,6 +60,22 @@ public final class ObjectGraphUtils {
         return lastSeenObjects;
     }
 
+    /**
+     * Triggered by a Smalltalk garbage collection request. We need to do two things: remove
+     * forwarding pointers, and remove spurious references from the stacks of dead frames. Any
+     * tracing of the object graph with FrameHandling.SCRUB will remove the spurious references, so
+     * if an unfollow is needed to remove the forwarding pointers, we're done. Otherwise, we ask for
+     * all instances of a null class to force a full trace.
+     */
+    @TruffleBoundary
+    public void flushDeadReferences() {
+        if (isUnfollowNeeded()) {
+            unfollow();
+        } else {
+            allInstancesOf(null);
+        }
+    }
+
     private record AllInstancesTask(ObjectTracer roots, ArrayDeque<AbstractSqueakObjectWithHash> objects,
                     UnmodifiableEconomicMap<Object, Object> fromToMap) implements Runnable {
         public void run() {
@@ -79,7 +96,7 @@ public final class ObjectGraphUtils {
     public Object[] allInstances() {
         final long startTime = System.nanoTime();
 
-        final ObjectTracer roots = ObjectTracer.fromRoots(image, true);
+        final ObjectTracer roots = ObjectTracer.fromRoots(image, true, FrameHandling.SCAN);
 
         final Runnable[] tasks = new Runnable[USABLE_THREAD_COUNT];
         final List<ArrayDeque<AbstractSqueakObjectWithHash>> objectsList = new ArrayList<>(USABLE_THREAD_COUNT);
@@ -136,7 +153,8 @@ public final class ObjectGraphUtils {
     public Object[] allInstancesOf(final ClassObject targetClass) {
         final long startTime = System.nanoTime();
 
-        final ObjectTracer roots = ObjectTracer.fromRoots(image, true);
+        // Scrub the stack frames if targetClass is null.
+        final ObjectTracer roots = ObjectTracer.fromRoots(image, true, targetClass == null ? FrameHandling.SCRUB : FrameHandling.SCAN);
 
         final Runnable[] tasks = new Runnable[USABLE_THREAD_COUNT];
         final List<ArrayDeque<AbstractSqueakObjectWithHash>> objectsList = new ArrayList<>(USABLE_THREAD_COUNT);
@@ -171,7 +189,7 @@ public final class ObjectGraphUtils {
     public AbstractSqueakObject someInstanceOf(final ClassObject targetClass) {
         final long startTime = System.nanoTime();
         final ArrayDeque<AbstractSqueakObjectWithHash> marked = new ArrayDeque<>(lastSeenObjects / 2);
-        final ObjectTracer tracer = ObjectTracer.fromRoots(image, true);
+        final ObjectTracer tracer = ObjectTracer.fromRoots(image, true, FrameHandling.SCAN);
         AbstractSqueakObject result = NilObject.SINGLETON;
         AbstractSqueakObjectWithHash currentObject;
         while ((currentObject = tracer.getNext()) != null) {
@@ -200,7 +218,7 @@ public final class ObjectGraphUtils {
         // each time it is called.
         final long startTime = System.nanoTime();
         final ArrayDeque<AbstractSqueakObjectWithHash> marked = new ArrayDeque<>(lastSeenObjects / 2);
-        final ObjectTracer tracer = ObjectTracer.fromRoots(image, true);
+        final ObjectTracer tracer = ObjectTracer.fromRoots(image, true, FrameHandling.SCAN);
         AbstractSqueakObjectWithHash currentObject = tracer.getNext();
         AbstractSqueakObject result = currentObject; // first object
         boolean foundObject = false;
@@ -251,7 +269,7 @@ public final class ObjectGraphUtils {
                 pointersBecomeOneWayFrames(_ -> {
                 }, becomeMap);
             } else {
-                final ObjectTracer roots = ObjectTracer.fromRoots(image, false);
+                final ObjectTracer roots = ObjectTracer.fromRoots(image, false, FrameHandling.SCAN);
                 pointersBecomeOneWayFrames(roots::addIfUnmarked, becomeMap);
                 becomeOneWayManyPairs(roots);
             }
@@ -284,7 +302,7 @@ public final class ObjectGraphUtils {
             return; // nothing to do
         }
         final long startTime = System.nanoTime();
-        becomeOneWayManyPairs(ObjectTracer.fromRoots(image, true));
+        becomeOneWayManyPairs(ObjectTracer.fromRoots(image, true, FrameHandling.SCRUB));
         if (trackOperations) {
             ObjectGraphOperations.UNFOLLOW.addNanos(System.nanoTime() - startTime);
         }
@@ -342,10 +360,6 @@ public final class ObjectGraphUtils {
                 tracer.accept(FrameAccess.getContext(current));
             }
 
-            /*
-             * Iterate over all stack slots here instead of stackPointer because in rare cases, the
-             * stack is accessed behind the stackPointer.
-             */
             FrameAccess.iterateStackObjectsWithReplacement(current, false, stackObject -> {
                 if (stackObject != null) {
                     final Object migratedObject = fromToMap.get(stackObject);
@@ -359,25 +373,18 @@ public final class ObjectGraphUtils {
         });
     }
 
-    private record EphemeronsTask(ObjectTracer roots, ArrayDeque<EphemeronObject> ephemeronsToBeTraced,
-                    UnmodifiableEconomicMap<Object, Object> fromToMap) implements Runnable {
+    private record EphemeronsTask(ObjectTracer roots, ArrayDeque<EphemeronObject> ephemeronsToBeTraced) implements Runnable {
         public void run() {
             final ObjectTracer tracer = roots.copyEmpty();
             AbstractSqueakObjectWithHash root;
             while ((root = roots.getNextWithLock()) != null) {
                 AbstractSqueakObjectWithHash currentObject = root;
                 do {
-                    currentObject.pointersBecomeOneWay(fromToMap);
                     // Ephemerons are traced in a special way.
                     if (currentObject instanceof final EphemeronObject ephemeronObject) {
-                        // An Ephemeron is traced normally if it has been signaled or its key has
-                        // been marked already. Otherwise, they are traced after all other objects.
-                        if (ephemeronObject.hasBeenSignaled() || ephemeronObject.keyHasBeenMarked(tracer)) {
-                            tracer.tracePointers(currentObject);
-                        } else {
-                            synchronized (ephemeronsToBeTraced) {
-                                ephemeronsToBeTraced.add(ephemeronObject);
-                            }
+                        // Defer all ephemerons to be traced safely in the sequential phase.
+                        synchronized (ephemeronsToBeTraced) {
+                            ephemeronsToBeTraced.add(ephemeronObject);
                         }
                     } else {
                         // Normal object
@@ -390,19 +397,20 @@ public final class ObjectGraphUtils {
 
     @TruffleBoundary
     public boolean checkEphemerons() {
+        assert !isUnfollowNeeded();
+
         final long startTime = System.nanoTime();
 
-        final ObjectTracer roots = ObjectTracer.fromRoots(image, true);
+        final ObjectTracer roots = ObjectTracer.fromRoots(image, true, FrameHandling.SCAN);
 
         // Mark and trace all non-ephemeron objects. Mark and trace ephemerons that have
         // been signaled or whose keys have been marked. Save all other ephemerons for later.
         final Runnable[] tasks = new Runnable[USABLE_THREAD_COUNT];
         final ArrayDeque<EphemeronObject> ephemeronsToBeTraced = new ArrayDeque<>();
         for (int i = 0; i < USABLE_THREAD_COUNT; i++) {
-            tasks[i] = new EphemeronsTask(roots, ephemeronsToBeTraced, becomeMap);
+            tasks[i] = new EphemeronsTask(roots, ephemeronsToBeTraced);
         }
         runTasks(tasks);
-        postProcessBecomeMap(null);
 
         // Now, trace the ephemerons until there are only ephemerons whose keys are reachable
         // through ephemerons.
@@ -416,7 +424,8 @@ public final class ObjectGraphUtils {
         if (trackOperations) {
             ObjectGraphOperations.CHECK_EPHEMERONS.addNanos(System.nanoTime() - startTime);
         }
-        return true;
+
+        return !image.ephemeronsQueue.isEmpty();
     }
 
     private static void traceRemainingEphemerons(final ArrayDeque<EphemeronObject> ephemeronsToBeMarked, final ObjectTracer tracer) {
@@ -427,7 +436,9 @@ public final class ObjectGraphUtils {
             final Iterator<EphemeronObject> iterator = ephemeronsToBeMarked.iterator();
             while (iterator.hasNext()) {
                 final EphemeronObject ephemeronObject = iterator.next();
-                if (ephemeronObject.keyHasBeenMarked(tracer)) {
+                // An Ephemeron is traced normally if it has been signaled or its key has
+                // been marked already. Otherwise, they are traced after all other objects.
+                if (ephemeronObject.hasBeenSignaled() || ephemeronObject.keyHasBeenMarked(tracer)) {
                     tracer.tracePointers(ephemeronObject);
                     iterator.remove();
                     finished = false;
@@ -482,30 +493,32 @@ public final class ObjectGraphUtils {
         private final ArrayDeque<AbstractSqueakObjectWithHash> workStack = new ArrayDeque<>();
         public final SqueakImageContext image;
         private final boolean currentMarkingFlag;
+        public final FrameHandling frameHandling;
 
-        private ObjectTracer(final SqueakImageContext image, final boolean markingFlag) {
+        private ObjectTracer(final SqueakImageContext image, final boolean markingFlag, final FrameHandling frameHandling) {
             this.image = image;
             this.currentMarkingFlag = markingFlag;
+            this.frameHandling = frameHandling;
         }
 
         /** Return an empty traversal based on this root traversal. */
         public ObjectTracer copyEmpty() {
-            return new ObjectTracer(image, currentMarkingFlag);
+            return new ObjectTracer(image, currentMarkingFlag, frameHandling);
         }
 
         /**
          * Return an ObjectTracer initialized with the roots and optionally including objects in the
          * Truffle frames. Flips the global marking flag.
          */
-        private static ObjectTracer fromRoots(final SqueakImageContext image, final boolean addObjectsFromFrames) {
-            final ObjectTracer tracer = new ObjectTracer(image, image.toggleCurrentMarkingFlag());
-            tracer.addRoots(addObjectsFromFrames);
+        private static ObjectTracer fromRoots(final SqueakImageContext image, final boolean includeActiveFrames, final FrameHandling frameHandling) {
+            final ObjectTracer tracer = new ObjectTracer(image, image.toggleCurrentMarkingFlag(), frameHandling);
+            tracer.addRoots(includeActiveFrames);
             return tracer;
         }
 
-        private void addRoots(final boolean addObjectsFromFrames) {
+        private void addRoots(final boolean includeActiveFrames) {
             /* Add roots, in reversed order because workStack is LIFO. */
-            if (addObjectsFromFrames) {
+            if (includeActiveFrames) {
                 addObjectsFromFrames();
             }
 
@@ -526,12 +539,16 @@ public final class ObjectGraphUtils {
 
         private void addObjectsFromFrames() {
             CompilerAsserts.neverPartOfCompilation();
+            final boolean shouldScrub = frameHandling == FrameHandling.SCRUB;
+
             Truffle.getRuntime().iterateFrames(frameInstance -> {
-                final Frame current = frameInstance.getFrame(FrameInstance.FrameAccess.READ_ONLY);
-                if (FrameAccess.isTruffleSqueakFrame(current)) {
+                final Frame readOnlyFrame = frameInstance.getFrame(FrameInstance.FrameAccess.READ_ONLY);
+
+                if (FrameAccess.isTruffleSqueakFrame(readOnlyFrame)) {
+                    final Frame current = shouldScrub ? frameInstance.getFrame(FrameInstance.FrameAccess.READ_WRITE) : readOnlyFrame;
                     addAllIfUnmarked(current.getArguments());
                     addIfUnmarked(FrameAccess.getContext(current));
-                    FrameAccess.iterateStackObjects(current, false, this::addIfUnmarked);
+                    FrameAccess.iterateStackObjects(current, frameHandling, this::addIfUnmarked);
                 }
                 return null; // continue
             });

--- a/src/image-tests/runCuisTests.st
+++ b/src/image-tests/runCuisTests.st
@@ -19,6 +19,7 @@ CompiledMethod preferredBytecodeSetEncoderClass == EncoderForSistaV1
 nonTerminatingTestCases := OrderedCollection new.
 {
     #ProcessTest -> #(#testResumeWithEnsureAfterBCR).
+    #TestValueWithinFix -> TestValueWithinFix allTestSelectors.
 } collect: [:assoc | | testCase |
     testCase := Smalltalk at: assoc key.
     assoc value do: [:sel | nonTerminatingTestCases add: (testCase selector: sel) ]].

--- a/src/image-tests/runCuisTests.st
+++ b/src/image-tests/runCuisTests.st
@@ -19,7 +19,6 @@ CompiledMethod preferredBytecodeSetEncoderClass == EncoderForSistaV1
 nonTerminatingTestCases := OrderedCollection new.
 {
     #ProcessTest -> #(#testResumeWithEnsureAfterBCR).
-    #TestValueWithinFix -> TestValueWithinFix allTestSelectors.
 } collect: [:assoc | | testCase |
     testCase := Smalltalk at: assoc key.
     assoc value do: [:sel | nonTerminatingTestCases add: (testCase selector: sel) ]].


### PR DESCRIPTION
### Summary
Eliminate the eager nilling of stack slots in `AbstractInterpreterNode.pop()` and `popN()`, and instead hide references to objects in stack slots above the stack pointer during object graph traversals in `ObjectGraphUtils`. The `FrameAccess` stack iteration methods were modified to explicitly stop iteration at the stack pointer limit. This transition to lazy nilling aligns the behavior with the Open Smalltalk VM and yields an approximate 4% speedup on benchmarks when executing on the JVM.

### GC & Finalization Determinism
Even though objects referenced from "dead" stack slots are invisible to Smalltalk, they will persist in the JVM. 
* The garbage collection primitives were modified to nil these "dead" stack slots before performing the GC (via `flushDeadReferences()`). 
* To make finalization deterministic, the GC primitives were modified to check for interrupts and handle them.

### Object Graph Traversal Policies
* Object graph traversals in `ObjectGraphUtils` were modified to indicate whether they want to `SCAN` or `SCRUB` frames they encounter. 
* The addition of `flushDeadReferences()` meant that `checkEphemerons()` could be simplified to safely ignore `becomeMap`. 
* Because of a possible (but very unlikely) race condition, some of the processing of ephemerons was moved from the parallel tracing tasks to the sequential trace in the second half of `checkEphemerons()`.

### Primitive and Node Updates
* **ControlPrimitives:** All methods that could cause a process switch were modified to push the result onto the stack rather than simply bumping the stack pointer. With the new lazy nilling semantics, merely bumping the stack pointer would leave a residual value (likely the message receiver) as the apparent result of the primitive, whereas the previous eager nil-on-pop behavior left `nil`.
* **ContextPrimitives:** The changes from #249 were incorporated, with an additional change to nil newly hidden or exposed stack slots when the stack pointer is manually modified.
* **Interrupts:** `CheckForInterruptsInLoopNode` was modified to save the current stack pointer in the frame in the event an interrupt occurs during a backward branch.
* **ResumeContextRootNode:** `execute()` was modified to save `activeContext` in its frame argument so that `iterateFrames()` can successfully find the context when execution is taking place directly within that active context.