### PR TITLE
Enhance Dispatch Failure Robustness and Performance

### DIFF
--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.logging.Level;
 
 import de.hpi.swa.trufflesqueak.util.DebugUtils;
+import org.graalvm.collections.EconomicMap;
 import org.graalvm.collections.UnmodifiableEconomicMap;
 
 import com.oracle.truffle.api.Assumption;
@@ -155,6 +156,7 @@ public final class SqueakImageContext {
     private static final int METHOD_CACHE_REPROBES = 4;
     private int methodCacheRandomish;
     @CompilationFinal(dimensions = 1) private final MethodCacheEntry[] methodCache = new MethodCacheEntry[METHOD_CACHE_SIZE];
+    private final EconomicMap<NativeObject, CyclicAssumption> absentSelectorAssumptions = EconomicMap.create();
 
     /* Interpreter state */
     private int primFailCode = -1;
@@ -234,8 +236,6 @@ public final class SqueakImageContext {
         }
         assert homePath != null && homePath.exists() : "Home directory does not exist: " + homePath;
         initializeMethodCache();
-
-        DebugUtils.registerContext(this);
     }
 
     public static SqueakImageContext get(final Node node) {
@@ -646,7 +646,39 @@ public final class SqueakImageContext {
         }
     }
 
+    @TruffleBoundary
+    public Assumption getAbsentSelectorAssumption(final NativeObject selector) {
+        CyclicAssumption absentAssumption = absentSelectorAssumptions.get(selector);
+        if (absentAssumption == null) {
+            absentAssumption = new CyclicAssumption("Absent selector globally: " + selector.asStringUnsafe());
+            absentSelectorAssumptions.put(selector, absentAssumption);
+        }
+        return absentAssumption.getAssumption();
+    }
+
+    @TruffleBoundary
+    private void invalidateAllAbsentSelectorAssumptions() {
+        for (final CyclicAssumption absentAssumption : absentSelectorAssumptions.getValues()) {
+            absentAssumption.invalidate("Fallback method (DNU/CI) shadowed or modified");
+        }
+        absentSelectorAssumptions.clear();
+    }
+
+    @TruffleBoundary
+    private void invalidateAbsentSelectorAssumption(final NativeObject selector) {
+        if (selector == doesNotUnderstand || selector == cannotInterpretSelector) {
+            invalidateAllAbsentSelectorAssumptions();
+            return;
+        }
+        final CyclicAssumption absentAssumption = absentSelectorAssumptions.get(selector);
+        if (absentAssumption != null) {
+            absentAssumption.invalidate("Absent selector flushed globally");
+            absentSelectorAssumptions.removeKey(selector);
+        }
+    }
+
     public void flushCachesForSelector(final NativeObject selector) {
+        invalidateAbsentSelectorAssumption(selector);
         flushCachesForSelectorInClassTable(selector);
         flushMethodCacheForSelector(selector);
     }
@@ -1045,10 +1077,6 @@ public final class SqueakImageContext {
 
     /* Clear cache entries for selector (prim 119). */
     private void flushMethodCacheForSelector(final NativeObject selector) {
-        if (selector == doesNotUnderstand || selector == cannotInterpretSelector) {
-            flushMethodCache();
-            return;
-        }
         for (int i = 0; i < METHOD_CACHE_SIZE; i++) {
             if (methodCache[i].getSelector() == selector) {
                 methodCache[i].freeAndRelease();

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
@@ -118,7 +118,7 @@ public final class SqueakImageContext {
     @CompilationFinal private ClassObject doubleByteArrayClass;
     @CompilationFinal private ClassObject wordArrayClass;
     @CompilationFinal private ClassObject doubleWordArrayClass;
-    public final NativeObject cannotInterpretSelector = new NativeObject(); // TODO: use selector
+    public final NativeObject cannotInterpretSelector = new NativeObject();
     public final ClassObject blockClosureClass = new ClassObject(this);
     @CompilationFinal private ClassObject fullBlockClosureClass;
     public final ClassObject largeNegativeIntegerClass = new ClassObject(this);
@@ -149,6 +149,11 @@ public final class SqueakImageContext {
                     CompiledCodeHeaderUtils.makeHeaderWord(true, 0, 0, 0, true, true),
                     ArrayUtils.EMPTY_ARRAY, compiledMethodClass);
     public final VirtualFrame externalSenderFrame = Truffle.getRuntime().createVirtualFrame(FrameAccess.newWith(NilObject.SINGLETON, null, NilObject.SINGLETON), dummyMethod.getFrameDescriptor());
+
+    // The maximum message arity that supports DNU shortcuts.
+    public static final int MAX_DNU_SHORTCUT_ARITY = 3;
+
+    @CompilationFinal(dimensions = 1) private NativeObject[] dnuShortcutSelectors = new NativeObject[0];
 
     /* Method Cache */
     private static final int METHOD_CACHE_SIZE = 2 << 12;
@@ -420,6 +425,19 @@ public final class SqueakImageContext {
 
     public boolean toggleCurrentMarkingFlag() {
         return currentMarkingFlag = !currentMarkingFlag;
+    }
+
+    public NativeObject getDNUShortcutSelector(final int arity) {
+        if (0 <= arity && arity < dnuShortcutSelectors.length) {
+            return dnuShortcutSelectors[arity];
+        }
+        return null;
+    }
+
+    public void setDNUShortcutSelectors(final NativeObject[] newSelectors) {
+        CompilerDirectives.transferToInterpreterAndInvalidate();
+        dnuShortcutSelectors = newSelectors;
+        flushMethodCache();
     }
 
     /* SpurMemoryManager>>#setHiddenRootsObj: */
@@ -1070,6 +1088,7 @@ public final class SqueakImageContext {
 
     /* Clear all cache entries (prim 89). */
     public void flushMethodCache() {
+        invalidateAllAbsentSelectorAssumptions();
         for (int i = 0; i < METHOD_CACHE_SIZE; i++) {
             methodCache[i].freeAndRelease();
         }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
@@ -440,6 +440,15 @@ public final class SqueakImageContext {
         flushMethodCache();
     }
 
+    private boolean isDNUShortcutSelector(final NativeObject selector) {
+        for (final NativeObject shortcutSelector : dnuShortcutSelectors) {
+            if (selector == shortcutSelector) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /* SpurMemoryManager>>#setHiddenRootsObj: */
     public void setHiddenRoots(final ArrayObject theHiddenRoots) {
         assert hiddenRoots == null && (theHiddenRoots.isObjectType() || isTesting());
@@ -684,21 +693,11 @@ public final class SqueakImageContext {
 
     @TruffleBoundary
     private void invalidateAbsentSelectorAssumption(final NativeObject selector) {
-        if (selector == doesNotUnderstand || selector == cannotInterpretSelector) {
-            invalidateAllAbsentSelectorAssumptions();
-            return;
-        }
         final CyclicAssumption absentAssumption = absentSelectorAssumptions.get(selector);
         if (absentAssumption != null) {
             absentAssumption.invalidate("Absent selector flushed globally");
             absentSelectorAssumptions.removeKey(selector);
         }
-    }
-
-    public void flushCachesForSelector(final NativeObject selector) {
-        invalidateAbsentSelectorAssumption(selector);
-        flushCachesForSelectorInClassTable(selector);
-        flushMethodCacheForSelector(selector);
     }
 
     public TruffleFile getHomePath() {
@@ -1095,6 +1094,19 @@ public final class SqueakImageContext {
     }
 
     /* Clear cache entries for selector (prim 119). */
+    public void flushCachesForSelector(final NativeObject selector) {
+        if (selector == doesNotUnderstand || selector == cannotInterpretSelector || isDNUShortcutSelector(selector)) {
+            // A core fallback changed. Invalidate the entire method cache to ensure
+            // no missing selectors are holding onto the stale fallback method.
+            flushMethodCache();
+            flushCachesForSelectorInClassTable(selector);
+        } else {
+            invalidateAbsentSelectorAssumption(selector);
+            flushCachesForSelectorInClassTable(selector);
+            flushMethodCacheForSelector(selector);
+        }
+    }
+
     private void flushMethodCacheForSelector(final NativeObject selector) {
         for (int i = 0; i < METHOD_CACHE_SIZE; i++) {
             if (methodCache[i].getSelector() == selector) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ClassObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ClassObject.java
@@ -36,6 +36,20 @@ import de.hpi.swa.trufflesqueak.util.ObjectGraphUtils.ObjectTracer;
  */
 @SuppressWarnings("static-method")
 public final class ClassObject extends AbstractSqueakObjectWithClassAndHash {
+    public enum FallbackConvention {
+        CANNOT_INTERPRET, // Use #cannotInterpret: and build nested Message objects
+        STANDARD_DNU,     // Use #doesNotUnderstand: and build a Message object
+        SHORTCUT_DNU      // Use #dnu...: and pass arguments and selector directly (no Message
+                          // object)
+    }
+
+    public record DispatchFailureResult(
+                    CompiledCodeObject fallbackMethod,
+                    int fallbackDepth,
+                    FallbackConvention convention,
+                    NativeObject fallbackSelector) {
+    }
+
     @CompilationFinal private CyclicAssumption classHierarchyAndMethodDictStable;
     @CompilationFinal private CyclicAssumption classFormatStable;
 
@@ -466,9 +480,10 @@ public final class ClassObject extends AbstractSqueakObjectWithClassAndHash {
      * @throws SqueakException if the fallback method cannot be found (fatal VM error).
      */
     @TruffleBoundary
-    public CompiledCodeObject resolveDispatchFailure(final NativeObject originalSelector) {
+    public DispatchFailureResult resolveDispatchFailure(final NativeObject originalSelector, final int arity) {
         CompilerAsserts.neverPartOfCompilation();
-        // Walk superclass chain to determine if #cannotInterpret:.
+
+        // Walk superclass chain to determine if this is a #cannotInterpret: case.
         ClassObject current = this;
         while (current != null) {
             assert current.assertNotForwarded();
@@ -478,31 +493,47 @@ public final class ClassObject extends AbstractSqueakObjectWithClassAndHash {
             current = current.getSuperclassOrNull();
         }
 
-        // If the walk terminates with null, we have a DNU.
+        // --- DNU Path (No nil method dictionaries) ---
         if (current == null) {
             assert originalSelector != image.doesNotUnderstand : "Fatal dispatch error: Recursive doesNotUnderstand:";
 
+            // Attempt the Shortcut DNU first
+            final NativeObject shortcutSelector = image.getDNUShortcutSelector(arity);
+            if (shortcutSelector != null) {
+                final CompiledCodeObject shortcutMethod = lookupMethodInMethodDictSlow(shortcutSelector);
+                if (shortcutMethod != null) {
+                    return new DispatchFailureResult(shortcutMethod, 1, FallbackConvention.SHORTCUT_DNU, shortcutSelector);
+                }
+            }
+
+            // Fall back to standard #doesNotUnderstand:
             final CompiledCodeObject dnuMethod = lookupMethodInMethodDictSlow(image.doesNotUnderstand);
             if (dnuMethod != null) {
-                return dnuMethod;
+                return new DispatchFailureResult(dnuMethod, 1, FallbackConvention.STANDARD_DNU, image.doesNotUnderstand);
             } else {
                 throw SqueakException.create("Fatal dispatch error: #doesNotUnderstand: not found in", this);
             }
-        } else {
-            // Search for #cannotInterpret: starting in the superclass of the missing method
-            // dictionary class.
-            final ClassObject startingClass = current.getSuperclassOrNull();
-            if (startingClass == null) {
-                throw SqueakException.create("Fatal dispatch error: hit nil method dictionary in class with no superclass while sending", originalSelector);
-            }
-
-            final CompiledCodeObject ciMethod = startingClass.lookupMethodInMethodDictSlow(image.cannotInterpretSelector);
-            if (ciMethod != null) {
-                return ciMethod;
-            } else {
-                throw SqueakException.create("Fatal dispatch error: #cannotInterpret: not found in superclass chain of", current);
-            }
         }
+
+        // --- CannotInterpret Path (Hit a nil dictionary) ---
+        int depth = 1;
+        ClassObject searchClass = current.getSuperclassOrNull();
+        final NativeObject selector = image.cannotInterpretSelector;
+        final int messageSelectorHash = selector.getSqueakHashInt();
+
+        while (searchClass != null) {
+            if (searchClass.methodDict == null) {
+                depth++;
+            } else {
+                final Object result = lookupMethodInDictionary(searchClass.getResolvedMethodDict(), selector, messageSelectorHash);
+                if (result instanceof CompiledCodeObject ciMethod) {
+                    return new DispatchFailureResult(ciMethod, depth, FallbackConvention.CANNOT_INTERPRET, selector);
+                }
+            }
+            searchClass = searchClass.getSuperclassOrNull();
+        }
+
+        throw SqueakException.create("Fatal dispatch error: #cannotInterpret: not found in superclass chain of", this);
     }
 
     /**

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ClassObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ClassObject.java
@@ -6,6 +6,7 @@
  */
 package de.hpi.swa.trufflesqueak.model;
 
+import de.hpi.swa.trufflesqueak.util.LogUtils;
 import org.graalvm.collections.UnmodifiableEconomicMap;
 
 import com.oracle.truffle.api.Assumption;
@@ -502,7 +503,12 @@ public final class ClassObject extends AbstractSqueakObjectWithClassAndHash {
             if (shortcutSelector != null) {
                 final CompiledCodeObject shortcutMethod = lookupMethodInMethodDictSlow(shortcutSelector);
                 if (shortcutMethod != null) {
-                    return new DispatchFailureResult(shortcutMethod, 1, FallbackConvention.SHORTCUT_DNU, shortcutSelector);
+                    if (shortcutMethod.getNumArgs() == arity + 1) {
+                        return new DispatchFailureResult(shortcutMethod, 1, FallbackConvention.SHORTCUT_DNU, shortcutSelector);
+                    } else {
+                        LogUtils.DEBUG.warning(() -> "Ignoring misconfigured DNU shortcut " + shortcutSelector.asStringUnsafe() +
+                                        ": expected " + (arity + 1) + " arguments, but got " + shortcutMethod.getNumArgs());
+                    }
                 }
             }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ClassObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ClassObject.java
@@ -48,7 +48,8 @@ public final class ClassObject extends AbstractSqueakObjectWithClassAndHash {
                     CompiledCodeObject fallbackMethod,
                     int fallbackDepth,
                     FallbackConvention convention,
-                    NativeObject fallbackSelector) {
+                    NativeObject fallbackSelector,
+                    int arity) {
     }
 
     @CompilationFinal private CyclicAssumption classHierarchyAndMethodDictStable;
@@ -504,7 +505,7 @@ public final class ClassObject extends AbstractSqueakObjectWithClassAndHash {
                 final CompiledCodeObject shortcutMethod = lookupMethodInMethodDictSlow(shortcutSelector);
                 if (shortcutMethod != null) {
                     if (shortcutMethod.getNumArgs() == arity + 1) {
-                        return new DispatchFailureResult(shortcutMethod, 1, FallbackConvention.SHORTCUT_DNU, shortcutSelector);
+                        return new DispatchFailureResult(shortcutMethod, 1, FallbackConvention.SHORTCUT_DNU, shortcutSelector, arity);
                     } else {
                         LogUtils.DEBUG.warning(() -> "Ignoring misconfigured DNU shortcut " + shortcutSelector.asStringUnsafe() +
                                         ": expected " + (arity + 1) + " arguments, but got " + shortcutMethod.getNumArgs());
@@ -515,7 +516,7 @@ public final class ClassObject extends AbstractSqueakObjectWithClassAndHash {
             // Fall back to standard #doesNotUnderstand:
             final CompiledCodeObject dnuMethod = lookupMethodInMethodDictSlow(image.doesNotUnderstand);
             if (dnuMethod != null) {
-                return new DispatchFailureResult(dnuMethod, 1, FallbackConvention.STANDARD_DNU, image.doesNotUnderstand);
+                return new DispatchFailureResult(dnuMethod, 1, FallbackConvention.STANDARD_DNU, image.doesNotUnderstand, arity);
             } else {
                 throw SqueakException.create("Fatal dispatch error: #doesNotUnderstand: not found in", this);
             }
@@ -533,7 +534,7 @@ public final class ClassObject extends AbstractSqueakObjectWithClassAndHash {
             } else {
                 final Object result = lookupMethodInDictionary(searchClass.getResolvedMethodDict(), selector, messageSelectorHash);
                 if (result instanceof CompiledCodeObject ciMethod) {
-                    return new DispatchFailureResult(ciMethod, depth, FallbackConvention.CANNOT_INTERPRET, selector);
+                    return new DispatchFailureResult(ciMethod, depth, FallbackConvention.CANNOT_INTERPRET, selector, arity);
                 }
             }
             searchClass = searchClass.getSuperclassOrNull();

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/CompiledCodeObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/CompiledCodeObject.java
@@ -737,7 +737,7 @@ public final class CompiledCodeObject extends AbstractSqueakObjectWithClassAndHa
         final boolean oldHasPrimitive = hasPrimitive();
         internalHeader = CompiledCodeHeaderUtils.fromSmallIntegerValue(value);
         assert getNumLiterals() == oldNumLiterals;
-        if (oldHasPrimitive && !hasPrimitive()) {
+        if (oldHasPrimitive != hasPrimitive()) {
             primitiveNodeOrNull = UNINITIALIZED_PRIMITIVE_NODE;
         }
         invalidateCallTarget();

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector0Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector0Node.java
@@ -140,7 +140,8 @@ public final class DispatchSelector0Node extends DispatchSelectorNode {
 
         private static DispatchDirectMessageFallback0Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
             final CompiledCodeObject fallbackMethod = receiverClass.resolveDispatchFailure(selector);
-            return new DispatchDirectMessageFallback0Node(assumptions, selector, fallbackMethod);
+            final Assumption[] finalAssumptions = DispatchUtils.getAssumptionsForMessageFallback(assumptions, selector, fallbackMethod);
+            return new DispatchDirectMessageFallback0Node(finalAssumptions, selector, fallbackMethod);
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector0Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector0Node.java
@@ -138,10 +138,15 @@ public final class DispatchSelector0Node extends DispatchSelectorNode {
             return new DispatchDirectMethod0Node(assumptions, method);
         }
 
-        private static DispatchDirectMessageFallback0Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
-            final CompiledCodeObject fallbackMethod = receiverClass.resolveDispatchFailure(selector);
-            final Assumption[] finalAssumptions = DispatchUtils.getAssumptionsForMessageFallback(assumptions, selector, fallbackMethod);
-            return new DispatchDirectMessageFallback0Node(finalAssumptions, selector, fallbackMethod);
+        private static DispatchDirect0Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
+            final ClassObject.DispatchFailureResult result = receiverClass.resolveDispatchFailure(selector, 0);
+            final Assumption[] finalAssumptions = DispatchUtils.getAssumptionsForMessageFallback(assumptions, selector, result.fallbackMethod());
+
+            return switch (result.convention()) {
+                case SHORTCUT_DNU -> new DispatchDirectShortcutFallback0Node(finalAssumptions, selector, result.fallbackMethod());
+                case STANDARD_DNU -> new DispatchDirectDNUFallback0Node(finalAssumptions, selector, result.fallbackMethod());
+                case CANNOT_INTERPRET -> new DispatchDirectCannotInterpretFallback0Node(finalAssumptions, selector, result.fallbackMethod(), result.fallbackDepth(), result.fallbackSelector());
+            };
         }
     }
 
@@ -220,21 +225,68 @@ public final class DispatchSelector0Node extends DispatchSelectorNode {
         }
     }
 
-    static final class DispatchDirectMessageFallback0Node extends DispatchDirectWithSender0Node {
-        private final NativeObject selector;
-        @Child private DirectCallNode callNode;
-        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+    abstract static class AbstractDispatchDirectFallback0Node extends DispatchDirectWithSender0Node {
+        protected final NativeObject selector;
+        @Child protected DirectCallNode callNode;
 
-        DispatchDirectMessageFallback0Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+        AbstractDispatchDirectFallback0Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject targetMethod) {
             super(assumptions);
             this.selector = selector;
-            callNode = DirectCallNode.create(dnuMethod.getCallTarget());
+            this.callNode = DirectCallNode.create(targetMethod.getCallTarget());
+        }
+
+        @Override
+        public abstract Object execute(VirtualFrame frame, Object receiver);
+    }
+
+    static final class DispatchDirectDNUFallback0Node extends AbstractDispatchDirectFallback0Node {
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectDNUFallback0Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+            super(assumptions, selector, dnuMethod);
         }
 
         @Override
         public Object execute(final VirtualFrame frame, final Object receiver) {
             final PointersObject message = createMessageNode.execute(selector, receiver, ArrayUtils.EMPTY_ARRAY);
             return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
+        }
+    }
+
+    static final class DispatchDirectCannotInterpretFallback0Node extends AbstractDispatchDirectFallback0Node {
+        private final int fallbackDepth;
+        private final NativeObject ciSelector;
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectCannotInterpretFallback0Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject ciMethod, final int fallbackDepth,
+                        final NativeObject ciSelector) {
+            super(assumptions, selector, ciMethod);
+            this.fallbackDepth = fallbackDepth;
+            this.ciSelector = ciSelector;
+        }
+
+        @Override
+        public Object execute(final VirtualFrame frame, final Object receiver) {
+            final PointersObject message = DispatchUtils.buildNestedMessage(
+                            createMessageNode,
+                            selector,
+                            ciSelector,
+                            receiver,
+                            ArrayUtils.EMPTY_ARRAY,
+                            fallbackDepth);
+            return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
+        }
+    }
+
+    static final class DispatchDirectShortcutFallback0Node extends AbstractDispatchDirectFallback0Node {
+
+        DispatchDirectShortcutFallback0Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject shortcutMethod) {
+            super(assumptions, selector, shortcutMethod);
+        }
+
+        @Override
+        public Object execute(final VirtualFrame frame, final Object receiver) {
+            return callNode.call(FrameAccess.newWith(senderNode.execute(frame), null, receiver, selector));
         }
     }
 
@@ -273,7 +325,14 @@ public final class DispatchSelector0Node extends DispatchSelectorNode {
             final ClassObject receiverClass = classNode.executeLookup(node, receiver);
             final Object lookupResult = getContext(node).lookup(receiverClass, selector);
             final CompiledCodeObject method = methodNode.execute(node, getContext(node), 0, canPrimFail, selector, receiverClass, lookupResult);
-            final Object result = tryPrimitiveNode.execute(frame, method, receiver);
+
+            final Object result;
+            if (lookupResult instanceof CompiledCodeObject) {
+                result = tryPrimitiveNode.execute(frame, method, receiver);
+            } else {
+                result = null;
+            }
+
             if (result != null) {
                 return result;
             } else {
@@ -346,9 +405,21 @@ public final class DispatchSelector0Node extends DispatchSelectorNode {
             @Specialization(guards = "lookupResult == null")
             protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final ClassObject receiverClass,
                             @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
-                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode) {
+                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(0);
+
+                if (result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU) {
+                    return FrameAccess.newWith(sender, null, receiver, selector);
+                }
+
                 final Object[] arguments = ArrayUtils.EMPTY_ARRAY;
-                final PointersObject message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                final PointersObject message;
+                if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
+                    message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
+                } else {
+                    message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                }
                 return FrameAccess.newMessageFallbackWith(sender, receiver, message);
             }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector1Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector1Node.java
@@ -137,10 +137,15 @@ public final class DispatchSelector1Node extends DispatchSelectorNode {
             return new DispatchDirectMethod1Node(assumptions, method);
         }
 
-        private static DispatchDirectMessageFallback1Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
-            final CompiledCodeObject fallbackMethod = receiverClass.resolveDispatchFailure(selector);
-            final Assumption[] finalAssumptions = DispatchUtils.getAssumptionsForMessageFallback(assumptions, selector, fallbackMethod);
-            return new DispatchDirectMessageFallback1Node(finalAssumptions, selector, fallbackMethod);
+        private static DispatchDirect1Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
+            final ClassObject.DispatchFailureResult result = receiverClass.resolveDispatchFailure(selector, 1);
+            final Assumption[] finalAssumptions = DispatchUtils.getAssumptionsForMessageFallback(assumptions, selector, result.fallbackMethod());
+
+            return switch (result.convention()) {
+                case SHORTCUT_DNU -> new DispatchDirectShortcutFallback1Node(finalAssumptions, selector, result.fallbackMethod());
+                case STANDARD_DNU -> new DispatchDirectDNUFallback1Node(finalAssumptions, selector, result.fallbackMethod());
+                case CANNOT_INTERPRET -> new DispatchDirectCannotInterpretFallback1Node(finalAssumptions, selector, result.fallbackMethod(), result.fallbackDepth(), result.fallbackSelector());
+            };
         }
     }
 
@@ -219,21 +224,68 @@ public final class DispatchSelector1Node extends DispatchSelectorNode {
         }
     }
 
-    static final class DispatchDirectMessageFallback1Node extends DispatchDirectWithSender1Node {
-        private final NativeObject selector;
-        @Child private DirectCallNode callNode;
-        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+    abstract static class AbstractDispatchDirectFallback1Node extends DispatchDirectWithSender1Node {
+        protected final NativeObject selector;
+        @Child protected DirectCallNode callNode;
 
-        DispatchDirectMessageFallback1Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+        AbstractDispatchDirectFallback1Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject targetMethod) {
             super(assumptions);
             this.selector = selector;
-            callNode = DirectCallNode.create(dnuMethod.getCallTarget());
+            this.callNode = DirectCallNode.create(targetMethod.getCallTarget());
+        }
+
+        @Override
+        public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1);
+    }
+
+    static final class DispatchDirectDNUFallback1Node extends AbstractDispatchDirectFallback1Node {
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectDNUFallback1Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+            super(assumptions, selector, dnuMethod);
         }
 
         @Override
         public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1) {
             final PointersObject message = createMessageNode.execute(selector, receiver, new Object[]{arg1});
             return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
+        }
+    }
+
+    static final class DispatchDirectCannotInterpretFallback1Node extends AbstractDispatchDirectFallback1Node {
+        private final int fallbackDepth;
+        private final NativeObject ciSelector;
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectCannotInterpretFallback1Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject ciMethod, final int fallbackDepth,
+                        final NativeObject ciSelector) {
+            super(assumptions, selector, ciMethod);
+            this.fallbackDepth = fallbackDepth;
+            this.ciSelector = ciSelector;
+        }
+
+        @Override
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1) {
+            final PointersObject message = DispatchUtils.buildNestedMessage(
+                            createMessageNode,
+                            selector,
+                            ciSelector,
+                            receiver,
+                            new Object[]{arg1},
+                            fallbackDepth);
+            return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
+        }
+    }
+
+    static final class DispatchDirectShortcutFallback1Node extends AbstractDispatchDirectFallback1Node {
+
+        DispatchDirectShortcutFallback1Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject shortcutMethod) {
+            super(assumptions, selector, shortcutMethod);
+        }
+
+        @Override
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1) {
+            return callNode.call(FrameAccess.newWith(senderNode.execute(frame), null, receiver, arg1, selector));
         }
     }
 
@@ -272,7 +324,14 @@ public final class DispatchSelector1Node extends DispatchSelectorNode {
             final ClassObject receiverClass = classNode.executeLookup(node, receiver);
             final Object lookupResult = getContext(node).lookup(receiverClass, selector);
             final CompiledCodeObject method = methodNode.execute(node, getContext(node), 1, canPrimFail, selector, receiverClass, lookupResult);
-            final Object result = tryPrimitiveNode.execute(frame, method, receiver, arg1);
+
+            final Object result;
+            if (lookupResult instanceof CompiledCodeObject) {
+                result = tryPrimitiveNode.execute(frame, method, receiver, arg1);
+            } else {
+                result = null;
+            }
+
             if (result != null) {
                 return result;
             } else {
@@ -346,9 +405,21 @@ public final class DispatchSelector1Node extends DispatchSelectorNode {
             @Specialization(guards = "lookupResult == null")
             protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final ClassObject receiverClass,
                             @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
-                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode) {
+                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(1);
+
+                if (result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU) {
+                    return FrameAccess.newWith(sender, null, receiver, arg1, selector);
+                }
+
                 final Object[] arguments = new Object[]{arg1};
-                final PointersObject message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                final PointersObject message;
+                if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
+                    message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
+                } else {
+                    message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                }
                 return FrameAccess.newMessageFallbackWith(sender, receiver, message);
             }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector1Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector1Node.java
@@ -139,7 +139,8 @@ public final class DispatchSelector1Node extends DispatchSelectorNode {
 
         private static DispatchDirectMessageFallback1Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
             final CompiledCodeObject fallbackMethod = receiverClass.resolveDispatchFailure(selector);
-            return new DispatchDirectMessageFallback1Node(assumptions, selector, fallbackMethod);
+            final Assumption[] finalAssumptions = DispatchUtils.getAssumptionsForMessageFallback(assumptions, selector, fallbackMethod);
+            return new DispatchDirectMessageFallback1Node(finalAssumptions, selector, fallbackMethod);
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector2Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector2Node.java
@@ -137,10 +137,15 @@ public final class DispatchSelector2Node extends DispatchSelectorNode {
             return new DispatchDirectMethod2Node(assumptions, method);
         }
 
-        private static DispatchDirectMessageFallback2Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
-            final CompiledCodeObject fallbackMethod = receiverClass.resolveDispatchFailure(selector);
-            final Assumption[] finalAssumptions = DispatchUtils.getAssumptionsForMessageFallback(assumptions, selector, fallbackMethod);
-            return new DispatchDirectMessageFallback2Node(finalAssumptions, selector, fallbackMethod);
+        private static DispatchDirect2Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
+            final ClassObject.DispatchFailureResult result = receiverClass.resolveDispatchFailure(selector, 2);
+            final Assumption[] finalAssumptions = DispatchUtils.getAssumptionsForMessageFallback(assumptions, selector, result.fallbackMethod());
+
+            return switch (result.convention()) {
+                case SHORTCUT_DNU -> new DispatchDirectShortcutFallback2Node(finalAssumptions, selector, result.fallbackMethod());
+                case STANDARD_DNU -> new DispatchDirectDNUFallback2Node(finalAssumptions, selector, result.fallbackMethod());
+                case CANNOT_INTERPRET -> new DispatchDirectCannotInterpretFallback2Node(finalAssumptions, selector, result.fallbackMethod(), result.fallbackDepth(), result.fallbackSelector());
+            };
         }
     }
 
@@ -219,21 +224,68 @@ public final class DispatchSelector2Node extends DispatchSelectorNode {
         }
     }
 
-    static final class DispatchDirectMessageFallback2Node extends DispatchDirectWithSender2Node {
-        private final NativeObject selector;
-        @Child private DirectCallNode callNode;
-        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+    abstract static class AbstractDispatchDirectFallback2Node extends DispatchDirectWithSender2Node {
+        protected final NativeObject selector;
+        @Child protected DirectCallNode callNode;
 
-        DispatchDirectMessageFallback2Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+        AbstractDispatchDirectFallback2Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject targetMethod) {
             super(assumptions);
             this.selector = selector;
-            callNode = DirectCallNode.create(dnuMethod.getCallTarget());
+            this.callNode = DirectCallNode.create(targetMethod.getCallTarget());
+        }
+
+        @Override
+        public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2);
+    }
+
+    static final class DispatchDirectDNUFallback2Node extends AbstractDispatchDirectFallback2Node {
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectDNUFallback2Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+            super(assumptions, selector, dnuMethod);
         }
 
         @Override
         public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2) {
             final PointersObject message = createMessageNode.execute(selector, receiver, new Object[]{arg1, arg2});
             return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
+        }
+    }
+
+    static final class DispatchDirectCannotInterpretFallback2Node extends AbstractDispatchDirectFallback2Node {
+        private final int fallbackDepth;
+        private final NativeObject ciSelector;
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectCannotInterpretFallback2Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject ciMethod, final int fallbackDepth,
+                        final NativeObject ciSelector) {
+            super(assumptions, selector, ciMethod);
+            this.fallbackDepth = fallbackDepth;
+            this.ciSelector = ciSelector;
+        }
+
+        @Override
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2) {
+            final PointersObject message = DispatchUtils.buildNestedMessage(
+                            createMessageNode,
+                            selector,
+                            ciSelector,
+                            receiver,
+                            new Object[]{arg1, arg2},
+                            fallbackDepth);
+            return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
+        }
+    }
+
+    static final class DispatchDirectShortcutFallback2Node extends AbstractDispatchDirectFallback2Node {
+
+        DispatchDirectShortcutFallback2Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject shortcutMethod) {
+            super(assumptions, selector, shortcutMethod);
+        }
+
+        @Override
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2) {
+            return callNode.call(FrameAccess.newWith(senderNode.execute(frame), null, receiver, arg1, arg2, selector));
         }
     }
 
@@ -272,7 +324,14 @@ public final class DispatchSelector2Node extends DispatchSelectorNode {
             final ClassObject receiverClass = classNode.executeLookup(node, receiver);
             final Object lookupResult = getContext(node).lookup(receiverClass, selector);
             final CompiledCodeObject method = methodNode.execute(node, getContext(node), 2, canPrimFail, selector, receiverClass, lookupResult);
-            final Object result = tryPrimitiveNode.execute(frame, method, receiver, arg1, arg2);
+
+            final Object result;
+            if (lookupResult instanceof CompiledCodeObject) {
+                result = tryPrimitiveNode.execute(frame, method, receiver, arg1, arg2);
+            } else {
+                result = null;
+            }
+
             if (result != null) {
                 return result;
             } else {
@@ -347,9 +406,20 @@ public final class DispatchSelector2Node extends DispatchSelectorNode {
             protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final Object arg2,
                             final ClassObject receiverClass,
                             @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
-                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode) {
+                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(2);
+                if (result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU) {
+                    return FrameAccess.newWith(sender, null, receiver, arg1, arg2, selector);
+                }
+
                 final Object[] arguments = new Object[]{arg1, arg2};
-                final PointersObject message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                final PointersObject message;
+                if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
+                    message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
+                } else {
+                    message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                }
                 return FrameAccess.newMessageFallbackWith(sender, receiver, message);
             }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector2Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector2Node.java
@@ -129,7 +129,7 @@ public final class DispatchSelector2Node extends DispatchSelectorNode {
             assert checkArgumentCount(method, 2);
             if (method.hasPrimitive()) {
                 final AbstractPrimitiveNode primitiveNode = PrimitiveNodeFactory.getOrCreateIndexedOrNamed(method);
-                if (primitiveNode instanceof Primitive2 primitive2) {
+                if (primitiveNode instanceof final Primitive2 primitive2) {
                     return new DispatchDirectPrimitive2Node(assumptions, method, primitive2);
                 }
                 DispatchUtils.logMissingPrimitive(primitiveNode, method);
@@ -139,7 +139,8 @@ public final class DispatchSelector2Node extends DispatchSelectorNode {
 
         private static DispatchDirectMessageFallback2Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
             final CompiledCodeObject fallbackMethod = receiverClass.resolveDispatchFailure(selector);
-            return new DispatchDirectMessageFallback2Node(assumptions, selector, fallbackMethod);
+            final Assumption[] finalAssumptions = DispatchUtils.getAssumptionsForMessageFallback(assumptions, selector, fallbackMethod);
+            return new DispatchDirectMessageFallback2Node(finalAssumptions, selector, fallbackMethod);
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector3Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector3Node.java
@@ -106,10 +106,15 @@ public final class DispatchSelector3Node extends DispatchSelectorNode {
             return new DispatchDirectMethod3Node(assumptions, method);
         }
 
-        private static DispatchDirectMessageFallback3Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
-            final CompiledCodeObject fallbackMethod = receiverClass.resolveDispatchFailure(selector);
-            final Assumption[] finalAssumptions = DispatchUtils.getAssumptionsForMessageFallback(assumptions, selector, fallbackMethod);
-            return new DispatchDirectMessageFallback3Node(finalAssumptions, selector, fallbackMethod);
+        private static DispatchDirect3Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
+            final ClassObject.DispatchFailureResult result = receiverClass.resolveDispatchFailure(selector, 3);
+            final Assumption[] finalAssumptions = DispatchUtils.getAssumptionsForMessageFallback(assumptions, selector, result.fallbackMethod());
+
+            return switch (result.convention()) {
+                case SHORTCUT_DNU -> new DispatchDirectShortcutFallback3Node(finalAssumptions, selector, result.fallbackMethod());
+                case STANDARD_DNU -> new DispatchDirectDNUFallback3Node(finalAssumptions, selector, result.fallbackMethod());
+                case CANNOT_INTERPRET -> new DispatchDirectCannotInterpretFallback3Node(finalAssumptions, selector, result.fallbackMethod(), result.fallbackDepth(), result.fallbackSelector());
+            };
         }
     }
 
@@ -188,21 +193,68 @@ public final class DispatchSelector3Node extends DispatchSelectorNode {
         }
     }
 
-    static final class DispatchDirectMessageFallback3Node extends DispatchDirectWithSender3Node {
-        private final NativeObject selector;
-        @Child private DirectCallNode callNode;
-        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+    abstract static class AbstractDispatchDirectFallback3Node extends DispatchDirectWithSender3Node {
+        protected final NativeObject selector;
+        @Child protected DirectCallNode callNode;
 
-        DispatchDirectMessageFallback3Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+        AbstractDispatchDirectFallback3Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject targetMethod) {
             super(assumptions);
             this.selector = selector;
-            callNode = DirectCallNode.create(dnuMethod.getCallTarget());
+            this.callNode = DirectCallNode.create(targetMethod.getCallTarget());
+        }
+
+        @Override
+        public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2, Object arg3);
+    }
+
+    static final class DispatchDirectDNUFallback3Node extends AbstractDispatchDirectFallback3Node {
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectDNUFallback3Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+            super(assumptions, selector, dnuMethod);
         }
 
         @Override
         public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3) {
             final PointersObject message = createMessageNode.execute(selector, receiver, new Object[]{arg1, arg2, arg3});
             return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
+        }
+    }
+
+    static final class DispatchDirectCannotInterpretFallback3Node extends AbstractDispatchDirectFallback3Node {
+        private final int fallbackDepth;
+        private final NativeObject ciSelector;
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectCannotInterpretFallback3Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject ciMethod, final int fallbackDepth,
+                        final NativeObject ciSelector) {
+            super(assumptions, selector, ciMethod);
+            this.fallbackDepth = fallbackDepth;
+            this.ciSelector = ciSelector;
+        }
+
+        @Override
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3) {
+            final PointersObject message = DispatchUtils.buildNestedMessage(
+                            createMessageNode,
+                            selector,
+                            ciSelector,
+                            receiver,
+                            new Object[]{arg1, arg2, arg3},
+                            fallbackDepth);
+            return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
+        }
+    }
+
+    static final class DispatchDirectShortcutFallback3Node extends AbstractDispatchDirectFallback3Node {
+
+        DispatchDirectShortcutFallback3Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject shortcutMethod) {
+            super(assumptions, selector, shortcutMethod);
+        }
+
+        @Override
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3) {
+            return callNode.call(FrameAccess.newWith(senderNode.execute(frame), null, receiver, arg1, arg2, arg3, selector));
         }
     }
 
@@ -242,7 +294,14 @@ public final class DispatchSelector3Node extends DispatchSelectorNode {
             final ClassObject receiverClass = classNode.executeLookup(node, receiver);
             final Object lookupResult = getContext(node).lookup(receiverClass, selector);
             final CompiledCodeObject method = methodNode.execute(node, getContext(node), 3, canPrimFail, selector, receiverClass, lookupResult);
-            final Object result = tryPrimitiveNode.execute(frame, method, receiver, arg1, arg2, arg3);
+
+            final Object result;
+            if (lookupResult instanceof CompiledCodeObject) {
+                result = tryPrimitiveNode.execute(frame, method, receiver, arg1, arg2, arg3);
+            } else {
+                result = null;
+            }
+
             if (result != null) {
                 return result;
             } else {
@@ -318,9 +377,21 @@ public final class DispatchSelector3Node extends DispatchSelectorNode {
             @Specialization(guards = "lookupResult == null")
             protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final Object arg2, final Object arg3,
                             final ClassObject receiverClass, @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
-                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode) {
+                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(3);
+
+                if (result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU) {
+                    return FrameAccess.newWith(sender, null, receiver, arg1, arg2, arg3, selector);
+                }
+
                 final Object[] arguments = new Object[]{arg1, arg2, arg3};
-                final PointersObject message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                final PointersObject message;
+                if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
+                    message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
+                } else {
+                    message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                }
                 return FrameAccess.newMessageFallbackWith(sender, receiver, message);
             }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector3Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector3Node.java
@@ -108,7 +108,8 @@ public final class DispatchSelector3Node extends DispatchSelectorNode {
 
         private static DispatchDirectMessageFallback3Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
             final CompiledCodeObject fallbackMethod = receiverClass.resolveDispatchFailure(selector);
-            return new DispatchDirectMessageFallback3Node(assumptions, selector, fallbackMethod);
+            final Assumption[] finalAssumptions = DispatchUtils.getAssumptionsForMessageFallback(assumptions, selector, fallbackMethod);
+            return new DispatchDirectMessageFallback3Node(finalAssumptions, selector, fallbackMethod);
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector4Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector4Node.java
@@ -108,7 +108,8 @@ public final class DispatchSelector4Node extends DispatchSelectorNode {
 
         private static DispatchDirectMessageFallback4Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
             final CompiledCodeObject fallbackMethod = receiverClass.resolveDispatchFailure(selector);
-            return new DispatchDirectMessageFallback4Node(assumptions, selector, fallbackMethod);
+            final Assumption[] finalAssumptions = DispatchUtils.getAssumptionsForMessageFallback(assumptions, selector, fallbackMethod);
+            return new DispatchDirectMessageFallback4Node(finalAssumptions, selector, fallbackMethod);
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector4Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector4Node.java
@@ -106,10 +106,16 @@ public final class DispatchSelector4Node extends DispatchSelectorNode {
             return new DispatchDirectMethod4Node(assumptions, method);
         }
 
-        private static DispatchDirectMessageFallback4Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
-            final CompiledCodeObject fallbackMethod = receiverClass.resolveDispatchFailure(selector);
-            final Assumption[] finalAssumptions = DispatchUtils.getAssumptionsForMessageFallback(assumptions, selector, fallbackMethod);
-            return new DispatchDirectMessageFallback4Node(finalAssumptions, selector, fallbackMethod);
+        private static DispatchDirect4Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
+            final ClassObject.DispatchFailureResult result = receiverClass.resolveDispatchFailure(selector, 4);
+            final Assumption[] finalAssumptions = DispatchUtils.getAssumptionsForMessageFallback(assumptions, selector, result.fallbackMethod());
+
+            if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
+                return new DispatchDirectCannotInterpretFallback4Node(finalAssumptions, selector, result.fallbackMethod(), result.fallbackDepth(), result.fallbackSelector());
+            } else {
+                assert result.convention() == ClassObject.FallbackConvention.STANDARD_DNU : "DNU shortcuts are not supported for arity 4+";
+                return new DispatchDirectDNUFallback4Node(finalAssumptions, selector, result.fallbackMethod());
+            }
         }
     }
 
@@ -189,20 +195,55 @@ public final class DispatchSelector4Node extends DispatchSelectorNode {
         }
     }
 
-    static final class DispatchDirectMessageFallback4Node extends DispatchDirectWithSender4Node {
-        private final NativeObject selector;
-        @Child private DirectCallNode callNode;
-        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+    abstract static class AbstractDispatchDirectFallback4Node extends DispatchDirectWithSender4Node {
+        protected final NativeObject selector;
+        @Child protected DirectCallNode callNode;
 
-        DispatchDirectMessageFallback4Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+        AbstractDispatchDirectFallback4Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject targetMethod) {
             super(assumptions);
             this.selector = selector;
-            callNode = DirectCallNode.create(dnuMethod.getCallTarget());
+            this.callNode = DirectCallNode.create(targetMethod.getCallTarget());
+        }
+
+        @Override
+        public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2, Object arg3, Object arg4);
+    }
+
+    static final class DispatchDirectDNUFallback4Node extends AbstractDispatchDirectFallback4Node {
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectDNUFallback4Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+            super(assumptions, selector, dnuMethod);
         }
 
         @Override
         public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4) {
             final PointersObject message = createMessageNode.execute(selector, receiver, new Object[]{arg1, arg2, arg3, arg4});
+            return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
+        }
+    }
+
+    static final class DispatchDirectCannotInterpretFallback4Node extends AbstractDispatchDirectFallback4Node {
+        private final int fallbackDepth;
+        private final NativeObject ciSelector;
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectCannotInterpretFallback4Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject ciMethod, final int fallbackDepth,
+                        final NativeObject ciSelector) {
+            super(assumptions, selector, ciMethod);
+            this.fallbackDepth = fallbackDepth;
+            this.ciSelector = ciSelector;
+        }
+
+        @Override
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4) {
+            final PointersObject message = DispatchUtils.buildNestedMessage(
+                            createMessageNode,
+                            selector,
+                            ciSelector,
+                            receiver,
+                            new Object[]{arg1, arg2, arg3, arg4},
+                            fallbackDepth);
             return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
         }
     }
@@ -243,7 +284,14 @@ public final class DispatchSelector4Node extends DispatchSelectorNode {
             final ClassObject receiverClass = classNode.executeLookup(node, receiver);
             final Object lookupResult = getContext(node).lookup(receiverClass, selector);
             final CompiledCodeObject method = methodNode.execute(node, getContext(node), 4, canPrimFail, selector, receiverClass, lookupResult);
-            final Object result = tryPrimitiveNode.execute(frame, method, receiver, arg1, arg2, arg3, arg4);
+
+            final Object result;
+            if (lookupResult instanceof CompiledCodeObject) {
+                result = tryPrimitiveNode.execute(frame, method, receiver, arg1, arg2, arg3, arg4);
+            } else {
+                result = null;
+            }
+
             if (result != null) {
                 return result;
             } else {
@@ -320,9 +368,17 @@ public final class DispatchSelector4Node extends DispatchSelectorNode {
             @Specialization(guards = "lookupResult == null")
             protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final Object arg2, final Object arg3,
                             final Object arg4, final ClassObject receiverClass, @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
-                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode) {
+                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(4);
                 final Object[] arguments = new Object[]{arg1, arg2, arg3, arg4};
-                final PointersObject message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+
+                final PointersObject message;
+                if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
+                    message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
+                } else {
+                    message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                }
                 return FrameAccess.newMessageFallbackWith(sender, receiver, message);
             }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector5Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector5Node.java
@@ -101,7 +101,8 @@ public final class DispatchSelector5Node extends DispatchSelectorNode {
 
         private static DispatchDirectMessageFallback5Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
             final CompiledCodeObject fallbackMethod = receiverClass.resolveDispatchFailure(selector);
-            return new DispatchDirectMessageFallback5Node(assumptions, selector, fallbackMethod);
+            final Assumption[] finalAssumptions = DispatchUtils.getAssumptionsForMessageFallback(assumptions, selector, fallbackMethod);
+            return new DispatchDirectMessageFallback5Node(finalAssumptions, selector, fallbackMethod);
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector5Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector5Node.java
@@ -99,10 +99,16 @@ public final class DispatchSelector5Node extends DispatchSelectorNode {
             return new DispatchDirectMethod5Node(assumptions, method);
         }
 
-        private static DispatchDirectMessageFallback5Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
-            final CompiledCodeObject fallbackMethod = receiverClass.resolveDispatchFailure(selector);
-            final Assumption[] finalAssumptions = DispatchUtils.getAssumptionsForMessageFallback(assumptions, selector, fallbackMethod);
-            return new DispatchDirectMessageFallback5Node(finalAssumptions, selector, fallbackMethod);
+        private static DispatchDirect5Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
+            final ClassObject.DispatchFailureResult result = receiverClass.resolveDispatchFailure(selector, 5);
+            final Assumption[] finalAssumptions = DispatchUtils.getAssumptionsForMessageFallback(assumptions, selector, result.fallbackMethod());
+
+            if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
+                return new DispatchDirectCannotInterpretFallback5Node(finalAssumptions, selector, result.fallbackMethod(), result.fallbackDepth(), result.fallbackSelector());
+            } else {
+                assert result.convention() == ClassObject.FallbackConvention.STANDARD_DNU : "DNU shortcuts are not supported for arity 4+";
+                return new DispatchDirectDNUFallback5Node(finalAssumptions, selector, result.fallbackMethod());
+            }
         }
     }
 
@@ -182,20 +188,55 @@ public final class DispatchSelector5Node extends DispatchSelectorNode {
         }
     }
 
-    static final class DispatchDirectMessageFallback5Node extends DispatchDirectWithSender5Node {
-        private final NativeObject selector;
-        @Child private DirectCallNode callNode;
-        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+    abstract static class AbstractDispatchDirectFallback5Node extends DispatchDirectWithSender5Node {
+        protected final NativeObject selector;
+        @Child protected DirectCallNode callNode;
 
-        DispatchDirectMessageFallback5Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+        AbstractDispatchDirectFallback5Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject targetMethod) {
             super(assumptions);
             this.selector = selector;
-            callNode = DirectCallNode.create(dnuMethod.getCallTarget());
+            this.callNode = DirectCallNode.create(targetMethod.getCallTarget());
+        }
+
+        @Override
+        public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5);
+    }
+
+    static final class DispatchDirectDNUFallback5Node extends AbstractDispatchDirectFallback5Node {
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectDNUFallback5Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+            super(assumptions, selector, dnuMethod);
         }
 
         @Override
         public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5) {
             final PointersObject message = createMessageNode.execute(selector, receiver, new Object[]{arg1, arg2, arg3, arg4, arg5});
+            return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
+        }
+    }
+
+    static final class DispatchDirectCannotInterpretFallback5Node extends AbstractDispatchDirectFallback5Node {
+        private final int fallbackDepth;
+        private final NativeObject ciSelector;
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectCannotInterpretFallback5Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject ciMethod, final int fallbackDepth,
+                        final NativeObject ciSelector) {
+            super(assumptions, selector, ciMethod);
+            this.fallbackDepth = fallbackDepth;
+            this.ciSelector = ciSelector;
+        }
+
+        @Override
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5) {
+            final PointersObject message = DispatchUtils.buildNestedMessage(
+                            createMessageNode,
+                            selector,
+                            ciSelector,
+                            receiver,
+                            new Object[]{arg1, arg2, arg3, arg4, arg5},
+                            fallbackDepth);
             return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
         }
     }
@@ -236,7 +277,14 @@ public final class DispatchSelector5Node extends DispatchSelectorNode {
             final ClassObject receiverClass = classNode.executeLookup(node, receiver);
             final Object lookupResult = getContext(node).lookup(receiverClass, selector);
             final CompiledCodeObject method = methodNode.execute(node, getContext(node), 5, canPrimFail, selector, receiverClass, lookupResult);
-            final Object result = tryPrimitiveNode.execute(frame, method, receiver, arg1, arg2, arg3, arg4, arg5);
+
+            final Object result;
+            if (lookupResult instanceof CompiledCodeObject) {
+                result = tryPrimitiveNode.execute(frame, method, receiver, arg1, arg2, arg3, arg4, arg5);
+            } else {
+                result = null;
+            }
+
             if (result != null) {
                 return result;
             } else {
@@ -315,9 +363,17 @@ public final class DispatchSelector5Node extends DispatchSelectorNode {
             @Specialization(guards = "lookupResult == null")
             protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final Object arg2, final Object arg3,
                             final Object arg4, final Object arg5, final ClassObject receiverClass, @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
-                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode) {
+                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(5);
                 final Object[] arguments = new Object[]{arg1, arg2, arg3, arg4, arg5};
-                final PointersObject message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+
+                final PointersObject message;
+                if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
+                    message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
+                } else {
+                    message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                }
                 return FrameAccess.newMessageFallbackWith(sender, receiver, message);
             }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
@@ -190,7 +190,8 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
 
         private static DispatchDirectMessageFallbackNaryNode createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
             final CompiledCodeObject fallbackMethod = receiverClass.resolveDispatchFailure(selector);
-            return new DispatchDirectMessageFallbackNaryNode(assumptions, selector, fallbackMethod);
+            final Assumption[] finalAssumptions = DispatchUtils.getAssumptionsForMessageFallback(assumptions, selector, fallbackMethod);
+            return new DispatchDirectMessageFallbackNaryNode(finalAssumptions, selector, fallbackMethod);
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
@@ -13,6 +13,7 @@ import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.HostCompilerDirectives;
 import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Cached.Shared;
 import com.oracle.truffle.api.dsl.GenerateCached;
 import com.oracle.truffle.api.dsl.GenerateInline;
 import com.oracle.truffle.api.dsl.GenerateUncached;
@@ -703,21 +704,37 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
 
             @Specialization(guards = {"lookupResult == null", "arguments.length == cachedArity"}, limit = "1")
             @ExplodeLoop
-            protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object[] arguments, final ClassObject receiverClass,
+            protected static final Object[] doMessageFallbackCached(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object[] arguments,
+                            final ClassObject receiverClass,
                             @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
                             @Cached("arguments.length") final int cachedArity,
-                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
-                            @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                            @Shared("writeNode") @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Shared("createNode") @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                return doMessageFallbackShared(node, sender, receiver, arguments, receiverClass, selector, cachedArity, writeNode, createMessageNode);
+            }
 
-                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(cachedArity);
+            @Specialization(guards = "lookupResult == null", replaces = "doMessageFallbackCached")
+            protected static final Object[] doMessageFallbackGeneric(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object[] arguments,
+                            final ClassObject receiverClass,
+                            @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
+                            @Shared("writeNode") @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Shared("createNode") @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                return doMessageFallbackShared(node, sender, receiver, arguments, receiverClass, selector, arguments.length, writeNode, createMessageNode);
+            }
+
+            private static Object[] doMessageFallbackShared(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object[] arguments, final ClassObject receiverClass,
+                            final NativeObject selector, final int arity, final AbstractPointersObjectWriteNode writeNode, final CreateMessageNode createMessageNode) {
+
+                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(arity);
 
                 if (result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU) {
-                    final Object[] shortcutArgs = new Object[cachedArity + 1];
-                    for (int i = 0; i < cachedArity; i++) {
-                        shortcutArgs[i] = arguments[i];
+                    final Object[] shortcutArgs = new Object[arity + 1];
+                    if (CompilerDirectives.isPartialEvaluationConstant(arity)) {
+                        copyExploded(arguments, shortcutArgs, arity);
+                    } else {
+                        System.arraycopy(arguments, 0, shortcutArgs, 0, arity);
                     }
-                    shortcutArgs[cachedArity] = selector;
-
+                    shortcutArgs[arity] = selector;
                     return FrameAccess.newWith(sender, null, receiver, shortcutArgs);
                 }
 
@@ -728,6 +745,19 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
                     message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
                 }
                 return FrameAccess.newMessageFallbackWith(sender, receiver, message);
+            }
+
+            @ExplodeLoop
+            private static void copyExploded(final Object[] source, final Object[] dest, final int length) {
+                for (int i = 0; i < length; i++) {
+                    dest[i] = source[i];
+                }
+            }
+
+            @Specialization(guards = {"targetObject != null", "!isCompiledCodeObject(targetObject)"})
+            protected static final Object[] doObjectAsMethod(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object[] arguments,
+                            @SuppressWarnings("unused") final ClassObject receiverClass, final Object targetObject, final NativeObject selector) {
+                return FrameAccess.newOAMWith(sender, targetObject, selector, getContext(node).asArrayOfObjects(arguments), receiver);
             }
         }
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
@@ -23,6 +23,7 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.DirectCallNode;
+import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.IndirectCallNode;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.InlinedBranchProfile;
@@ -77,7 +78,7 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
         @Specialization(guards = "guard.check(receiver)", assumptions = "dispatchDirectNode.getAssumptions()", limit = "INLINE_METHOD_CACHE_LIMIT")
         protected static final Object doDirect(final VirtualFrame frame, final Object receiver, final Object[] arguments,
                         @SuppressWarnings("unused") @Cached("create(receiver)") final LookupClassGuard guard,
-                        @Cached("create(selector, guard)") final DispatchDirectNaryNode dispatchDirectNode) {
+                        @Cached("create(selector, guard, arguments.length)") final DispatchDirectNaryNode dispatchDirectNode) {
             return dispatchDirectNode.execute(frame, receiver, arguments);
         }
 
@@ -101,7 +102,7 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
 
         @Specialization(assumptions = {"methodClass.getClassHierarchyAndMethodDictStable()", "dispatchDirectNode.getAssumptions()"})
         protected static final Object doCached(final VirtualFrame frame, final Object receiver, final Object[] arguments,
-                        @Cached("create(selector, methodClass.getResolvedSuperclass())") final DispatchDirectNaryNode dispatchDirectNode) {
+                        @Cached("create(selector, methodClass.getResolvedSuperclass(), arguments.length)") final DispatchDirectNaryNode dispatchDirectNode) {
             return dispatchDirectNode.execute(frame, receiver, arguments);
         }
     }
@@ -117,7 +118,7 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
                         "dispatchDirectNode.getAssumptions()"}, limit = "3")
         protected static final Object doCached(final VirtualFrame frame, @SuppressWarnings("unused") final ClassObject lookupClass, final Object receiver, final Object[] arguments,
                         @SuppressWarnings("unused") @Cached("lookupClass") final ClassObject cachedLookupClass,
-                        @Cached("create(selector, cachedLookupClass)") final DispatchDirectNaryNode dispatchDirectNode) {
+                        @Cached("create(selector, cachedLookupClass, arguments.length)") final DispatchDirectNaryNode dispatchDirectNode) {
             return dispatchDirectNode.execute(frame, receiver, arguments);
         }
     }
@@ -144,9 +145,9 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
         }
 
         @NeverDefault
-        public static final DispatchDirectNaryNode create(final NativeObject selector, final LookupClassGuard guard) {
+        public static final DispatchDirectNaryNode create(final NativeObject selector, final LookupClassGuard guard, final int arity) {
             final ClassObject receiverClass = guard.getSqueakClassInternal(null);
-            return create(selector, receiverClass);
+            return create(selector, receiverClass, arity);
         }
 
         @NeverDefault
@@ -157,13 +158,13 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
         }
 
         @NeverDefault
-        public static final DispatchDirectNaryNode create(final NativeObject selector, final ClassObject lookupClass) {
+        public static final DispatchDirectNaryNode create(final NativeObject selector, final ClassObject lookupClass, final int arity) {
             final Object lookupResult = lookupClass.lookupInMethodDictSlow(selector);
             final Assumption[] assumptions = DispatchUtils.createAssumptions(lookupClass, lookupResult);
             if (lookupResult instanceof final CompiledCodeObject lookupMethod) {
                 return create(assumptions, lookupMethod);
             } else if (lookupResult == null) {
-                return createMessageFallbackNode(selector, assumptions, lookupClass);
+                return createMessageFallbackNode(selector, assumptions, lookupClass, arity);
             } else {
                 final ClassObject lookupResultClass = SqueakObjectClassNode.executeUncached(lookupResult);
                 final Object runWithInLookupResult = LookupMethodNode.executeUncached(lookupResultClass, SqueakImageContext.getSlow().runWithInSelector);
@@ -171,27 +172,31 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
                     return new DispatchDirectObjectAsMethodNaryNode(assumptions, selector, runWithInMethod, lookupResult);
                 } else {
                     assert runWithInLookupResult == null : "runWithInLookupResult should not be another Object";
-                    return createMessageFallbackNode(selector, assumptions, lookupResultClass);
+                    return createMessageFallbackNode(selector, assumptions, lookupResultClass, arity);
                 }
             }
         }
 
         private static DispatchDirectNaryNode create(final Assumption[] assumptions, final CompiledCodeObject method) {
-            // Cannot check argument count here (actual count of arguments only known when called).
             if (method.hasPrimitive()) {
                 final AbstractPrimitiveNode primitiveNode = PrimitiveNodeFactory.getOrCreateIndexedOrNamed(method);
                 if (primitiveNode != null) {
                     return new DispatchDirectPrimitiveNaryNode(assumptions, method, primitiveNode);
                 }
-                DispatchUtils.logMissingPrimitive(null, method);
+                DispatchUtils.logMissingPrimitive(primitiveNode, method);
             }
             return new DispatchDirectMethodNaryNode(assumptions, method);
         }
 
-        private static DispatchDirectMessageFallbackNaryNode createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
-            final CompiledCodeObject fallbackMethod = receiverClass.resolveDispatchFailure(selector);
-            final Assumption[] finalAssumptions = DispatchUtils.getAssumptionsForMessageFallback(assumptions, selector, fallbackMethod);
-            return new DispatchDirectMessageFallbackNaryNode(finalAssumptions, selector, fallbackMethod);
+        private static DispatchDirectNaryNode createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass, final int arity) {
+            final ClassObject.DispatchFailureResult result = receiverClass.resolveDispatchFailure(selector, arity);
+            final Assumption[] finalAssumptions = DispatchUtils.getAssumptionsForMessageFallback(assumptions, selector, result.fallbackMethod());
+
+            return switch (result.convention()) {
+                case SHORTCUT_DNU -> new DispatchDirectShortcutFallbackNaryNode(finalAssumptions, selector, result.fallbackMethod(), arity);
+                case STANDARD_DNU -> new DispatchDirectDNUFallbackNaryNode(finalAssumptions, selector, result.fallbackMethod());
+                case CANNOT_INTERPRET -> new DispatchDirectCannotInterpretFallbackNaryNode(finalAssumptions, selector, result.fallbackMethod(), result.fallbackDepth(), result.fallbackSelector());
+            };
         }
     }
 
@@ -490,26 +495,85 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
         }
     }
 
-    static final class DispatchDirectMessageFallbackNaryNode extends DispatchDirectWithSenderNaryNode {
-        private final NativeObject selector;
-        @Child private DirectCallNode callNode;
-        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+    abstract static class AbstractDispatchDirectFallbackNaryNode extends DispatchDirectWithSenderNaryNode {
+        protected final NativeObject selector;
+        @Child protected DirectCallNode callNode;
 
-        DispatchDirectMessageFallbackNaryNode(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+        AbstractDispatchDirectFallbackNaryNode(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject targetMethod) {
             super(assumptions);
             this.selector = selector;
-            callNode = DirectCallNode.create(dnuMethod.getCallTarget());
+            this.callNode = DirectCallNode.create(targetMethod.getCallTarget());
         }
 
         @Override
         protected void checkNumArguments(final Object[] arguments) {
-            // nothing to do
+            // Nothing to do; fallback message creation handles arbitrary arrays
+        }
+
+        @Override
+        public abstract Object execute(VirtualFrame frame, Object receiver, Object[] arguments);
+    }
+
+    static final class DispatchDirectDNUFallbackNaryNode extends AbstractDispatchDirectFallbackNaryNode {
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectDNUFallbackNaryNode(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+            super(assumptions, selector, dnuMethod);
         }
 
         @Override
         public Object execute(final VirtualFrame frame, final Object receiver, final Object[] arguments) {
             final PointersObject message = createMessageNode.execute(selector, receiver, arguments);
             return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
+        }
+    }
+
+    static final class DispatchDirectCannotInterpretFallbackNaryNode extends AbstractDispatchDirectFallbackNaryNode {
+        private final int fallbackDepth;
+        private final NativeObject ciSelector;
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectCannotInterpretFallbackNaryNode(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject ciMethod, final int fallbackDepth,
+                        final NativeObject ciSelector) {
+            super(assumptions, selector, ciMethod);
+            this.fallbackDepth = fallbackDepth;
+            this.ciSelector = ciSelector;
+        }
+
+        @Override
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object[] arguments) {
+            final PointersObject message = DispatchUtils.buildNestedMessage(
+                            createMessageNode,
+                            selector,
+                            ciSelector,
+                            receiver,
+                            arguments,
+                            fallbackDepth);
+            return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
+        }
+    }
+
+    static final class DispatchDirectShortcutFallbackNaryNode extends AbstractDispatchDirectFallbackNaryNode {
+        private final int arity;
+
+        DispatchDirectShortcutFallbackNaryNode(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject shortcutMethod, final int arity) {
+            super(assumptions, selector, shortcutMethod);
+            this.arity = arity;
+        }
+
+        @Override
+        @ExplodeLoop
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object[] arguments) {
+            assert arguments.length == arity : "Shortcut arity mismatch!";
+
+            // Build the shortcut arguments: [arg0, arg1, ..., argN, selector]
+            final Object[] shortcutArgs = new Object[arity + 1];
+            for (int i = 0; i < arity; i++) {
+                shortcutArgs[i] = arguments[i];
+            }
+            shortcutArgs[arity] = selector;
+
+            return callNode.call(FrameAccess.newWith(senderNode.execute(frame), null, receiver, shortcutArgs));
         }
     }
 
@@ -553,7 +617,14 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
             final ClassObject receiverClass = classNode.executeLookup(node, receiver);
             final Object lookupResult = getContext(node).lookup(receiverClass, selector);
             final CompiledCodeObject method = methodNode.execute(node, getContext(node), arguments.length, canPrimFail, selector, receiverClass, lookupResult);
-            final Object result = tryPrimitiveNode.execute(frame, method, receiver, arguments);
+
+            final Object result;
+            if (lookupResult instanceof CompiledCodeObject) {
+                result = tryPrimitiveNode.execute(frame, method, receiver, arguments);
+            } else {
+                result = null;
+            }
+
             if (result != null) {
                 return result;
             } else {
@@ -630,18 +701,33 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
                 return FrameAccess.newWith(sender, null, receiver, arguments);
             }
 
-            @Specialization(guards = "lookupResult == null")
+            @Specialization(guards = {"lookupResult == null", "arguments.length == cachedArity"}, limit = "1")
+            @ExplodeLoop
             protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object[] arguments, final ClassObject receiverClass,
                             @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
-                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode) {
-                final PointersObject message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
-                return FrameAccess.newMessageFallbackWith(sender, receiver, message);
-            }
+                            @Cached("arguments.length") final int cachedArity,
+                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Cached(inline = false) final CreateMessageNode createMessageNode) {
 
-            @Specialization(guards = {"targetObject != null", "!isCompiledCodeObject(targetObject)"})
-            protected static final Object[] doObjectAsMethod(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object[] arguments,
-                            @SuppressWarnings("unused") final ClassObject receiverClass, final Object targetObject, final NativeObject selector) {
-                return FrameAccess.newOAMWith(sender, targetObject, selector, getContext(node).asArrayOfObjects(arguments), receiver);
+                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(cachedArity);
+
+                if (result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU) {
+                    final Object[] shortcutArgs = new Object[cachedArity + 1];
+                    for (int i = 0; i < cachedArity; i++) {
+                        shortcutArgs[i] = arguments[i];
+                    }
+                    shortcutArgs[cachedArity] = selector;
+
+                    return FrameAccess.newWith(sender, null, receiver, shortcutArgs);
+                }
+
+                final PointersObject message;
+                if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
+                    message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
+                } else {
+                    message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                }
+                return FrameAccess.newMessageFallbackWith(sender, receiver, message);
             }
         }
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchUtils.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchUtils.java
@@ -17,6 +17,7 @@ import de.hpi.swa.trufflesqueak.exceptions.PrimitiveFailed;
 import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
 import de.hpi.swa.trufflesqueak.model.ClassObject;
 import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
+import de.hpi.swa.trufflesqueak.model.NativeObject;
 import de.hpi.swa.trufflesqueak.nodes.primitives.AbstractPrimitiveNode;
 import de.hpi.swa.trufflesqueak.nodes.primitives.PrimitiveNodeFactory;
 import de.hpi.swa.trufflesqueak.util.LogUtils;
@@ -63,6 +64,27 @@ public final class DispatchUtils {
             // be avoided.
             return list.toArray(new Assumption[0]);
         }
+    }
+
+    /**
+     * Creates the complete assumption array for a message fallback node (DNU or CI). On top of the
+     * standard class hierarchy stability, it registers two assumptions:
+     *
+     * Fallback Method Stability: Tracks the `callTargetStable` of the resolved fallback method
+     * itself. This ensures the AST node is invalidated if the actual #doesNotUnderstand: or
+     * #cannotInterpret: method is later modified or recompiled.
+     *
+     * Absent Selector Stability: Tracks an image-global assumption that the specific failing
+     * selector does not exist. If a method for this missing selector is compiled, the VM's cache
+     * flush (primitive 119) will trip this assumption globally. This prevents "stranded DNU" nodes
+     * by forcing them to drop and re-resolve to the newly added method.
+     */
+    static Assumption[] getAssumptionsForMessageFallback(final Assumption[] classAssumptions, final NativeObject selector, final CompiledCodeObject fallbackMethod) {
+        final Assumption[] finalAssumptions = new Assumption[classAssumptions.length + 2];
+        System.arraycopy(classAssumptions, 0, finalAssumptions, 0, classAssumptions.length);
+        finalAssumptions[classAssumptions.length] = fallbackMethod.getCallTargetStable();
+        finalAssumptions[classAssumptions.length + 1] = SqueakImageContext.getSlow().getAbsentSelectorAssumption(selector);
+        return finalAssumptions;
     }
 
     static void logMissingPrimitive(final AbstractPrimitiveNode primitiveNode, final CompiledCodeObject code) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchUtils.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchUtils.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 
 import com.oracle.truffle.api.Assumption;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.NodeInterface;
 
@@ -18,6 +19,7 @@ import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
 import de.hpi.swa.trufflesqueak.model.ClassObject;
 import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
 import de.hpi.swa.trufflesqueak.model.NativeObject;
+import de.hpi.swa.trufflesqueak.model.PointersObject;
 import de.hpi.swa.trufflesqueak.nodes.primitives.AbstractPrimitiveNode;
 import de.hpi.swa.trufflesqueak.nodes.primitives.PrimitiveNodeFactory;
 import de.hpi.swa.trufflesqueak.util.LogUtils;
@@ -85,6 +87,17 @@ public final class DispatchUtils {
         finalAssumptions[classAssumptions.length] = fallbackMethod.getCallTargetStable();
         finalAssumptions[classAssumptions.length + 1] = SqueakImageContext.getSlow().getAbsentSelectorAssumption(selector);
         return finalAssumptions;
+    }
+
+    @ExplodeLoop
+    static PointersObject buildNestedMessage(final CreateMessageNode createMessageNode,
+                    final NativeObject originalSelector, final NativeObject cannotInterpretSelector,
+                    final Object receiver, final Object[] arguments, final int fallbackDepth) {
+        PointersObject message = createMessageNode.execute(originalSelector, receiver, arguments);
+        for (int i = 1; i < fallbackDepth; i++) {
+            message = createMessageNode.execute(cannotInterpretSelector, receiver, new Object[]{message});
+        }
+        return message;
     }
 
     static void logMissingPrimitive(final AbstractPrimitiveNode primitiveNode, final CompiledCodeObject code) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/ResolveMethodNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/ResolveMethodNode.java
@@ -48,12 +48,15 @@ public abstract class ResolveMethodNode extends AbstractNode {
 
     @SuppressWarnings("unused")
     @Specialization(guards = "lookupResult == null")
-    protected static final CompiledCodeObject doDispatchFailure(final SqueakImageContext image, final int expectedNumArgs, final boolean canPrimFail, final NativeObject selector,
+    protected static final CompiledCodeObject doDispatchFailure(final SqueakImageContext image, final int expectedNumArgs, final boolean canPrimFail,
+                    final NativeObject selector,
                     final ClassObject receiverClass,
                     final Object lookupResult) {
         final MethodCacheEntry cacheEntry = image.findMethodCacheEntry(receiverClass, selector);
-        final CompiledCodeObject fallbackMethod = cacheEntry.getOrCreateFallbackMethod();
-        assert fallbackMethod.getNumArgs() == 1 : "Fallback method with unexpected number of arguments, got " + fallbackMethod.getNumArgs();
+        final ClassObject.DispatchFailureResult result = cacheEntry.getOrCreateDispatchFailureResult(expectedNumArgs);
+        final CompiledCodeObject fallbackMethod = result.fallbackMethod();
+        assert fallbackMethod.getNumArgs() == 1 || (result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU &&
+                        fallbackMethod.getNumArgs() == expectedNumArgs + 1) : "Fallback method with unexpected number of arguments";
         return fallbackMethod;
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/TruffleSqueakPlugin.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/TruffleSqueakPlugin.java
@@ -134,7 +134,7 @@ public final class TruffleSqueakPlugin extends AbstractPrimitiveFactoryHolder {
             for (int i = 0; i < arraySize; i++) {
                 final Object element = elements[i];
 
-                if (element instanceof final NativeObject nativeObject) {
+                if (element instanceof final NativeObject nativeObject && getContext().isByteSymbol(nativeObject)) {
                     isolatedSelectors[i] = nativeObject;
                 } else if (element == NilObject.SINGLETON) {
                     isolatedSelectors[i] = null;

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/TruffleSqueakPlugin.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/TruffleSqueakPlugin.java
@@ -11,15 +11,22 @@ import java.util.List;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.Truffle;
+import com.oracle.truffle.api.dsl.Bind;
+import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.DirectCallNode;
+import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.RootNode;
 
 import de.hpi.swa.trufflesqueak.exceptions.PrimitiveFailed;
+import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
 import de.hpi.swa.trufflesqueak.interop.JavaObjectWrapper;
+import de.hpi.swa.trufflesqueak.model.ArrayObject;
 import de.hpi.swa.trufflesqueak.model.NativeObject;
+import de.hpi.swa.trufflesqueak.model.NilObject;
+import de.hpi.swa.trufflesqueak.nodes.accessing.ArrayObjectNodes;
 import de.hpi.swa.trufflesqueak.nodes.interpreter.AbstractInterpreterNode;
 import de.hpi.swa.trufflesqueak.nodes.primitives.AbstractPrimitiveFactoryHolder;
 import de.hpi.swa.trufflesqueak.nodes.primitives.AbstractPrimitiveNode;
@@ -103,6 +110,42 @@ public final class TruffleSqueakPlugin extends AbstractPrimitiveFactoryHolder {
             } else {
                 throw PrimitiveFailed.andTransferToInterpreter();
             }
+        }
+    }
+
+    @GenerateNodeFactory
+    @SqueakPrimitive(names = "primitiveSetDNUShortcutSelectors")
+    protected abstract static class PrimSetDNUShortcutSelectorsNode extends AbstractPrimitiveNode implements Primitive1WithFallback {
+        @Specialization
+        protected final Object doSet(final Object receiver, final ArrayObject array,
+                        @Bind final Node node,
+                        @Cached final ArrayObjectNodes.ArrayObjectToObjectArrayCopyNode toObjectArrayNode) {
+
+            final Object[] elements = toObjectArrayNode.execute(node, array);
+            final int arraySize = elements.length;
+
+            if (arraySize > SqueakImageContext.MAX_DNU_SHORTCUT_ARITY + 1) {
+                CompilerDirectives.transferToInterpreter();
+                throw PrimitiveFailed.BAD_ARGUMENT;
+            }
+
+            final NativeObject[] isolatedSelectors = new NativeObject[arraySize];
+
+            for (int i = 0; i < arraySize; i++) {
+                final Object element = elements[i];
+
+                if (element instanceof final NativeObject nativeObject) {
+                    isolatedSelectors[i] = nativeObject;
+                } else if (element == NilObject.SINGLETON) {
+                    isolatedSelectors[i] = null;
+                } else {
+                    CompilerDirectives.transferToInterpreter();
+                    throw PrimitiveFailed.BAD_ARGUMENT;
+                }
+            }
+
+            getContext().setDNUShortcutSelectors(isolatedSelectors);
+            return receiver;
         }
     }
 }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ControlPrimitives.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ControlPrimitives.java
@@ -276,7 +276,9 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
                         @Bind final Node node,
                         @Cached("selector") final NativeObject cachedSelector,
                         @Cached("create(receiver)") final LookupClassGuard guard,
-                        @Cached("create(cachedSelector, guard)") final DispatchDirectNaryNode dispatchDirectNode,
+                        @Cached final ArrayObjectSizeNode sizeNode,
+                        @Bind("sizeNode.execute(node, argumentsArray)") final int arity,
+                        @Cached("create(cachedSelector, guard, arity)") final DispatchDirectNaryNode dispatchDirectNode,
                         @Exclusive @Cached final ArrayObjectToObjectArrayCopyNode getObjectArrayNode) {
             final Object[] arguments = getObjectArrayNode.execute(node, argumentsArray);
             return dispatchDirectNode.executeWithCheckedArguments(frame, receiver, arguments);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ControlPrimitives.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ControlPrimitives.java
@@ -271,14 +271,15 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
     @SqueakPrimitive(indices = 84)
     protected abstract static class PrimPerformWithArguments2Node extends AbstractPrimitiveWithFrameNode implements Primitive2 {
         @SuppressWarnings("unused")
-        @Specialization(guards = {"selector == cachedSelector", "guard.check(receiver)"}, assumptions = "dispatchDirectNode.getAssumptions()", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
+        @Specialization(guards = {"selector == cachedSelector", "guard.check(receiver)", "arity == cachedArity"}, assumptions = "dispatchDirectNode.getAssumptions()", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
         protected static final Object performCached(final VirtualFrame frame, final Object receiver, final NativeObject selector, final ArrayObject argumentsArray,
                         @Bind final Node node,
                         @Cached("selector") final NativeObject cachedSelector,
                         @Cached("create(receiver)") final LookupClassGuard guard,
                         @Cached final ArrayObjectSizeNode sizeNode,
                         @Bind("sizeNode.execute(node, argumentsArray)") final int arity,
-                        @Cached("create(cachedSelector, guard, arity)") final DispatchDirectNaryNode dispatchDirectNode,
+                        @Cached("arity") final int cachedArity,
+                        @Cached("create(cachedSelector, guard, cachedArity)") final DispatchDirectNaryNode dispatchDirectNode,
                         @Exclusive @Cached final ArrayObjectToObjectArrayCopyNode getObjectArrayNode) {
             final Object[] arguments = getObjectArrayNode.execute(node, argumentsArray);
             return dispatchDirectNode.executeWithCheckedArguments(frame, receiver, arguments);
@@ -509,11 +510,12 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
 
         protected abstract Object execute(VirtualFrame frame, ClassObject lookupClass, Object receiver, Object[] arguments);
 
-        @Specialization(guards = "lookupClass == cachedLookupClass", assumptions = {"cachedLookupClass.getClassHierarchyAndMethodDictStable()",
+        @Specialization(guards = {"lookupClass == cachedLookupClass", "arguments.length == cachedArity"}, assumptions = {"cachedLookupClass.getClassHierarchyAndMethodDictStable()",
                         "dispatchDirectNode.getAssumptions()"}, limit = "3")
         protected static final Object doCached(final VirtualFrame frame, @SuppressWarnings("unused") final ClassObject lookupClass, final Object receiver, final Object[] arguments,
                         @SuppressWarnings("unused") @Cached("lookupClass") final ClassObject cachedLookupClass,
-                        @Cached("create(selector, cachedLookupClass)") final DispatchDirectNaryNode dispatchDirectNode) {
+                        @SuppressWarnings("unused") @Cached("arguments.length") final int cachedArity,
+                        @Cached("create(selector, cachedLookupClass, cachedArity)") final DispatchDirectNaryNode dispatchDirectNode) {
             return dispatchDirectNode.executeWithCheckedArguments(frame, receiver, arguments);
         }
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ControlPrimitives.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ControlPrimitives.java
@@ -271,7 +271,8 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
     @SqueakPrimitive(indices = 84)
     protected abstract static class PrimPerformWithArguments2Node extends AbstractPrimitiveWithFrameNode implements Primitive2 {
         @SuppressWarnings("unused")
-        @Specialization(guards = {"selector == cachedSelector", "guard.check(receiver)", "arity == cachedArity"}, assumptions = "dispatchDirectNode.getAssumptions()", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
+        @Specialization(guards = {"selector == cachedSelector", "guard.check(receiver)",
+                        "arity == cachedArity"}, assumptions = "dispatchDirectNode.getAssumptions()", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
         protected static final Object performCached(final VirtualFrame frame, final Object receiver, final NativeObject selector, final ArrayObject argumentsArray,
                         @Bind final Node node,
                         @Cached("selector") final NativeObject cachedSelector,

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/MethodCacheEntry.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/MethodCacheEntry.java
@@ -10,14 +10,13 @@ import com.oracle.truffle.api.CompilerAsserts;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import de.hpi.swa.trufflesqueak.model.ClassObject;
-import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
 import de.hpi.swa.trufflesqueak.model.NativeObject;
 
 public final class MethodCacheEntry {
     private ClassObject classObject;
     private NativeObject selector;
     private Object result;
-    private CompiledCodeObject fallbackMethod;
+    private ClassObject.DispatchFailureResult dispatchFailure;
 
     public ClassObject getClassObject() {
         return classObject;
@@ -31,34 +30,34 @@ public final class MethodCacheEntry {
         return result;
     }
 
-    public CompiledCodeObject getOrCreateFallbackMethod() {
-        if (fallbackMethod == null) {
-            fallbackMethod = createFallbackMethod();
+    public ClassObject.DispatchFailureResult getOrCreateDispatchFailureResult(final int arity) {
+        if (dispatchFailure == null) {
+            dispatchFailure = createDispatchFailureResult(arity);
         }
-        return fallbackMethod;
+        return dispatchFailure;
     }
 
     @CompilerDirectives.TruffleBoundary
-    private CompiledCodeObject createFallbackMethod() {
-        return classObject.resolveDispatchFailure(selector);
+    private ClassObject.DispatchFailureResult createDispatchFailureResult(final int arity) {
+        return classObject.resolveDispatchFailure(selector, arity);
     }
 
     public void setResult(final Object object) {
         result = object;
-        fallbackMethod = null;
+        dispatchFailure = null;
     }
 
     public void freeAndRelease() {
         selector = null; /* Mark it free. */
         result = null; /* Release the method. */
-        fallbackMethod = null;
+        dispatchFailure = null;
     }
 
     public MethodCacheEntry reuseFor(final ClassObject lookupClass, final NativeObject lookupSelector) {
         classObject = lookupClass;
         selector = lookupSelector;
         result = null;
-        fallbackMethod = null;
+        dispatchFailure = null;
         return this;
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/MethodCacheEntry.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/MethodCacheEntry.java
@@ -17,6 +17,7 @@ public final class MethodCacheEntry {
     private NativeObject selector;
     private Object result;
     private ClassObject.DispatchFailureResult dispatchFailure;
+    private int dispatchFailureArity = -1;
 
     public ClassObject getClassObject() {
         return classObject;
@@ -31,8 +32,9 @@ public final class MethodCacheEntry {
     }
 
     public ClassObject.DispatchFailureResult getOrCreateDispatchFailureResult(final int arity) {
-        if (dispatchFailure == null) {
+        if (dispatchFailure == null || dispatchFailureArity != arity) {
             dispatchFailure = createDispatchFailureResult(arity);
+            dispatchFailureArity = arity;
         }
         return dispatchFailure;
     }
@@ -45,12 +47,14 @@ public final class MethodCacheEntry {
     public void setResult(final Object object) {
         result = object;
         dispatchFailure = null;
+        dispatchFailureArity = -1;
     }
 
     public void freeAndRelease() {
         selector = null; /* Mark it free. */
         result = null; /* Release the method. */
         dispatchFailure = null;
+        dispatchFailureArity = -1;
     }
 
     public MethodCacheEntry reuseFor(final ClassObject lookupClass, final NativeObject lookupSelector) {
@@ -58,6 +62,7 @@ public final class MethodCacheEntry {
         selector = lookupSelector;
         result = null;
         dispatchFailure = null;
+        dispatchFailureArity = -1;
         return this;
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/MethodCacheEntry.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/MethodCacheEntry.java
@@ -17,7 +17,6 @@ public final class MethodCacheEntry {
     private NativeObject selector;
     private Object result;
     private ClassObject.DispatchFailureResult dispatchFailure;
-    private int dispatchFailureArity = -1;
 
     public ClassObject getClassObject() {
         return classObject;
@@ -32,9 +31,8 @@ public final class MethodCacheEntry {
     }
 
     public ClassObject.DispatchFailureResult getOrCreateDispatchFailureResult(final int arity) {
-        if (dispatchFailure == null || dispatchFailureArity != arity) {
+        if (dispatchFailure == null || dispatchFailure.arity() != arity) {
             dispatchFailure = createDispatchFailureResult(arity);
-            dispatchFailureArity = arity;
         }
         return dispatchFailure;
     }
@@ -47,14 +45,12 @@ public final class MethodCacheEntry {
     public void setResult(final Object object) {
         result = object;
         dispatchFailure = null;
-        dispatchFailureArity = -1;
     }
 
     public void freeAndRelease() {
         selector = null; /* Mark it free. */
         result = null; /* Release the method. */
         dispatchFailure = null;
-        dispatchFailureArity = -1;
     }
 
     public MethodCacheEntry reuseFor(final ClassObject lookupClass, final NativeObject lookupSelector) {
@@ -62,7 +58,6 @@ public final class MethodCacheEntry {
         selector = lookupSelector;
         result = null;
         dispatchFailure = null;
-        dispatchFailureArity = -1;
         return this;
     }
 


### PR DESCRIPTION
### Description
This PR improves how the VM handles message dispatch failures. It integrates a DNU shortcut architecture into the dispatch paths and refines the handling of recursive failure scenarios.

### 1. Nested `#cannotInterpret:` Support
The VM now correctly handles "cascading" dispatch failures: If a message lookup fails (CI) and the subsequent attempt to send `#cannotInterpret:` also fails (CI), the VM now correctly nests these failures. `DispatchUtils` and related nodes now build nested `Message` objects, ensuring the original selector and arguments are preserved even across deep delegation chains.

### 2. Optimized DNU Shortcuts
Optional DNU shortcuts are now available for messages with 3 or fewer arguments. These shortcuts avoid the allocation of the arguments `Array` and the `Message` object by redirecting the failed dispatch to specialized, image-defined selectors.

* **Configuration:** The shortcuts are enabled by providing an array of symbols to the VM via the `primitiveSetDNUShortcutSelectors` primitive. The array maps message arity to a specific shortcut selector (index 1 for arity 0, index 2 for arity 1, etc.).
* **Form of the Shortcut:** When a dispatch failure occurs for an arity $N$ send, the VM checks if a shortcut is configured for that arity. If so, it dispatches a new message where the original arguments are followed by the original selector as the final argument.
    * *Example (Arity 2):* A failed send of `#at:put:` with args `[key, val]` is transformed into a send of the shortcut selector (e.g., `#dnu2:and:selector:`) with arguments `[key, val, #at:put:]`.
* **N-ary & Megamorphic Support:** This PR extends these shortcuts to the N-ary dispatch path and the indirect (megamorphic) path. By caching the arity as a compilation-final constant and using `@ExplodeLoop`, the JIT can unroll the shortcut frame creation into optimized machine code.

### 3. Cache Flushing & Stability
* **Absent Selector Assumptions:** Fallback nodes now track an image-global "absent selector" assumption. If a missing method is compiled into the image, the VM now correctly trips and invalidates these DNU nodes globally, preventing "stranded" DNU entries in the AST.
* **Stable Fallbacks:** The VM now tracks the stability of the fallback methods themselves (e.g., `#doesNotUnderstand:`), ensuring that if a developer redefines these error handlers, the AST updates immediately.

## Testing
* **Arity 0-3 Verification:** Verified that shortcuts for arities 0 through 3 correctly bypass standard DNU allocation and reach the expected Smalltalk methods.
* **Nested CI Verification:** Verified that corrupting multiple method dictionaries triggers the new nested `#cannotInterpret:` logic successfully, preserving the original message context.

[TruffleSqueakDispatchFallbackTests.st.zip](https://github.com/user-attachments/files/26916433/TruffleSqueakDispatchFallbackTests.st.zip)
