### PR TITLE
disable menubar shortcuts; fix setWindowIcon error

### DIFF
--- a/src/de.hpi.swa.trufflesqueak.launcher/src/de/hpi/swa/trufflesqueak/launcher/TruffleSqueakLauncher.java
+++ b/src/de.hpi.swa.trufflesqueak.launcher/src/de/hpi/swa/trufflesqueak/launcher/TruffleSqueakLauncher.java
@@ -34,6 +34,7 @@ import de.hpi.swa.trufflesqueak.shared.SqueakLanguageOptions;
 public final class TruffleSqueakLauncher extends AbstractLanguageLauncher {
     private static final String ENGINE_MODE_OPTION = "engine.Mode";
     private static final String ENGINE_MODE_LATENCY = "latency";
+    private static final String ENGINE_DYNAMIC_COMPILATION_THRESHOLDS_OPTION = "engine.DynamicCompilationThresholds";
 
     private static final String[] EMPTY_STRING_ARRAY = new String[0];
 
@@ -44,7 +45,8 @@ public final class TruffleSqueakLauncher extends AbstractLanguageLauncher {
     private String imagePath;
     private String sourceCode;
     private boolean enableTranscriptForwarding;
-    private boolean useEngineModeLatency = true;
+    private boolean addEnableEngineModeLatency = true;
+    private boolean addDisableDynamicCompilationThresholds = true;
 
     public static void main(final String[] arguments) throws RuntimeException {
         new TruffleSqueakLauncher().launch(arguments);
@@ -83,8 +85,11 @@ public final class TruffleSqueakLauncher extends AbstractLanguageLauncher {
             } else if (SqueakLanguageOptions.TRANSCRIPT_FORWARDING_FLAG.equals(arg)) {
                 enableTranscriptForwarding = true;
             } else {
+                // Check for options explicitly set by user
                 if (arg.contains(ENGINE_MODE_OPTION)) {
-                    useEngineModeLatency = false; // engine.Mode set explicitly
+                    addEnableEngineModeLatency = false;
+                } else if (arg.contains(ENGINE_DYNAMIC_COMPILATION_THRESHOLDS_OPTION)) {
+                    addDisableDynamicCompilationThresholds = false;
                 }
                 unrecognized.add(arg);
             }
@@ -111,15 +116,19 @@ public final class TruffleSqueakLauncher extends AbstractLanguageLauncher {
             println(imagePath);
             return 0;
         }
-        final String runtimeName = getRuntimeName();
-        // only ever use latency on Graal
-        useEngineModeLatency = useEngineModeLatency && runtimeName.contains("Graal");
         contextBuilder.option(SqueakLanguageConfig.ID + "." + SqueakLanguageOptions.IMAGE_PATH, imagePath);
         contextBuilder.option(SqueakLanguageConfig.ID + "." + SqueakLanguageOptions.HEADLESS, Boolean.toString(headless));
         contextBuilder.option(SqueakLanguageConfig.ID + "." + SqueakLanguageOptions.QUIET, Boolean.toString(quiet));
         contextBuilder.arguments(getLanguageId(), imageArguments);
-        if (useEngineModeLatency) {
+        final String runtimeName = getRuntimeName();
+        final boolean hasGraalCompiler = runtimeName.contains("Graal");
+        addEnableEngineModeLatency = addEnableEngineModeLatency && hasGraalCompiler;
+        if (addEnableEngineModeLatency) {
             contextBuilder.option(ENGINE_MODE_OPTION, ENGINE_MODE_LATENCY);
+        }
+        addDisableDynamicCompilationThresholds = addDisableDynamicCompilationThresholds && hasGraalCompiler;
+        if (addDisableDynamicCompilationThresholds) {
+            contextBuilder.option(ENGINE_DYNAMIC_COMPILATION_THRESHOLDS_OPTION, Boolean.toString(false));
         }
         contextBuilder.allowAllAccess(true);
         final SqueakTranscriptForwarder out;
@@ -135,7 +144,7 @@ public final class TruffleSqueakLauncher extends AbstractLanguageLauncher {
         }
         try (Context context = contextBuilder.build()) {
             if (!quiet) {
-                final String engineModeSuffix = useEngineModeLatency ? " (" + ENGINE_MODE_LATENCY + " mode)" : "";
+                final String engineModeSuffix = addEnableEngineModeLatency ? " (" + ENGINE_MODE_LATENCY + " mode)" : "";
                 println(String.format("[trufflesqueak] Running %s on %s%s...", new File(imagePath).getName(), runtimeName, engineModeSuffix));
             }
             if (sourceCode != null) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/io/MacMenuShortcutDisabler.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/io/MacMenuShortcutDisabler.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026 Software Architecture Group, Hasso Plattner Institute
+ * Copyright (c) 2026 Oracle and/or its affiliates
+ *
+ * Licensed under the MIT License.
+ */
+package de.hpi.swa.trufflesqueak.io;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+
+import static de.hpi.swa.trufflesqueak.sdl3.SDL3Utils.warning;
+
+@SuppressWarnings("restricted")
+class MacMenuShortcutDisabler {
+
+    // The inner class delays native initialization until explicitly called.
+    // This prevents libobjc lookup crashes on Windows and Linux.
+    private static final class ObjC {
+        static final Linker LINKER = Linker.nativeLinker();
+        static final SymbolLookup LIB = SymbolLookup.libraryLookup("libobjc.A.dylib", Arena.global());
+
+        static final MethodHandle OBJC_GET_CLASS;
+        static final MethodHandle SEL_REGISTER_NAME;
+
+        static final MethodHandle MSG_SEND_PTR;
+        static final MethodHandle MSG_SEND_PTR_PTR;
+        static final MethodHandle MSG_SEND_PTR_LONG;
+        static final MethodHandle MSG_SEND_LONG;
+        static final MethodHandle MSG_SEND_VOID_PTR;
+
+        static {
+            final MemorySegment getClassAddr = LIB.find("objc_getClass").orElseThrow();
+            OBJC_GET_CLASS = LINKER.downcallHandle(getClassAddr, FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+
+            final MemorySegment selRegNameAddr = LIB.find("sel_registerName").orElseThrow();
+            SEL_REGISTER_NAME = LINKER.downcallHandle(selRegNameAddr, FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+
+            final MemorySegment msgSendAddr = LIB.find("objc_msgSend").orElseThrow();
+
+            MSG_SEND_PTR = LINKER.downcallHandle(msgSendAddr,
+                            FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+
+            MSG_SEND_PTR_PTR = LINKER.downcallHandle(msgSendAddr,
+                            FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+
+            MSG_SEND_PTR_LONG = LINKER.downcallHandle(msgSendAddr,
+                            FunctionDescriptor.of(ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.JAVA_LONG));
+
+            MSG_SEND_LONG = LINKER.downcallHandle(msgSendAddr,
+                            FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+
+            MSG_SEND_VOID_PTR = LINKER.downcallHandle(msgSendAddr,
+                            FunctionDescriptor.ofVoid(ValueLayout.ADDRESS, ValueLayout.ADDRESS, ValueLayout.ADDRESS));
+        }
+    }
+
+    public static void disableSystemShortcuts() {
+        try (Arena arena = Arena.ofConfined()) {
+            final MemorySegment nsAppClass = (MemorySegment) ObjC.OBJC_GET_CLASS.invokeExact(arena.allocateFrom("NSApplication"));
+            final MemorySegment sharedAppSel = (MemorySegment) ObjC.SEL_REGISTER_NAME.invokeExact(arena.allocateFrom("sharedApplication"));
+            final MemorySegment app = (MemorySegment) ObjC.MSG_SEND_PTR.invokeExact(nsAppClass, sharedAppSel);
+
+            final MemorySegment mainMenuSel = (MemorySegment) ObjC.SEL_REGISTER_NAME.invokeExact(arena.allocateFrom("mainMenu"));
+            final MemorySegment mainMenu = (MemorySegment) ObjC.MSG_SEND_PTR.invokeExact(app, mainMenuSel);
+
+            if (mainMenu.equals(MemorySegment.NULL)) {
+                return;
+            }
+
+            final MemorySegment itemArraySel = (MemorySegment) ObjC.SEL_REGISTER_NAME.invokeExact(arena.allocateFrom("itemArray"));
+            final MemorySegment countSel = (MemorySegment) ObjC.SEL_REGISTER_NAME.invokeExact(arena.allocateFrom("count"));
+            final MemorySegment objectAtIndexSel = (MemorySegment) ObjC.SEL_REGISTER_NAME.invokeExact(arena.allocateFrom("objectAtIndex:"));
+            final MemorySegment submenuSel = (MemorySegment) ObjC.SEL_REGISTER_NAME.invokeExact(arena.allocateFrom("submenu"));
+            final MemorySegment keyEquivalentSel = (MemorySegment) ObjC.SEL_REGISTER_NAME.invokeExact(arena.allocateFrom("keyEquivalent"));
+            final MemorySegment utf8StringSel = (MemorySegment) ObjC.SEL_REGISTER_NAME.invokeExact(arena.allocateFrom("UTF8String"));
+            final MemorySegment setKeyEquivSel = (MemorySegment) ObjC.SEL_REGISTER_NAME.invokeExact(arena.allocateFrom("setKeyEquivalent:"));
+
+            final MemorySegment nsStringClass = (MemorySegment) ObjC.OBJC_GET_CLASS.invokeExact(arena.allocateFrom("NSString"));
+            final MemorySegment utf8Sel = (MemorySegment) ObjC.SEL_REGISTER_NAME.invokeExact(arena.allocateFrom("stringWithUTF8String:"));
+            final MemorySegment emptyString = (MemorySegment) ObjC.MSG_SEND_PTR_PTR.invokeExact(nsStringClass, utf8Sel, arena.allocateFrom(""));
+
+            final MemorySegment topLevelItems = (MemorySegment) ObjC.MSG_SEND_PTR.invokeExact(mainMenu, itemArraySel);
+            if (topLevelItems.equals(MemorySegment.NULL)) {
+                return;
+            }
+
+            final long topCount = (long) ObjC.MSG_SEND_LONG.invokeExact(topLevelItems, countSel);
+
+            // Iterate through top-level menus
+            for (long i = 0; i < topCount; i++) {
+                final MemorySegment topMenuItem = (MemorySegment) ObjC.MSG_SEND_PTR_LONG.invokeExact(topLevelItems, objectAtIndexSel, i);
+                final MemorySegment submenu = (MemorySegment) ObjC.MSG_SEND_PTR.invokeExact(topMenuItem, submenuSel);
+
+                if (!submenu.equals(MemorySegment.NULL)) {
+                    final MemorySegment subItems = (MemorySegment) ObjC.MSG_SEND_PTR.invokeExact(submenu, itemArraySel);
+                    if (!subItems.equals(MemorySegment.NULL)) {
+                        final long subCount = (long) ObjC.MSG_SEND_LONG.invokeExact(subItems, countSel);
+
+                        // Iterate through immediate sub-items
+                        for (long j = 0; j < subCount; j++) {
+                            final MemorySegment subMenuItem = (MemorySegment) ObjC.MSG_SEND_PTR_LONG.invokeExact(subItems, objectAtIndexSel, j);
+
+                            final MemorySegment keyEquivObj = (MemorySegment) ObjC.MSG_SEND_PTR.invokeExact(subMenuItem, keyEquivalentSel);
+                            if (!keyEquivObj.equals(MemorySegment.NULL)) {
+                                final MemorySegment cStrPtr = (MemorySegment) ObjC.MSG_SEND_PTR.invokeExact(keyEquivObj, utf8StringSel);
+                                if (!cStrPtr.equals(MemorySegment.NULL)) {
+                                    final String keyEquiv = cStrPtr.reinterpret(Long.MAX_VALUE).getString(0);
+                                    if ("q".equalsIgnoreCase(keyEquiv)) {
+                                        continue;
+                                    }
+                                }
+                            }
+
+                            // Clear the string shortcut
+                            ObjC.MSG_SEND_VOID_PTR.invokeExact(subMenuItem, setKeyEquivSel, emptyString);
+                        }
+                    }
+                }
+            }
+        } catch (final Throwable t) {
+            warning("MacMenuShortcutDisabler: Failed to strip shortcuts: " + t.getMessage());
+        }
+    }
+}

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/io/SqueakDisplay.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/io/SqueakDisplay.java
@@ -693,6 +693,9 @@ public final class SqueakDisplay {
                     if (cursorData != null) {
                         SDL_RunOnMainThread(setCursorTask, MemorySegment.NULL, false);
                     }
+                    if (OS.isMacOS()) {
+                        MacMenuShortcutDisabler.disableSystemShortcuts();
+                    }
                 }, arena), MemorySegment.NULL, true);
             }
         } else {
@@ -726,20 +729,20 @@ public final class SqueakDisplay {
                 final MemorySegment imageBuffer = arena.allocateFrom(ValueLayout.JAVA_BYTE, imageBytes);
                 final MemorySegment ioStream = SDL_IOFromMem(imageBuffer, imageBytes.length);
                 if (ioStream == MemorySegment.NULL) {
-                    warning(getSDLError());
+                    warning("SDL_IOFromMem failed: " + getSDLError());
                     return;
                 }
 
                 // Load the PNG directly from the IO stream
-                final MemorySegment iconSurface = checkSdlError(SDL_LoadPNG_IO(ioStream, true));
+                final MemorySegment iconSurface = SDL_LoadPNG_IO(ioStream, true);
 
                 if (iconSurface != MemorySegment.NULL) {
                     if (!SDL_SetWindowIcon(window, iconSurface)) {
-                        warning(getSDLError());
+                        warning("SDL_SetWindowIcon failed: " + getSDLError());
                     }
                     SDL_DestroySurface(iconSurface);
                 } else {
-                    warning(getSDLError());
+                    warning("SDL_LoadPNG_IO failed: " + getSDLError());
                 }
             }
         } catch (final IOException e) {


### PR DESCRIPTION
Disable the macOS menubar shortcuts (except for Command+Q).

Improve error handling in `setWindowIcon()` so that it gives a warning when the window icon PNG file cannot be read.