### PR TITLE
Unify #cannotInterpret: and #doesNotUnderstand: dispatch fallbacks

### DIFF
--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
@@ -1042,6 +1042,10 @@ public final class SqueakImageContext {
 
     /* Clear cache entries for selector (prim 119). */
     private void flushMethodCacheForSelector(final NativeObject selector) {
+        if (selector == doesNotUnderstand || selector == cannotInterpretSelector) {
+            flushMethodCache();
+            return;
+        }
         for (int i = 0; i < METHOD_CACHE_SIZE; i++) {
             if (methodCache[i].getSelector() == selector) {
                 methodCache[i].freeAndRelease();

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/io/SqueakDisplay.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/io/SqueakDisplay.java
@@ -504,7 +504,11 @@ public final class SqueakDisplay {
             frameRequested = true;
         }
 
-        // Wake the event loop to render the frame
+        wakeUpEventLoopToRenderFrame();
+    }
+
+    @TruffleBoundary
+    private static void wakeUpEventLoopToRenderFrame() {
         PlatformEventLoop.wakeUp();
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ClassObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ClassObject.java
@@ -65,7 +65,7 @@ public final class ClassObject extends AbstractSqueakObjectWithClassAndHash {
         instancesAreClasses = original.instancesAreClasses;
         superclass = original.superclass;
         assert superclass == null || superclass.assertNotForwarded();
-        methodDict = original.methodDict == null ? null : new VariablePointersObject(original.methodDict);
+        methodDict = original.methodDict != null ? new VariablePointersObject(original.methodDict) : null;
         format = original.format;
         // FIXME: should clone the pointers themselves, too
         pointers = original.pointers.clone();
@@ -368,9 +368,10 @@ public final class ClassObject extends AbstractSqueakObjectWithClassAndHash {
         assert superclass == null || superclass.assertNotForwarded();
         invalidateClassHierarchyAndMethodDictStableAssumption("new superclass");
         this.superclass = superclass;
-        // ToDo: Instead of a full global flush, this should be refined to only flush
-        // entries in image.methodCache where the entry's class is `this` class or a
-        // subclass of `this` class.
+        /*
+         * TODO: Instead of a full global flush, this should be refined to only flush entries in
+         * image.methodCache where the entry's class is `this` class or a subclass of `this` class.
+         */
         image.flushMethodCache();
     }
 
@@ -378,9 +379,10 @@ public final class ClassObject extends AbstractSqueakObjectWithClassAndHash {
         assert methodDict == null || methodDict.assertNotForwarded();
         invalidateClassHierarchyAndMethodDictStableAssumption("new method dict");
         this.methodDict = methodDict;
-        // ToDo: Instead of a full global flush, this should be refined to only flush
-        // entries in image.methodCache where the entry's class is `this` class or a
-        // subclass of `this` class.
+        /*
+         * TODO: Instead of a full global flush, this should be refined to only flush entries in
+         * image.methodCache where the entry's class is `this` class or a subclass of `this` class.
+         */
         image.flushMethodCache();
     }
 
@@ -465,7 +467,7 @@ public final class ClassObject extends AbstractSqueakObjectWithClassAndHash {
      */
     @TruffleBoundary
     public CompiledCodeObject resolveDispatchFailure(final NativeObject originalSelector) {
-
+        CompilerAsserts.neverPartOfCompilation();
         // Walk superclass chain to determine if #cannotInterpret:.
         ClassObject current = this;
         while (current != null) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ClassObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ClassObject.java
@@ -65,7 +65,7 @@ public final class ClassObject extends AbstractSqueakObjectWithClassAndHash {
         instancesAreClasses = original.instancesAreClasses;
         superclass = original.superclass;
         assert superclass == null || superclass.assertNotForwarded();
-        methodDict = new VariablePointersObject(original.methodDict);
+        methodDict = original.methodDict == null ? null : new VariablePointersObject(original.methodDict);
         format = original.format;
         // FIXME: should clone the pointers themselves, too
         pointers = original.pointers.clone();
@@ -247,7 +247,7 @@ public final class ClassObject extends AbstractSqueakObjectWithClassAndHash {
                 setSqueakHash(chunk.getHash());
             }
             superclass = (ClassObject) NilObject.nilToNull(chunk.getPointer(CLASS_DESCRIPTION.SUPERCLASS));
-            methodDict = (VariablePointersObject) chunk.getPointer(CLASS_DESCRIPTION.METHOD_DICT);
+            methodDict = (VariablePointersObject) NilObject.nilToNull(chunk.getPointer(CLASS_DESCRIPTION.METHOD_DICT));
             format = (long) chunk.getPointer(CLASS_DESCRIPTION.FORMAT);
             pointers = chunk.getPointers(CLASS_DESCRIPTION.INLINE_POINTERS);
             initializeLayout();
@@ -322,6 +322,11 @@ public final class ClassObject extends AbstractSqueakObjectWithClassAndHash {
         return getSuperclassOrNull();
     }
 
+    public AbstractSqueakObject getMethodDictOrNil() {
+        assert assertNotForwarded();
+        return NilObject.nullToNil(methodDict);
+    }
+
     public VariablePointersObject getMethodDict() {
         assert assertNotForwarded() && (methodDict == null || methodDict.assertNotForwarded());
         return methodDict;
@@ -329,6 +334,9 @@ public final class ClassObject extends AbstractSqueakObjectWithClassAndHash {
 
     private VariablePointersObject getResolvedMethodDict() {
         assert assertNotForwarded();
+        if (methodDict == null) {
+            return methodDict;
+        }
         if (!methodDict.isNotForwarded()) {
             CompilerDirectives.transferToInterpreter();
             setMethodDict((VariablePointersObject) methodDict.getForwardingPointer());
@@ -368,7 +376,24 @@ public final class ClassObject extends AbstractSqueakObjectWithClassAndHash {
         this.methodDict = methodDict;
     }
 
-    /** See Interpreter#lookupMethodInClass:. */
+    /**
+     * Performs a full method lookup up the class hierarchy. See Interpreter#lookupMethodInClass:.
+     * <p>
+     * This method handles the core Smalltalk lookup semantics. It can return:
+     * <ul>
+     * <li>A {@link CompiledCodeObject} for a standard method.</li>
+     * <li>An arbitrary {@link Object} for Object-As-Method (run:with:in:) semantics.</li>
+     * <li>{@code null} if a structural dispatch failure occurs (either the selector is not found,
+     * or a nil method dictionary is encountered).</li>
+     * </ul>
+     * <p>
+     * Callers encountering a {@code null} result should use {@link #resolveDispatchFailure} to
+     * determine the appropriate fallback method (e.g., #doesNotUnderstand: or #cannotInterpret:).
+     *
+     * @param selector The message selector to look up.
+     * @return The result of the lookup (method or object), or {@code null} if dispatch fails.
+     */
+
     @TruffleBoundary
     public Object lookupInMethodDictSlow(final NativeObject selector) {
         final int selectorHash = selector.getSqueakHashInt();
@@ -380,7 +405,7 @@ public final class ClassObject extends AbstractSqueakObjectWithClassAndHash {
                  * "MethodDict pointer is nil (hopefully due a swapped out stub) -- raise exception
                  * #cannotInterpret:."
                  */
-                return getSuperclassOrNull().lookupInMethodDictSlow(image.cannotReturn);
+                return null;
             }
             final Object result = lookupMethodInDictionary(lookupClass.getResolvedMethodDict(), selector, selectorHash);
             if (result != null) {
@@ -423,8 +448,70 @@ public final class ClassObject extends AbstractSqueakObjectWithClassAndHash {
         return null;
     }
 
+    /**
+     * Resolves the fallback method for a failed dispatch (either DNU or CI).
+     *
+     * @param originalSelector The selector that failed (used for assertions and error context).
+     * @return The CompiledCodeObject for the fallback method.
+     * @throws SqueakException if the fallback method cannot be found (fatal VM error).
+     */
+    @TruffleBoundary
+    public CompiledCodeObject resolveDispatchFailure(final NativeObject originalSelector) {
+
+        // Walk superclass chain to determine if #cannotInterpret:.
+        ClassObject current = this;
+        while (current != null) {
+            assert current.assertNotForwarded();
+            if (current.methodDict == null) {
+                break;
+            }
+            current = current.getSuperclassOrNull();
+        }
+
+        // If the walk terminates with null, we have a DNU.
+        if (current == null) {
+            assert originalSelector != image.doesNotUnderstand : "Fatal dispatch error: Recursive doesNotUnderstand:";
+
+            final CompiledCodeObject dnuMethod = lookupMethodInMethodDictSlow(image.doesNotUnderstand);
+            if (dnuMethod != null) {
+                return dnuMethod;
+            } else {
+                throw SqueakException.create("Fatal dispatch error: #doesNotUnderstand: not found in", this);
+            }
+        } else {
+            // Search for #cannotInterpret: starting in the superclass of the missing method
+            // dictionary class.
+            final ClassObject startingClass = current.getSuperclassOrNull();
+            if (startingClass == null) {
+                throw SqueakException.create("Fatal dispatch error: hit nil method dictionary in class with no superclass while sending", originalSelector);
+            }
+
+            final CompiledCodeObject ciMethod = startingClass.lookupMethodInMethodDictSlow(image.cannotInterpretSelector);
+            if (ciMethod != null) {
+                return ciMethod;
+            } else {
+                throw SqueakException.create("Fatal dispatch error: #cannotInterpret: not found in superclass chain of", current);
+            }
+        }
+    }
+
+    /**
+     * A strict convenience wrapper around {@link #lookupInMethodDictSlow(NativeObject)} that only
+     * returns compiled methods.
+     * <p>
+     * This acts as a safe filter. It returns {@code null} if the underlying lookup results in a
+     * structural failure (such as #doesNotUnderstand: or #cannotInterpret:) OR if the lookup
+     * resolves to a non-method object (Object-As-Method).
+     *
+     * @param selector The message selector to look up.
+     * @return The compiled method, or {@code null} if not found or not a method.
+     */
     public CompiledCodeObject lookupMethodInMethodDictSlow(final NativeObject selector) {
-        return (CompiledCodeObject) lookupInMethodDictSlow(selector);
+        final Object result = lookupInMethodDictSlow(selector);
+        if (result instanceof CompiledCodeObject compiledCode) {
+            return compiledCode;
+        }
+        return null;
     }
 
     public void flushCachesForSelector(final NativeObject selector) {
@@ -576,7 +663,7 @@ public final class ClassObject extends AbstractSqueakObjectWithClassAndHash {
             throw SqueakException.create("ClassObject must have slots:", this);
         }
         writer.writeObject(getSuperclass());
-        writer.writeObject(getMethodDict());
+        writer.writeObject(getMethodDictOrNil());
         writer.writeSmallInteger(format);
         writer.writeObjects(getOtherPointers());
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ClassObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ClassObject.java
@@ -368,12 +368,20 @@ public final class ClassObject extends AbstractSqueakObjectWithClassAndHash {
         assert superclass == null || superclass.assertNotForwarded();
         invalidateClassHierarchyAndMethodDictStableAssumption("new superclass");
         this.superclass = superclass;
+        // ToDo: Instead of a full global flush, this should be refined to only flush
+        // entries in image.methodCache where the entry's class is `this` class or a
+        // subclass of `this` class.
+        image.flushMethodCache();
     }
 
     public void setMethodDict(final VariablePointersObject methodDict) {
         assert methodDict == null || methodDict.assertNotForwarded();
         invalidateClassHierarchyAndMethodDictStableAssumption("new method dict");
         this.methodDict = methodDict;
+        // ToDo: Instead of a full global flush, this should be refined to only flush
+        // entries in image.methodCache where the entry's class is `this` class or a
+        // subclass of `this` class.
+        image.flushMethodCache();
     }
 
     /**

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/CompiledCodeObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/CompiledCodeObject.java
@@ -240,6 +240,7 @@ public final class CompiledCodeObject extends AbstractSqueakObjectWithClassAndHa
         this.internalHeader = internalHeader;
         this.literals = literals;
         this.bytes = bytes;
+        this.primitiveNodeOrNull = UNINITIALIZED_PRIMITIVE_NODE;
         invalidateCallTargetStable("new literals and bytes");
     }
 
@@ -468,7 +469,13 @@ public final class CompiledCodeObject extends AbstractSqueakObjectWithClassAndHa
         if (index < offset) {
             throw PrimitiveFailed.BAD_INDEX;
         } else {
-            bytes[(int) index - offset] = (byte) value;
+            final int byteIndex = (int) index - offset;
+            final boolean canHavePrimitive = hasPrimitive() && bytes.length >= 3;
+            final int oldPrimitiveIndex = canHavePrimitive ? primitiveIndex() : -1;
+            bytes[byteIndex] = (byte) value;
+            if (canHavePrimitive && oldPrimitiveIndex != primitiveIndex()) {
+                primitiveNodeOrNull = UNINITIALIZED_PRIMITIVE_NODE;
+            }
             invalidateCallTarget();
         }
     }
@@ -727,8 +734,12 @@ public final class CompiledCodeObject extends AbstractSqueakObjectWithClassAndHa
 
     public void setHeader(final long value) {
         final int oldNumLiterals = getNumLiterals();
+        final boolean oldHasPrimitive = hasPrimitive();
         internalHeader = CompiledCodeHeaderUtils.fromSmallIntegerValue(value);
         assert getNumLiterals() == oldNumLiterals;
+        if (oldHasPrimitive && !hasPrimitive()) {
+            primitiveNodeOrNull = UNINITIALIZED_PRIMITIVE_NODE;
+        }
         invalidateCallTarget();
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/LookupMethodNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/LookupMethodNode.java
@@ -47,6 +47,6 @@ public abstract class LookupMethodNode extends AbstractNode {
         if (cachedEntry.getResult() == null) {
             cachedEntry.setResult(classObject.lookupInMethodDictSlow(selector));
         }
-        return cachedEntry.getResult(); /* `null` return signals a doesNotUnderstand. */
+        return cachedEntry.getResult(); /* `null` return signals DNU or CI. */
     }
 }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/accessing/ClassObjectNodes.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/accessing/ClassObjectNodes.java
@@ -33,8 +33,8 @@ public final class ClassObjectNodes {
         }
 
         @Specialization(guards = {"isMethodDictIndex(index)"})
-        protected static final VariablePointersObject doClassMethodDict(final ClassObject obj, @SuppressWarnings("unused") final long index) {
-            return obj.getMethodDict();
+        protected static final AbstractSqueakObject doClassMethodDict(final ClassObject obj, @SuppressWarnings("unused") final long index) {
+            return obj.getMethodDictOrNil();
         }
 
         @Specialization(guards = {"isFormatIndex(index)"})
@@ -69,6 +69,11 @@ public final class ClassObjectNodes {
         @Specialization(guards = "isMethodDictIndex(index)")
         protected static final void doClassMethodDict(final ClassObject obj, @SuppressWarnings("unused") final long index, final VariablePointersObject value) {
             obj.setMethodDict(value);
+        }
+
+        @Specialization(guards = "isMethodDictIndex(index)")
+        protected static final void doClassMethodDict(final ClassObject obj, @SuppressWarnings("unused") final long index, @SuppressWarnings("unused") final NilObject value) {
+            obj.setMethodDict(null);
         }
 
         @Specialization(guards = "isFormatIndex(index)")

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/CreateMessageNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/CreateMessageNode.java
@@ -20,7 +20,7 @@ import de.hpi.swa.trufflesqueak.nodes.accessing.AbstractPointersObjectNodes.Abst
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectClassNode;
 
 @GenerateInline(false)
-abstract class CreateDoesNotUnderstandMessageNode extends AbstractNode {
+abstract class CreateMessageNode extends AbstractNode {
     public abstract PointersObject execute(NativeObject selector, Object receiver, Object[] arguments);
 
     @Specialization

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector0Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector0Node.java
@@ -29,7 +29,6 @@ import com.oracle.truffle.api.profiles.InlinedBranchProfile;
 import com.oracle.truffle.api.profiles.InlinedConditionProfile;
 
 import de.hpi.swa.trufflesqueak.exceptions.PrimitiveFailed;
-import de.hpi.swa.trufflesqueak.exceptions.SqueakExceptions.SqueakException;
 import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
 import de.hpi.swa.trufflesqueak.model.AbstractSqueakObject;
 import de.hpi.swa.trufflesqueak.model.ClassObject;
@@ -102,9 +101,7 @@ public final class DispatchSelector0Node extends DispatchSelectorNode {
         public static final DispatchDirect0Node create(final NativeObject selector, final ClassObject lookupClass, final boolean canPrimFail) {
             final Object lookupResult = lookupClass.lookupInMethodDictSlow(selector);
             final Assumption[] assumptions = DispatchUtils.createAssumptions(lookupClass, lookupResult);
-            if (lookupResult == null) {
-                return createDNUNode(selector, assumptions, lookupClass);
-            } else if (lookupResult instanceof final CompiledCodeObject lookupMethod) {
+            if (lookupResult instanceof final CompiledCodeObject lookupMethod) {
                 if (lookupMethod.getNumArgs() == 0) {
                     return create(assumptions, lookupMethod);
                 } else {
@@ -115,6 +112,8 @@ public final class DispatchSelector0Node extends DispatchSelectorNode {
                         return create(assumptions, lookupMethod);
                     }
                 }
+            } else if (lookupResult == null) {
+                return createMessageFallbackNode(selector, assumptions, lookupClass);
             } else {
                 final ClassObject lookupResultClass = SqueakObjectClassNode.executeUncached(lookupResult);
                 final Object runWithInLookupResult = LookupMethodNode.executeUncached(lookupResultClass, SqueakImageContext.getSlow().runWithInSelector);
@@ -122,7 +121,7 @@ public final class DispatchSelector0Node extends DispatchSelectorNode {
                     return new DispatchDirectObjectAsMethod0Node(assumptions, selector, runWithInMethod, lookupResult);
                 } else {
                     assert runWithInLookupResult == null : "runWithInLookupResult should not be another Object";
-                    return createDNUNode(selector, assumptions, lookupResultClass);
+                    return createMessageFallbackNode(selector, assumptions, lookupResultClass);
                 }
             }
         }
@@ -139,13 +138,9 @@ public final class DispatchSelector0Node extends DispatchSelectorNode {
             return new DispatchDirectMethod0Node(assumptions, method);
         }
 
-        private static DispatchDirectDoesNotUnderstand0Node createDNUNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
-            final Object dnuLookupResult = receiverClass.lookupInMethodDictSlow(SqueakImageContext.getSlow().doesNotUnderstand);
-            if (dnuLookupResult instanceof final CompiledCodeObject dnuMethod) {
-                return new DispatchDirectDoesNotUnderstand0Node(assumptions, selector, dnuMethod);
-            } else {
-                throw SqueakException.create("Unable to find DNU method in", receiverClass);
-            }
+        private static DispatchDirectMessageFallback0Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
+            final CompiledCodeObject fallbackMethod = receiverClass.resolveDispatchFailure(selector);
+            return new DispatchDirectMessageFallback0Node(assumptions, selector, fallbackMethod);
         }
     }
 
@@ -224,12 +219,12 @@ public final class DispatchSelector0Node extends DispatchSelectorNode {
         }
     }
 
-    static final class DispatchDirectDoesNotUnderstand0Node extends DispatchDirectWithSender0Node {
+    static final class DispatchDirectMessageFallback0Node extends DispatchDirectWithSender0Node {
         private final NativeObject selector;
         @Child private DirectCallNode callNode;
-        @Child private CreateDoesNotUnderstandMessageNode createDNUMessageNode = CreateDoesNotUnderstandMessageNodeGen.create();
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
 
-        DispatchDirectDoesNotUnderstand0Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+        DispatchDirectMessageFallback0Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
             super(assumptions);
             this.selector = selector;
             callNode = DirectCallNode.create(dnuMethod.getCallTarget());
@@ -237,7 +232,8 @@ public final class DispatchSelector0Node extends DispatchSelectorNode {
 
         @Override
         public Object execute(final VirtualFrame frame, final Object receiver) {
-            return callNode.call(FrameAccess.newDNUWith(senderNode.execute(frame), receiver, createDNUMessageNode.execute(selector, receiver, ArrayUtils.EMPTY_ARRAY)));
+            final PointersObject message = createMessageNode.execute(selector, receiver, ArrayUtils.EMPTY_ARRAY);
+            return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
         }
     }
 
@@ -275,7 +271,7 @@ public final class DispatchSelector0Node extends DispatchSelectorNode {
             CompilerAsserts.partialEvaluationConstant(canPrimFail);
             final ClassObject receiverClass = classNode.executeLookup(node, receiver);
             final Object lookupResult = getContext(node).lookup(receiverClass, selector);
-            final CompiledCodeObject method = methodNode.execute(node, getContext(node), 0, canPrimFail, receiverClass, lookupResult);
+            final CompiledCodeObject method = methodNode.execute(node, getContext(node), 0, canPrimFail, selector, receiverClass, lookupResult);
             final Object result = tryPrimitiveNode.execute(frame, method, receiver);
             if (result != null) {
                 return result;
@@ -347,12 +343,12 @@ public final class DispatchSelector0Node extends DispatchSelectorNode {
             }
 
             @Specialization(guards = "lookupResult == null")
-            protected static final Object[] doDoesNotUnderstand(final Node node, final AbstractSqueakObject sender, final Object receiver, final ClassObject receiverClass,
+            protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final ClassObject receiverClass,
                             @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
                             @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode) {
                 final Object[] arguments = ArrayUtils.EMPTY_ARRAY;
                 final PointersObject message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
-                return FrameAccess.newDNUWith(sender, receiver, message);
+                return FrameAccess.newMessageFallbackWith(sender, receiver, message);
             }
 
             @Specialization(guards = {"targetObject != null", "!isCompiledCodeObject(targetObject)"})

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector1Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector1Node.java
@@ -29,7 +29,6 @@ import com.oracle.truffle.api.profiles.InlinedBranchProfile;
 import com.oracle.truffle.api.profiles.InlinedConditionProfile;
 
 import de.hpi.swa.trufflesqueak.exceptions.PrimitiveFailed;
-import de.hpi.swa.trufflesqueak.exceptions.SqueakExceptions.SqueakException;
 import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
 import de.hpi.swa.trufflesqueak.model.AbstractSqueakObject;
 import de.hpi.swa.trufflesqueak.model.ClassObject;
@@ -101,9 +100,7 @@ public final class DispatchSelector1Node extends DispatchSelectorNode {
         public static final DispatchDirect1Node create(final NativeObject selector, final ClassObject lookupClass, final boolean canPrimFail) {
             final Object lookupResult = lookupClass.lookupInMethodDictSlow(selector);
             final Assumption[] assumptions = DispatchUtils.createAssumptions(lookupClass, lookupResult);
-            if (lookupResult == null) {
-                return createDNUNode(selector, assumptions, lookupClass);
-            } else if (lookupResult instanceof final CompiledCodeObject lookupMethod) {
+            if (lookupResult instanceof final CompiledCodeObject lookupMethod) {
                 if (lookupMethod.getNumArgs() == 1) {
                     return create(assumptions, lookupMethod);
                 } else {
@@ -114,6 +111,8 @@ public final class DispatchSelector1Node extends DispatchSelectorNode {
                         return create(assumptions, lookupMethod);
                     }
                 }
+            } else if (lookupResult == null) {
+                return createMessageFallbackNode(selector, assumptions, lookupClass);
             } else {
                 final ClassObject lookupResultClass = SqueakObjectClassNode.executeUncached(lookupResult);
                 final Object runWithInLookupResult = LookupMethodNode.executeUncached(lookupResultClass, SqueakImageContext.getSlow().runWithInSelector);
@@ -121,7 +120,7 @@ public final class DispatchSelector1Node extends DispatchSelectorNode {
                     return new DispatchDirectObjectAsMethod1Node(assumptions, selector, runWithInMethod, lookupResult);
                 } else {
                     assert runWithInLookupResult == null : "runWithInLookupResult should not be another Object";
-                    return createDNUNode(selector, assumptions, lookupResultClass);
+                    return createMessageFallbackNode(selector, assumptions, lookupResultClass);
                 }
             }
         }
@@ -138,13 +137,9 @@ public final class DispatchSelector1Node extends DispatchSelectorNode {
             return new DispatchDirectMethod1Node(assumptions, method);
         }
 
-        private static DispatchDirectDoesNotUnderstand1Node createDNUNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
-            final Object dnuLookupResult = receiverClass.lookupInMethodDictSlow(SqueakImageContext.getSlow().doesNotUnderstand);
-            if (dnuLookupResult instanceof final CompiledCodeObject dnuMethod) {
-                return new DispatchDirectDoesNotUnderstand1Node(assumptions, selector, dnuMethod);
-            } else {
-                throw SqueakException.create("Unable to find DNU method in", receiverClass);
-            }
+        private static DispatchDirectMessageFallback1Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
+            final CompiledCodeObject fallbackMethod = receiverClass.resolveDispatchFailure(selector);
+            return new DispatchDirectMessageFallback1Node(assumptions, selector, fallbackMethod);
         }
     }
 
@@ -223,12 +218,12 @@ public final class DispatchSelector1Node extends DispatchSelectorNode {
         }
     }
 
-    static final class DispatchDirectDoesNotUnderstand1Node extends DispatchDirectWithSender1Node {
+    static final class DispatchDirectMessageFallback1Node extends DispatchDirectWithSender1Node {
         private final NativeObject selector;
         @Child private DirectCallNode callNode;
-        @Child private CreateDoesNotUnderstandMessageNode createDNUMessageNode = CreateDoesNotUnderstandMessageNodeGen.create();
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
 
-        DispatchDirectDoesNotUnderstand1Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+        DispatchDirectMessageFallback1Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
             super(assumptions);
             this.selector = selector;
             callNode = DirectCallNode.create(dnuMethod.getCallTarget());
@@ -236,7 +231,8 @@ public final class DispatchSelector1Node extends DispatchSelectorNode {
 
         @Override
         public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1) {
-            return callNode.call(FrameAccess.newDNUWith(senderNode.execute(frame), receiver, createDNUMessageNode.execute(selector, receiver, new Object[]{arg1})));
+            final PointersObject message = createMessageNode.execute(selector, receiver, new Object[]{arg1});
+            return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
         }
     }
 
@@ -274,7 +270,7 @@ public final class DispatchSelector1Node extends DispatchSelectorNode {
             CompilerAsserts.partialEvaluationConstant(canPrimFail);
             final ClassObject receiverClass = classNode.executeLookup(node, receiver);
             final Object lookupResult = getContext(node).lookup(receiverClass, selector);
-            final CompiledCodeObject method = methodNode.execute(node, getContext(node), 1, canPrimFail, receiverClass, lookupResult);
+            final CompiledCodeObject method = methodNode.execute(node, getContext(node), 1, canPrimFail, selector, receiverClass, lookupResult);
             final Object result = tryPrimitiveNode.execute(frame, method, receiver, arg1);
             if (result != null) {
                 return result;
@@ -347,12 +343,12 @@ public final class DispatchSelector1Node extends DispatchSelectorNode {
             }
 
             @Specialization(guards = "lookupResult == null")
-            protected static final Object[] doDoesNotUnderstand(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final ClassObject receiverClass,
+            protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final ClassObject receiverClass,
                             @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
                             @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode) {
                 final Object[] arguments = new Object[]{arg1};
                 final PointersObject message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
-                return FrameAccess.newDNUWith(sender, receiver, message);
+                return FrameAccess.newMessageFallbackWith(sender, receiver, message);
             }
 
             @Specialization(guards = {"targetObject != null", "!isCompiledCodeObject(targetObject)"})

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector2Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector2Node.java
@@ -29,7 +29,6 @@ import com.oracle.truffle.api.profiles.InlinedBranchProfile;
 import com.oracle.truffle.api.profiles.InlinedConditionProfile;
 
 import de.hpi.swa.trufflesqueak.exceptions.PrimitiveFailed;
-import de.hpi.swa.trufflesqueak.exceptions.SqueakExceptions.SqueakException;
 import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
 import de.hpi.swa.trufflesqueak.model.AbstractSqueakObject;
 import de.hpi.swa.trufflesqueak.model.ClassObject;
@@ -101,9 +100,7 @@ public final class DispatchSelector2Node extends DispatchSelectorNode {
         public static final DispatchDirect2Node create(final NativeObject selector, final ClassObject lookupClass, final boolean canPrimFail) {
             final Object lookupResult = lookupClass.lookupInMethodDictSlow(selector);
             final Assumption[] assumptions = DispatchUtils.createAssumptions(lookupClass, lookupResult);
-            if (lookupResult == null) {
-                return createDNUNode(selector, assumptions, lookupClass);
-            } else if (lookupResult instanceof final CompiledCodeObject lookupMethod) {
+            if (lookupResult instanceof final CompiledCodeObject lookupMethod) {
                 if (lookupMethod.getNumArgs() == 2) {
                     return create(assumptions, lookupMethod);
                 } else {
@@ -114,6 +111,8 @@ public final class DispatchSelector2Node extends DispatchSelectorNode {
                         return create(assumptions, lookupMethod);
                     }
                 }
+            } else if (lookupResult == null) {
+                return createMessageFallbackNode(selector, assumptions, lookupClass);
             } else {
                 final ClassObject lookupResultClass = SqueakObjectClassNode.executeUncached(lookupResult);
                 final Object runWithInLookupResult = LookupMethodNode.executeUncached(lookupResultClass, SqueakImageContext.getSlow().runWithInSelector);
@@ -121,7 +120,7 @@ public final class DispatchSelector2Node extends DispatchSelectorNode {
                     return new DispatchDirectObjectAsMethod2Node(assumptions, selector, runWithInMethod, lookupResult);
                 } else {
                     assert runWithInLookupResult == null : "runWithInLookupResult should not be another Object";
-                    return createDNUNode(selector, assumptions, lookupResultClass);
+                    return createMessageFallbackNode(selector, assumptions, lookupResultClass);
                 }
             }
         }
@@ -138,13 +137,9 @@ public final class DispatchSelector2Node extends DispatchSelectorNode {
             return new DispatchDirectMethod2Node(assumptions, method);
         }
 
-        private static DispatchDirectDoesNotUnderstand2Node createDNUNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
-            final Object dnuLookupResult = receiverClass.lookupInMethodDictSlow(SqueakImageContext.getSlow().doesNotUnderstand);
-            if (dnuLookupResult instanceof final CompiledCodeObject dnuMethod) {
-                return new DispatchDirectDoesNotUnderstand2Node(assumptions, selector, dnuMethod);
-            } else {
-                throw SqueakException.create("Unable to find DNU method in", receiverClass);
-            }
+        private static DispatchDirectMessageFallback2Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
+            final CompiledCodeObject fallbackMethod = receiverClass.resolveDispatchFailure(selector);
+            return new DispatchDirectMessageFallback2Node(assumptions, selector, fallbackMethod);
         }
     }
 
@@ -223,12 +218,12 @@ public final class DispatchSelector2Node extends DispatchSelectorNode {
         }
     }
 
-    static final class DispatchDirectDoesNotUnderstand2Node extends DispatchDirectWithSender2Node {
+    static final class DispatchDirectMessageFallback2Node extends DispatchDirectWithSender2Node {
         private final NativeObject selector;
         @Child private DirectCallNode callNode;
-        @Child private CreateDoesNotUnderstandMessageNode createDNUMessageNode = CreateDoesNotUnderstandMessageNodeGen.create();
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
 
-        DispatchDirectDoesNotUnderstand2Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+        DispatchDirectMessageFallback2Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
             super(assumptions);
             this.selector = selector;
             callNode = DirectCallNode.create(dnuMethod.getCallTarget());
@@ -236,7 +231,8 @@ public final class DispatchSelector2Node extends DispatchSelectorNode {
 
         @Override
         public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2) {
-            return callNode.call(FrameAccess.newDNUWith(senderNode.execute(frame), receiver, createDNUMessageNode.execute(selector, receiver, new Object[]{arg1, arg2})));
+            final PointersObject message = createMessageNode.execute(selector, receiver, new Object[]{arg1, arg2});
+            return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
         }
     }
 
@@ -274,7 +270,7 @@ public final class DispatchSelector2Node extends DispatchSelectorNode {
             CompilerAsserts.partialEvaluationConstant(canPrimFail);
             final ClassObject receiverClass = classNode.executeLookup(node, receiver);
             final Object lookupResult = getContext(node).lookup(receiverClass, selector);
-            final CompiledCodeObject method = methodNode.execute(node, getContext(node), 2, canPrimFail, receiverClass, lookupResult);
+            final CompiledCodeObject method = methodNode.execute(node, getContext(node), 2, canPrimFail, selector, receiverClass, lookupResult);
             final Object result = tryPrimitiveNode.execute(frame, method, receiver, arg1, arg2);
             if (result != null) {
                 return result;
@@ -347,13 +343,13 @@ public final class DispatchSelector2Node extends DispatchSelectorNode {
             }
 
             @Specialization(guards = "lookupResult == null")
-            protected static final Object[] doDoesNotUnderstand(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final Object arg2,
+            protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final Object arg2,
                             final ClassObject receiverClass,
                             @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
                             @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode) {
                 final Object[] arguments = new Object[]{arg1, arg2};
                 final PointersObject message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
-                return FrameAccess.newDNUWith(sender, receiver, message);
+                return FrameAccess.newMessageFallbackWith(sender, receiver, message);
             }
 
             @Specialization(guards = {"targetObject != null", "!isCompiledCodeObject(targetObject)"})

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector3Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector3Node.java
@@ -28,7 +28,6 @@ import com.oracle.truffle.api.profiles.InlinedBranchProfile;
 import com.oracle.truffle.api.profiles.InlinedConditionProfile;
 
 import de.hpi.swa.trufflesqueak.exceptions.PrimitiveFailed;
-import de.hpi.swa.trufflesqueak.exceptions.SqueakExceptions.SqueakException;
 import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
 import de.hpi.swa.trufflesqueak.model.AbstractSqueakObject;
 import de.hpi.swa.trufflesqueak.model.ClassObject;
@@ -72,9 +71,7 @@ public final class DispatchSelector3Node extends DispatchSelectorNode {
         public static final DispatchDirect3Node create(final NativeObject selector, final ClassObject lookupClass, final boolean canPrimFail) {
             final Object lookupResult = lookupClass.lookupInMethodDictSlow(selector);
             final Assumption[] assumptions = DispatchUtils.createAssumptions(lookupClass, lookupResult);
-            if (lookupResult == null) {
-                return createDNUNode(selector, assumptions, lookupClass);
-            } else if (lookupResult instanceof final CompiledCodeObject lookupMethod) {
+            if (lookupResult instanceof final CompiledCodeObject lookupMethod) {
                 if (lookupMethod.getNumArgs() == 3) {
                     return create(assumptions, lookupMethod);
                 } else {
@@ -85,6 +82,8 @@ public final class DispatchSelector3Node extends DispatchSelectorNode {
                         return create(assumptions, lookupMethod);
                     }
                 }
+            } else if (lookupResult == null) {
+                return createMessageFallbackNode(selector, assumptions, lookupClass);
             } else {
                 final ClassObject lookupResultClass = SqueakObjectClassNode.executeUncached(lookupResult);
                 final Object runWithInLookupResult = LookupMethodNode.executeUncached(lookupResultClass, SqueakImageContext.getSlow().runWithInSelector);
@@ -92,7 +91,7 @@ public final class DispatchSelector3Node extends DispatchSelectorNode {
                     return new DispatchDirectObjectAsMethod3Node(assumptions, selector, runWithInMethod, lookupResult);
                 } else {
                     assert runWithInLookupResult == null : "runWithInLookupResult should not be another Object";
-                    return createDNUNode(selector, assumptions, lookupResultClass);
+                    return createMessageFallbackNode(selector, assumptions, lookupResultClass);
                 }
             }
         }
@@ -109,13 +108,9 @@ public final class DispatchSelector3Node extends DispatchSelectorNode {
             return new DispatchDirectMethod3Node(assumptions, method);
         }
 
-        private static DispatchDirectDoesNotUnderstand3Node createDNUNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
-            final Object dnuLookupResult = receiverClass.lookupInMethodDictSlow(SqueakImageContext.getSlow().doesNotUnderstand);
-            if (dnuLookupResult instanceof final CompiledCodeObject dnuMethod) {
-                return new DispatchDirectDoesNotUnderstand3Node(assumptions, selector, dnuMethod);
-            } else {
-                throw SqueakException.create("Unable to find DNU method in", receiverClass);
-            }
+        private static DispatchDirectMessageFallback3Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
+            final CompiledCodeObject fallbackMethod = receiverClass.resolveDispatchFailure(selector);
+            return new DispatchDirectMessageFallback3Node(assumptions, selector, fallbackMethod);
         }
     }
 
@@ -194,12 +189,12 @@ public final class DispatchSelector3Node extends DispatchSelectorNode {
         }
     }
 
-    static final class DispatchDirectDoesNotUnderstand3Node extends DispatchDirectWithSender3Node {
+    static final class DispatchDirectMessageFallback3Node extends DispatchDirectWithSender3Node {
         private final NativeObject selector;
         @Child private DirectCallNode callNode;
-        @Child private CreateDoesNotUnderstandMessageNode createDNUMessageNode = CreateDoesNotUnderstandMessageNodeGen.create();
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
 
-        DispatchDirectDoesNotUnderstand3Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+        DispatchDirectMessageFallback3Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
             super(assumptions);
             this.selector = selector;
             callNode = DirectCallNode.create(dnuMethod.getCallTarget());
@@ -207,7 +202,8 @@ public final class DispatchSelector3Node extends DispatchSelectorNode {
 
         @Override
         public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3) {
-            return callNode.call(FrameAccess.newDNUWith(senderNode.execute(frame), receiver, createDNUMessageNode.execute(selector, receiver, new Object[]{arg1, arg2, arg3})));
+            final PointersObject message = createMessageNode.execute(selector, receiver, new Object[]{arg1, arg2, arg3});
+            return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
         }
     }
 
@@ -246,7 +242,7 @@ public final class DispatchSelector3Node extends DispatchSelectorNode {
             CompilerAsserts.partialEvaluationConstant(canPrimFail);
             final ClassObject receiverClass = classNode.executeLookup(node, receiver);
             final Object lookupResult = getContext(node).lookup(receiverClass, selector);
-            final CompiledCodeObject method = methodNode.execute(node, getContext(node), 3, canPrimFail, receiverClass, lookupResult);
+            final CompiledCodeObject method = methodNode.execute(node, getContext(node), 3, canPrimFail, selector, receiverClass, lookupResult);
             final Object result = tryPrimitiveNode.execute(frame, method, receiver, arg1, arg2, arg3);
             if (result != null) {
                 return result;
@@ -321,12 +317,12 @@ public final class DispatchSelector3Node extends DispatchSelectorNode {
             }
 
             @Specialization(guards = "lookupResult == null")
-            protected static final Object[] doDoesNotUnderstand(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final Object arg2, final Object arg3,
+            protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final Object arg2, final Object arg3,
                             final ClassObject receiverClass, @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
                             @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode) {
                 final Object[] arguments = new Object[]{arg1, arg2, arg3};
                 final PointersObject message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
-                return FrameAccess.newDNUWith(sender, receiver, message);
+                return FrameAccess.newMessageFallbackWith(sender, receiver, message);
             }
 
             @Specialization(guards = {"targetObject != null", "!isCompiledCodeObject(targetObject)"})

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector4Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector4Node.java
@@ -28,7 +28,6 @@ import com.oracle.truffle.api.profiles.InlinedBranchProfile;
 import com.oracle.truffle.api.profiles.InlinedConditionProfile;
 
 import de.hpi.swa.trufflesqueak.exceptions.PrimitiveFailed;
-import de.hpi.swa.trufflesqueak.exceptions.SqueakExceptions.SqueakException;
 import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
 import de.hpi.swa.trufflesqueak.model.AbstractSqueakObject;
 import de.hpi.swa.trufflesqueak.model.ClassObject;
@@ -72,9 +71,7 @@ public final class DispatchSelector4Node extends DispatchSelectorNode {
         public static final DispatchDirect4Node create(final NativeObject selector, final ClassObject lookupClass, final boolean canPrimFail) {
             final Object lookupResult = lookupClass.lookupInMethodDictSlow(selector);
             final Assumption[] assumptions = DispatchUtils.createAssumptions(lookupClass, lookupResult);
-            if (lookupResult == null) {
-                return createDNUNode(selector, assumptions, lookupClass);
-            } else if (lookupResult instanceof final CompiledCodeObject lookupMethod) {
+            if (lookupResult instanceof final CompiledCodeObject lookupMethod) {
                 if (lookupMethod.getNumArgs() == 4) {
                     return create(assumptions, lookupMethod);
                 } else {
@@ -85,6 +82,8 @@ public final class DispatchSelector4Node extends DispatchSelectorNode {
                         return create(assumptions, lookupMethod);
                     }
                 }
+            } else if (lookupResult == null) {
+                return createMessageFallbackNode(selector, assumptions, lookupClass);
             } else {
                 final ClassObject lookupResultClass = SqueakObjectClassNode.executeUncached(lookupResult);
                 final Object runWithInLookupResult = LookupMethodNode.executeUncached(lookupResultClass, SqueakImageContext.getSlow().runWithInSelector);
@@ -92,7 +91,7 @@ public final class DispatchSelector4Node extends DispatchSelectorNode {
                     return new DispatchDirectObjectAsMethod4Node(assumptions, selector, runWithInMethod, lookupResult);
                 } else {
                     assert runWithInLookupResult == null : "runWithInLookupResult should not be another Object";
-                    return createDNUNode(selector, assumptions, lookupResultClass);
+                    return createMessageFallbackNode(selector, assumptions, lookupResultClass);
                 }
             }
         }
@@ -109,13 +108,9 @@ public final class DispatchSelector4Node extends DispatchSelectorNode {
             return new DispatchDirectMethod4Node(assumptions, method);
         }
 
-        private static DispatchDirectDoesNotUnderstand4Node createDNUNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
-            final Object dnuLookupResult = receiverClass.lookupInMethodDictSlow(SqueakImageContext.getSlow().doesNotUnderstand);
-            if (dnuLookupResult instanceof final CompiledCodeObject dnuMethod) {
-                return new DispatchDirectDoesNotUnderstand4Node(assumptions, selector, dnuMethod);
-            } else {
-                throw SqueakException.create("Unable to find DNU method in", receiverClass);
-            }
+        private static DispatchDirectMessageFallback4Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
+            final CompiledCodeObject fallbackMethod = receiverClass.resolveDispatchFailure(selector);
+            return new DispatchDirectMessageFallback4Node(assumptions, selector, fallbackMethod);
         }
     }
 
@@ -195,12 +190,12 @@ public final class DispatchSelector4Node extends DispatchSelectorNode {
         }
     }
 
-    static final class DispatchDirectDoesNotUnderstand4Node extends DispatchDirectWithSender4Node {
+    static final class DispatchDirectMessageFallback4Node extends DispatchDirectWithSender4Node {
         private final NativeObject selector;
         @Child private DirectCallNode callNode;
-        @Child private CreateDoesNotUnderstandMessageNode createDNUMessageNode = CreateDoesNotUnderstandMessageNodeGen.create();
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
 
-        DispatchDirectDoesNotUnderstand4Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+        DispatchDirectMessageFallback4Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
             super(assumptions);
             this.selector = selector;
             callNode = DirectCallNode.create(dnuMethod.getCallTarget());
@@ -208,7 +203,8 @@ public final class DispatchSelector4Node extends DispatchSelectorNode {
 
         @Override
         public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4) {
-            return callNode.call(FrameAccess.newDNUWith(senderNode.execute(frame), receiver, createDNUMessageNode.execute(selector, receiver, new Object[]{arg1, arg2, arg3, arg4})));
+            final PointersObject message = createMessageNode.execute(selector, receiver, new Object[]{arg1, arg2, arg3, arg4});
+            return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
         }
     }
 
@@ -247,7 +243,7 @@ public final class DispatchSelector4Node extends DispatchSelectorNode {
             CompilerAsserts.partialEvaluationConstant(canPrimFail);
             final ClassObject receiverClass = classNode.executeLookup(node, receiver);
             final Object lookupResult = getContext(node).lookup(receiverClass, selector);
-            final CompiledCodeObject method = methodNode.execute(node, getContext(node), 4, canPrimFail, receiverClass, lookupResult);
+            final CompiledCodeObject method = methodNode.execute(node, getContext(node), 4, canPrimFail, selector, receiverClass, lookupResult);
             final Object result = tryPrimitiveNode.execute(frame, method, receiver, arg1, arg2, arg3, arg4);
             if (result != null) {
                 return result;
@@ -323,12 +319,12 @@ public final class DispatchSelector4Node extends DispatchSelectorNode {
             }
 
             @Specialization(guards = "lookupResult == null")
-            protected static final Object[] doDoesNotUnderstand(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final Object arg2, final Object arg3,
+            protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final Object arg2, final Object arg3,
                             final Object arg4, final ClassObject receiverClass, @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
                             @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode) {
                 final Object[] arguments = new Object[]{arg1, arg2, arg3, arg4};
                 final PointersObject message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
-                return FrameAccess.newDNUWith(sender, receiver, message);
+                return FrameAccess.newMessageFallbackWith(sender, receiver, message);
             }
 
             @Specialization(guards = {"targetObject != null", "!isCompiledCodeObject(targetObject)"})

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector5Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector5Node.java
@@ -28,7 +28,6 @@ import com.oracle.truffle.api.profiles.InlinedBranchProfile;
 import com.oracle.truffle.api.profiles.InlinedConditionProfile;
 
 import de.hpi.swa.trufflesqueak.exceptions.PrimitiveFailed;
-import de.hpi.swa.trufflesqueak.exceptions.SqueakExceptions.SqueakException;
 import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
 import de.hpi.swa.trufflesqueak.model.AbstractSqueakObject;
 import de.hpi.swa.trufflesqueak.model.ClassObject;
@@ -65,9 +64,7 @@ public final class DispatchSelector5Node extends DispatchSelectorNode {
         public static final DispatchDirect5Node create(final NativeObject selector, final ClassObject lookupClass, final boolean canPrimFail) {
             final Object lookupResult = lookupClass.lookupInMethodDictSlow(selector);
             final Assumption[] assumptions = DispatchUtils.createAssumptions(lookupClass, lookupResult);
-            if (lookupResult == null) {
-                return createDNUNode(selector, assumptions, lookupClass);
-            } else if (lookupResult instanceof final CompiledCodeObject lookupMethod) {
+            if (lookupResult instanceof final CompiledCodeObject lookupMethod) {
                 if (lookupMethod.getNumArgs() == 5) {
                     return create(assumptions, lookupMethod);
                 } else {
@@ -78,6 +75,8 @@ public final class DispatchSelector5Node extends DispatchSelectorNode {
                         return create(assumptions, lookupMethod);
                     }
                 }
+            } else if (lookupResult == null) {
+                return createMessageFallbackNode(selector, assumptions, lookupClass);
             } else {
                 final ClassObject lookupResultClass = SqueakObjectClassNode.executeUncached(lookupResult);
                 final Object runWithInLookupResult = LookupMethodNode.executeUncached(lookupResultClass, SqueakImageContext.getSlow().runWithInSelector);
@@ -85,7 +84,7 @@ public final class DispatchSelector5Node extends DispatchSelectorNode {
                     return new DispatchDirectObjectAsMethod5Node(assumptions, selector, runWithInMethod, lookupResult);
                 } else {
                     assert runWithInLookupResult == null : "runWithInLookupResult should not be another Object";
-                    return createDNUNode(selector, assumptions, lookupResultClass);
+                    return createMessageFallbackNode(selector, assumptions, lookupResultClass);
                 }
             }
         }
@@ -102,13 +101,9 @@ public final class DispatchSelector5Node extends DispatchSelectorNode {
             return new DispatchDirectMethod5Node(assumptions, method);
         }
 
-        private static DispatchDirectDoesNotUnderstand5Node createDNUNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
-            final Object dnuLookupResult = receiverClass.lookupInMethodDictSlow(SqueakImageContext.getSlow().doesNotUnderstand);
-            if (dnuLookupResult instanceof final CompiledCodeObject dnuMethod) {
-                return new DispatchDirectDoesNotUnderstand5Node(assumptions, selector, dnuMethod);
-            } else {
-                throw SqueakException.create("Unable to find DNU method in", receiverClass);
-            }
+        private static DispatchDirectMessageFallback5Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
+            final CompiledCodeObject fallbackMethod = receiverClass.resolveDispatchFailure(selector);
+            return new DispatchDirectMessageFallback5Node(assumptions, selector, fallbackMethod);
         }
     }
 
@@ -188,12 +183,12 @@ public final class DispatchSelector5Node extends DispatchSelectorNode {
         }
     }
 
-    static final class DispatchDirectDoesNotUnderstand5Node extends DispatchDirectWithSender5Node {
+    static final class DispatchDirectMessageFallback5Node extends DispatchDirectWithSender5Node {
         private final NativeObject selector;
         @Child private DirectCallNode callNode;
-        @Child private CreateDoesNotUnderstandMessageNode createDNUMessageNode = CreateDoesNotUnderstandMessageNodeGen.create();
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
 
-        DispatchDirectDoesNotUnderstand5Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+        DispatchDirectMessageFallback5Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
             super(assumptions);
             this.selector = selector;
             callNode = DirectCallNode.create(dnuMethod.getCallTarget());
@@ -201,7 +196,8 @@ public final class DispatchSelector5Node extends DispatchSelectorNode {
 
         @Override
         public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5) {
-            return callNode.call(FrameAccess.newDNUWith(senderNode.execute(frame), receiver, createDNUMessageNode.execute(selector, receiver, new Object[]{arg1, arg2, arg3, arg4, arg5})));
+            final PointersObject message = createMessageNode.execute(selector, receiver, new Object[]{arg1, arg2, arg3, arg4, arg5});
+            return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
         }
     }
 
@@ -240,7 +236,7 @@ public final class DispatchSelector5Node extends DispatchSelectorNode {
             CompilerAsserts.partialEvaluationConstant(canPrimFail);
             final ClassObject receiverClass = classNode.executeLookup(node, receiver);
             final Object lookupResult = getContext(node).lookup(receiverClass, selector);
-            final CompiledCodeObject method = methodNode.execute(node, getContext(node), 5, canPrimFail, receiverClass, lookupResult);
+            final CompiledCodeObject method = methodNode.execute(node, getContext(node), 5, canPrimFail, selector, receiverClass, lookupResult);
             final Object result = tryPrimitiveNode.execute(frame, method, receiver, arg1, arg2, arg3, arg4, arg5);
             if (result != null) {
                 return result;
@@ -318,12 +314,12 @@ public final class DispatchSelector5Node extends DispatchSelectorNode {
             }
 
             @Specialization(guards = "lookupResult == null")
-            protected static final Object[] doDoesNotUnderstand(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final Object arg2, final Object arg3,
+            protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final Object arg2, final Object arg3,
                             final Object arg4, final Object arg5, final ClassObject receiverClass, @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
                             @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode) {
                 final Object[] arguments = new Object[]{arg1, arg2, arg3, arg4, arg5};
                 final PointersObject message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
-                return FrameAccess.newDNUWith(sender, receiver, message);
+                return FrameAccess.newMessageFallbackWith(sender, receiver, message);
             }
 
             @Specialization(guards = {"targetObject != null", "!isCompiledCodeObject(targetObject)"})

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
@@ -160,10 +160,10 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
         public static final DispatchDirectNaryNode create(final NativeObject selector, final ClassObject lookupClass) {
             final Object lookupResult = lookupClass.lookupInMethodDictSlow(selector);
             final Assumption[] assumptions = DispatchUtils.createAssumptions(lookupClass, lookupResult);
-            if (lookupResult == null) {
-                return createDNUNode(selector, assumptions, lookupClass);
-            } else if (lookupResult instanceof final CompiledCodeObject lookupMethod) {
+            if (lookupResult instanceof final CompiledCodeObject lookupMethod) {
                 return create(assumptions, lookupMethod);
+            } else if (lookupResult == null) {
+                return createMessageFallbackNode(selector, assumptions, lookupClass);
             } else {
                 final ClassObject lookupResultClass = SqueakObjectClassNode.executeUncached(lookupResult);
                 final Object runWithInLookupResult = LookupMethodNode.executeUncached(lookupResultClass, SqueakImageContext.getSlow().runWithInSelector);
@@ -171,7 +171,7 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
                     return new DispatchDirectObjectAsMethodNaryNode(assumptions, selector, runWithInMethod, lookupResult);
                 } else {
                     assert runWithInLookupResult == null : "runWithInLookupResult should not be another Object";
-                    return createDNUNode(selector, assumptions, lookupResultClass);
+                    return createMessageFallbackNode(selector, assumptions, lookupResultClass);
                 }
             }
         }
@@ -188,13 +188,9 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
             return new DispatchDirectMethodNaryNode(assumptions, method);
         }
 
-        private static DispatchDirectDoesNotUnderstandNaryNode createDNUNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
-            final Object dnuLookupResult = receiverClass.lookupInMethodDictSlow(SqueakImageContext.getSlow().doesNotUnderstand);
-            if (dnuLookupResult instanceof final CompiledCodeObject dnuMethod) {
-                return new DispatchDirectDoesNotUnderstandNaryNode(assumptions, selector, dnuMethod);
-            } else {
-                throw SqueakException.create("Unable to find DNU method in", receiverClass);
-            }
+        private static DispatchDirectMessageFallbackNaryNode createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
+            final CompiledCodeObject fallbackMethod = receiverClass.resolveDispatchFailure(selector);
+            return new DispatchDirectMessageFallbackNaryNode(assumptions, selector, fallbackMethod);
         }
     }
 
@@ -493,12 +489,12 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
         }
     }
 
-    static final class DispatchDirectDoesNotUnderstandNaryNode extends DispatchDirectWithSenderNaryNode {
+    static final class DispatchDirectMessageFallbackNaryNode extends DispatchDirectWithSenderNaryNode {
         private final NativeObject selector;
         @Child private DirectCallNode callNode;
-        @Child private CreateDoesNotUnderstandMessageNode createDNUMessageNode = CreateDoesNotUnderstandMessageNodeGen.create();
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
 
-        DispatchDirectDoesNotUnderstandNaryNode(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+        DispatchDirectMessageFallbackNaryNode(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
             super(assumptions);
             this.selector = selector;
             callNode = DirectCallNode.create(dnuMethod.getCallTarget());
@@ -511,7 +507,8 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
 
         @Override
         public Object execute(final VirtualFrame frame, final Object receiver, final Object[] arguments) {
-            return callNode.call(FrameAccess.newDNUWith(senderNode.execute(frame), receiver, createDNUMessageNode.execute(selector, receiver, arguments)));
+            final PointersObject message = createMessageNode.execute(selector, receiver, arguments);
+            return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
         }
     }
 
@@ -554,7 +551,7 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
             CompilerAsserts.partialEvaluationConstant(canPrimFail);
             final ClassObject receiverClass = classNode.executeLookup(node, receiver);
             final Object lookupResult = getContext(node).lookup(receiverClass, selector);
-            final CompiledCodeObject method = methodNode.execute(node, getContext(node), arguments.length, canPrimFail, receiverClass, lookupResult);
+            final CompiledCodeObject method = methodNode.execute(node, getContext(node), arguments.length, canPrimFail, selector, receiverClass, lookupResult);
             final Object result = tryPrimitiveNode.execute(frame, method, receiver, arguments);
             if (result != null) {
                 return result;
@@ -633,11 +630,11 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
             }
 
             @Specialization(guards = "lookupResult == null")
-            protected static final Object[] doDoesNotUnderstand(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object[] arguments, final ClassObject receiverClass,
+            protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object[] arguments, final ClassObject receiverClass,
                             @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
                             @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode) {
                 final PointersObject message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
-                return FrameAccess.newDNUWith(sender, receiver, message);
+                return FrameAccess.newMessageFallbackWith(sender, receiver, message);
             }
 
             @Specialization(guards = {"targetObject != null", "!isCompiledCodeObject(targetObject)"})

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/ResolveMethodNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/ResolveMethodNode.java
@@ -15,7 +15,6 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
 
 import de.hpi.swa.trufflesqueak.exceptions.PrimitiveFailed;
-import de.hpi.swa.trufflesqueak.exceptions.SqueakExceptions.SqueakException;
 import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
 import de.hpi.swa.trufflesqueak.model.ClassObject;
 import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
@@ -28,11 +27,12 @@ import de.hpi.swa.trufflesqueak.util.MethodCacheEntry;
 @GenerateCached(false)
 public abstract class ResolveMethodNode extends AbstractNode {
 
-    public abstract CompiledCodeObject execute(Node node, SqueakImageContext image, int expectedNumArgs, boolean canPrimFail, ClassObject receiverClass, Object lookupResult);
+    public abstract CompiledCodeObject execute(Node node, SqueakImageContext image, int expectedNumArgs, boolean canPrimFail, NativeObject selector, ClassObject receiverClass, Object lookupResult);
 
     @Specialization
     @SuppressWarnings("unused")
-    protected static final CompiledCodeObject doMethod(final SqueakImageContext image, final int expectedNumArgs, final boolean canPrimFail, final ClassObject receiverClass,
+    protected static final CompiledCodeObject doMethod(final SqueakImageContext image, final int expectedNumArgs, final boolean canPrimFail, final NativeObject selector,
+                    final ClassObject receiverClass,
                     final CompiledCodeObject method) {
         CompilerAsserts.partialEvaluationConstant(canPrimFail);
         if (method.getNumArgs() != expectedNumArgs) {
@@ -48,38 +48,38 @@ public abstract class ResolveMethodNode extends AbstractNode {
 
     @SuppressWarnings("unused")
     @Specialization(guards = "lookupResult == null")
-    protected static final CompiledCodeObject doDoesNotUnderstand(final SqueakImageContext image, final int expectedNumArgs, final boolean canPrimFail, final ClassObject receiverClass,
+    protected static final CompiledCodeObject doDispatchFailure(final SqueakImageContext image, final int expectedNumArgs, final boolean canPrimFail, final NativeObject selector,
+                    final ClassObject receiverClass,
                     final Object lookupResult) {
-        final Object dnuMethod = lookupMethod(image, receiverClass, image.doesNotUnderstand);
-        if (dnuMethod instanceof final CompiledCodeObject method) {
-            assert method.getNumArgs() == 1 : "#doesNotUnderstand: with unexpected number of arguments, got " + method.getNumArgs();
-            return method;
-        } else {
-            throw SqueakException.create("Unable to find #doesNotUnderstand: in", receiverClass);
-        }
+
+        final MethodCacheEntry cacheEntry = image.findMethodCacheEntry(receiverClass, selector);
+        final CompiledCodeObject fallbackMethod = cacheEntry.getOrCreateFallbackMethod();
+
+        assert fallbackMethod.getNumArgs() == 1 : "Fallback method with unexpected number of arguments, got " + fallbackMethod.getNumArgs();
+        return fallbackMethod;
     }
 
     @SuppressWarnings("unused")
     @Specialization(guards = {"targetObject != null", "!isCompiledCodeObject(targetObject)"})
-    protected static final CompiledCodeObject doObjectAsMethod(final Node node, final SqueakImageContext image, final int expectedNumArgs, final boolean canPrimFail, final ClassObject receiverClass,
+    protected static final CompiledCodeObject doObjectAsMethod(final Node node, final SqueakImageContext image, final int expectedNumArgs, final boolean canPrimFail, final NativeObject selector,
+                    final ClassObject receiverClass,
                     final Object targetObject,
                     @Cached final SqueakObjectClassNode classNode) {
         final ClassObject targetObjectClass = classNode.executeLookup(node, targetObject);
-        final Object runWithInMethod = lookupMethod(image, targetObjectClass, image.runWithInSelector);
-        if (runWithInMethod instanceof final CompiledCodeObject method) {
-            assert method.getNumArgs() == 3 : "#run:with:in: with unexpected number of arguments, got " + method.getNumArgs();
-            return method;
-        } else {
-            assert runWithInMethod == null : "#run:with:in: should not be another Object";
-            return doDoesNotUnderstand(image, 2, false, targetObjectClass, null);
-        }
-    }
 
-    private static Object lookupMethod(final SqueakImageContext image, final ClassObject classObject, final NativeObject selector) {
-        final MethodCacheEntry cachedEntry = image.findMethodCacheEntry(classObject, selector);
-        if (cachedEntry.getResult() == null) {
-            cachedEntry.setResult(classObject.lookupInMethodDictSlow(selector));
+        final MethodCacheEntry oamCacheEntry = image.findMethodCacheEntry(targetObjectClass, image.runWithInSelector);
+        if (oamCacheEntry.getResult() == null) {
+            oamCacheEntry.setResult(targetObjectClass.lookupMethodInMethodDictSlow(image.runWithInSelector));
         }
-        return cachedEntry.getResult(); /* `null` return signals a doesNotUnderstand. */
+
+        if (oamCacheEntry.getResult() instanceof final CompiledCodeObject runWithInMethod) {
+            assert runWithInMethod.getNumArgs() == 3 : "#run:with:in: with unexpected number of arguments, got " + runWithInMethod.getNumArgs();
+            return runWithInMethod;
+        } else {
+            // Target object doesn't understand run:with:in: (or it resolved to another non-method
+            // object),
+            // so we fall back to unified DNU.
+            return doDispatchFailure(image, 3, false, image.runWithInSelector, targetObjectClass, null);
+        }
     }
 }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/ResolveMethodNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/ResolveMethodNode.java
@@ -51,10 +51,8 @@ public abstract class ResolveMethodNode extends AbstractNode {
     protected static final CompiledCodeObject doDispatchFailure(final SqueakImageContext image, final int expectedNumArgs, final boolean canPrimFail, final NativeObject selector,
                     final ClassObject receiverClass,
                     final Object lookupResult) {
-
         final MethodCacheEntry cacheEntry = image.findMethodCacheEntry(receiverClass, selector);
         final CompiledCodeObject fallbackMethod = cacheEntry.getOrCreateFallbackMethod();
-
         assert fallbackMethod.getNumArgs() == 1 : "Fallback method with unexpected number of arguments, got " + fallbackMethod.getNumArgs();
         return fallbackMethod;
     }
@@ -76,9 +74,10 @@ public abstract class ResolveMethodNode extends AbstractNode {
             assert runWithInMethod.getNumArgs() == 3 : "#run:with:in: with unexpected number of arguments, got " + runWithInMethod.getNumArgs();
             return runWithInMethod;
         } else {
-            // Target object doesn't understand run:with:in: (or it resolved to another non-method
-            // object),
-            // so we fall back to unified DNU.
+            /*
+             * Target object doesn't understand run:with:in: (or it resolved to another non-method
+             * object), so we fall back to unified DNU.
+             */
             return doDispatchFailure(image, 3, false, image.runWithInSelector, targetObjectClass, null);
         }
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ControlPrimitives.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ControlPrimitives.java
@@ -483,7 +483,7 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
                         final GetOrCreateContextWithoutFrameNode senderNode, final CreateFrameArgumentsForIndirectCallNaryNode argumentsNode, final IndirectCallNode callNode, final Node node) {
             if (inheritsFromNode.execute(node, receiver, lookupClass)) {
                 final Object lookupResult = getContext(node).lookup(lookupClass, selector);
-                final CompiledCodeObject method = methodNode.execute(node, getContext(node), sizeNode.execute(node, arguments), true, lookupClass, lookupResult);
+                final CompiledCodeObject method = methodNode.execute(node, getContext(node), sizeNode.execute(node, arguments), true, selector, lookupClass, lookupResult);
                 final Object callArguments = argumentsNode.execute(node, senderNode.execute(frame, node), receiver, getObjectArrayNode.execute(node, arguments), lookupClass, lookupResult, selector);
                 return callNode.call(method.getCallTarget(), callArguments);
             } else {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/FrameAccess.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/FrameAccess.java
@@ -503,7 +503,7 @@ public final class FrameAccess {
         return frameArguments;
     }
 
-    public static Object[] newDNUWith(final AbstractSqueakObject sender, final Object receiver, final PointersObject message) {
+    public static Object[] newMessageFallbackWith(final AbstractSqueakObject sender, final Object receiver, final PointersObject message) {
         return newWith(sender, null, receiver, message);
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/MethodCacheEntry.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/MethodCacheEntry.java
@@ -33,10 +33,14 @@ public final class MethodCacheEntry {
 
     public CompiledCodeObject getOrCreateFallbackMethod() {
         if (fallbackMethod == null) {
-            CompilerDirectives.transferToInterpreter();
-            fallbackMethod = classObject.resolveDispatchFailure(selector);
+            fallbackMethod = createFallbackMethod();
         }
         return fallbackMethod;
+    }
+
+    @CompilerDirectives.TruffleBoundary
+    private CompiledCodeObject createFallbackMethod() {
+        return classObject.resolveDispatchFailure(selector);
     }
 
     public void setResult(final Object object) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/MethodCacheEntry.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/MethodCacheEntry.java
@@ -8,13 +8,16 @@ package de.hpi.swa.trufflesqueak.util;
 
 import com.oracle.truffle.api.CompilerAsserts;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import de.hpi.swa.trufflesqueak.model.ClassObject;
+import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
 import de.hpi.swa.trufflesqueak.model.NativeObject;
 
 public final class MethodCacheEntry {
     private ClassObject classObject;
     private NativeObject selector;
     private Object result;
+    private CompiledCodeObject fallbackMethod;
 
     public ClassObject getClassObject() {
         return classObject;
@@ -28,19 +31,30 @@ public final class MethodCacheEntry {
         return result;
     }
 
+    public CompiledCodeObject getOrCreateFallbackMethod() {
+        if (fallbackMethod == null) {
+            CompilerDirectives.transferToInterpreter();
+            fallbackMethod = classObject.resolveDispatchFailure(selector);
+        }
+        return fallbackMethod;
+    }
+
     public void setResult(final Object object) {
         result = object;
+        fallbackMethod = null;
     }
 
     public void freeAndRelease() {
         selector = null; /* Mark it free. */
         result = null; /* Release the method. */
+        fallbackMethod = null;
     }
 
     public MethodCacheEntry reuseFor(final ClassObject lookupClass, final NativeObject lookupSelector) {
         classObject = lookupClass;
         selector = lookupSelector;
         result = null;
+        fallbackMethod = null;
         return this;
     }
 


### PR DESCRIPTION
Unify the handling of missing selectors (`#doesNotUnderstand:`) and missing method dictionaries (`#cannotInterpret:`) into a single fallback path.

`ClassObject#lookupInMethodDictSlow` now returns Java null on either structural failure. `resolveDispatchFailure(selector)` is used to walk the superclass chain and resolve the correct fallback method.

Added support for setting `methodDict` to nil or a MethodDictionary from Smalltalk.

Modifying `superclass` or `methodDict` now triggers a global method cache flush.

Flushing `#doesNotUnderstand:` or `#cannotInterpret:` now explicitly clears the entire global cache to prevent stale fallbacks.

`CompiledCodeObject`now invalidates its cached `primitiveNodeOrNull` if its headers or primitive-declaration bytecodes are mutated.