### PR TITLE
Merge extA and extB into extBA (supercedes #235)

### DIFF
--- a/src/de.hpi.swa.trufflesqueak.test/src/de/hpi/swa/trufflesqueak/test/SqueakMiscellaneousTest.java
+++ b/src/de.hpi.swa.trufflesqueak.test/src/de/hpi/swa/trufflesqueak/test/SqueakMiscellaneousTest.java
@@ -18,6 +18,8 @@ import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
 import de.hpi.swa.trufflesqueak.model.FloatObject;
 import de.hpi.swa.trufflesqueak.model.NilObject;
 import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.CONTEXT;
+import de.hpi.swa.trufflesqueak.nodes.interpreter.AbstractDecoder.ShadowBlockParams;
+import de.hpi.swa.trufflesqueak.nodes.interpreter.DecoderSistaV1;
 import de.hpi.swa.trufflesqueak.nodes.interpreter.DecoderV3PlusClosures;
 import de.hpi.swa.trufflesqueak.util.UnsafeUtils;
 
@@ -185,5 +187,30 @@ public final class SqueakMiscellaneousTest extends AbstractSqueakTestCaseWithDum
         );
         chunk.setSqueakClass(image.floatClass);
         return chunk;
+    }
+
+    @Test
+    public void testSistaV1ExtendedBlockSizeDecoder() {
+        /*
+         * EXT_B sequence for 0x8765 (34661): 225, 0, 225, 135, 225, 101. Followed by
+         * EXT_PUSH_CLOSURE (250) with byteA=192 and byteB=42. byteA=192 (11000000 in binary)
+         * encodes that there are 3 extensions (192 >> 6 == 3), 0 args, and 0 copied values.
+         */
+        final Object[] literals = {NilObject.SINGLETON, NilObject.SINGLETON};
+        final long header = makeHeaderWord(0, 0, 2, false, true);
+
+        final CompiledCodeObject code = makeMethod(header, literals,
+                        225, 0, 225, 135, 225, 101, 250, 192, 42);
+
+        // shadowBlockIndex is the index immediately following the closure creation bytecode
+        final int shadowBlockIndex = 9;
+
+        final ShadowBlockParams params = DecoderSistaV1.SINGLETON.decodeShadowBlock(code, shadowBlockIndex);
+
+        // Expected block size: (34661 << 8) | 42 = 8873258
+        // If the leading zero bug is present, this would incorrectly yield -7903958
+        assertEquals(8873258, params.blockSize());
+        assertEquals(0, params.numArgs());
+        assertEquals(0, params.numCopied());
     }
 }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/DecoderSistaV1.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/DecoderSistaV1.java
@@ -201,19 +201,22 @@ public final class DecoderSistaV1 extends AbstractDecoder {
     private static DecodedExtension decodeExtension(final byte[] bc, final int index) {
         int b = Byte.toUnsignedInt(bc[index]);
         int offset = 0;
-        int extA = 0;
-        int extB = 0;
+
+        // Track unified state
+        long extBA = 0;
+
         while (b == 0xE0 || b == 0xE1) {
             final int byteValue = Byte.toUnsignedInt(bc[index + offset + 1]);
             if (b == 0xE0) {
-                extA = (extA << 8) | byteValue;
+                extBA = InterpreterSistaV1Node.computeExtA(extBA, byteValue);
             } else {
-                extB = (extB == 0 && byteValue > 127) ? byteValue - 256 : (extB << 8) | byteValue;
+                extBA = InterpreterSistaV1Node.computeExtB(extBA, byteValue);
             }
             offset += 2;
             b = Byte.toUnsignedInt(bc[index + offset]);
         }
-        return new DecodedExtension(offset, extA, extB);
+
+        return new DecodedExtension(offset, (int) extBA, (int) (extBA >> 32));
     }
 
     private static int decodeNextPCDelta(final CompiledCodeObject code, final int index, final DecodedExtension extension, final boolean skipOverBlocks) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterSistaV1Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterSistaV1Node.java
@@ -83,6 +83,39 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
         super(original);
     }
 
+    @EarlyInline
+    static long computeExtA(final long currentExtBA, final int bytecode) {
+        final int newExtA = ((int) currentExtBA << 8) | bytecode;
+        return (currentExtBA >>> 32 << 32) | Integer.toUnsignedLong(newExtA);
+    }
+
+    @EarlyInline
+    static long computeExtB(final long currentExtBA, final int bytecode) {
+        /*
+         * OSVM maintains a counter (numExtB) to determine whether an EXT_B byte code is the first
+         * in a series. Here, we use extB == 0 to indicate that the byte code is the first. At the
+         * moment, Squeak only emits single EXT_B byte codes, so this method will always work.
+         * However, when the image starts using sequences of EXT_B byte codes and the value being
+         * encoded is a positive integer with positions 7, 15 or 23 as the highest set bit, the
+         * decoded value will be interpreted as a negative integer. For example, the emitted
+         * sequence for the value 0x8765 would be 0x00, 0x87, 0x65. If we assume that the encoder
+         * will never try to encode the value 0 (since that is the default value without any emitted
+         * byte codes), we can detect the case of the leading zero byte by setting the upper byte of
+         * extB and relying on the next byte to shift that byte out of the extB register.
+         */
+        final int extB = (int) (currentExtBA >> 32);
+        final int newExtB;
+        if (extB == 0) {
+            /* leading byte is signed */
+            /* make sure newExtB is non-zero for next byte processing */
+            newExtB = bytecode == 0 ? 0x80000000 : (byte) bytecode;
+        } else {
+            /* subsequent bytes are unsigned */
+            newExtB = (extB << 8) | bytecode;
+        }
+        return ((long) newExtB << 32) | Integer.toUnsignedLong((int) currentExtBA);
+    }
+
     @ValueType
     private static final class VirtualState {
         int sp;
@@ -105,36 +138,12 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
 
         @EarlyInline
         void updateExtA(final int bytecode) {
-            final int newExtA = ((int) extBA << 8) | bytecode;
-            extBA = (extBA >>> 32 << 32) | Integer.toUnsignedLong(newExtA);
+            extBA = computeExtA(extBA, bytecode);
         }
 
         @EarlyInline
         void updateExtB(final int bytecode) {
-            /*
-             * OSVM maintains a counter (numExtB) to determine whether an EXT_B byte code is the
-             * first in a series. Here, we use extB == 0 to indicate that the byte code is the
-             * first. At the moment, Squeak only emits single EXT_B byte codes, so this method will
-             * always work. However, when the image starts using sequences of EXT_B byte codes and
-             * the value being encoded is a positive integer with positions 7, 15 or 23 as the
-             * highest set bit, the decoded value will be interpreted as a negative integer. For
-             * example, the emitted sequence for the value 0x8765 would be 0x00, 0x87, 0x65. If we
-             * assume that the encoder will never try to encode the value 0 (since that is the
-             * default value without any emitted byte codes), we can detect the case of the leading
-             * zero byte by setting the upper byte of extB and relying on the next byte to shift
-             * that byte out of the extB register.
-             */
-            final int extB = (int) (extBA >> 32);
-            final int newExtB;
-            if (extB == 0) {
-                /* leading byte is signed */
-                /* make sure newExtB is non-zero for next byte processing */
-                newExtB = bytecode == 0 ? 0x80000000 : (byte) bytecode;
-            } else {
-                /* subsequent bytes are unsigned */
-                newExtB = (extB << 8) | bytecode;
-            }
-            extBA = ((long) newExtB << 32) | Integer.toUnsignedLong((int) extBA);
+            extBA = computeExtB(extBA, bytecode);
         }
 
         @EarlyInline

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterSistaV1Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterSistaV1Node.java
@@ -86,8 +86,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
     @ValueType
     private static final class VirtualState {
         int sp;
-        int extA;
-        int extB;
+        long extBA;
 
         @EarlyInline
         VirtualState(final int sp) {
@@ -95,18 +94,52 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
         }
 
         @EarlyInline
-        void resetExtA() {
-            extA = 0;
+        int getExtA() {
+            return (int) extBA;
         }
 
         @EarlyInline
-        void resetExtB() {
-            extB = 0;
+        int getExtB() {
+            return (int) (extBA >> 32);
+        }
+
+        @EarlyInline
+        void updateExtA(final int bytecode) {
+            final int newExtA = ((int) extBA << 8) | bytecode;
+            extBA = (extBA >>> 32 << 32) | Integer.toUnsignedLong(newExtA);
+        }
+
+        @EarlyInline
+        void updateExtB(final int bytecode) {
+            /*
+             * OSVM maintains a counter (numExtB) to determine whether an EXT_B byte code is the
+             * first in a series. Here, we use extB == 0 to indicate that the byte code is the
+             * first. At the moment, Squeak only emits single EXT_B byte codes, so this method will
+             * always work. However, when the image starts using sequences of EXT_B byte codes and
+             * the value being encoded is a positive integer with positions 7, 15 or 23 as the
+             * highest set bit, the decoded value will be interpreted as a negative integer. For
+             * example, the emitted sequence for the value 0x8765 would be 0x00, 0x87, 0x65. If we
+             * assume that the encoder will never try to encode the value 0 (since that is the
+             * default value without any emitted byte codes), we can detect the case of the leading
+             * zero byte by setting the upper byte of extB and relying on the next byte to shift
+             * that byte out of the extB register.
+             */
+            final int extB = (int) (extBA >> 32);
+            final int newExtB;
+            if (extB == 0) {
+                /* leading byte is signed */
+                /* make sure newExtB is non-zero for next byte processing */
+                newExtB = bytecode == 0 ? 0x80000000 : (byte) bytecode;
+            } else {
+                /* subsequent bytes are unsigned */
+                newExtB = (extB << 8) | bytecode;
+            }
+            extBA = ((long) newExtB << 32) | Integer.toUnsignedLong((int) extBA);
         }
 
         @EarlyInline
         void resetExtAB() {
-            extA = extB = 0;
+            extBA = 0;
         }
     }
 
@@ -140,8 +173,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
 
         int pc = startPC;
         assert pc < endPC;
-        int extA = 0;
-        int extB = 0;
+        final VirtualState vstate = new VirtualState(0);
 
         while (pc < endPC) {
             final int currentPC = pc++;
@@ -172,14 +204,14 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                     break;
                 }
                 case BC.EXT_PUSH_PSEUDO_VARIABLE: {
-                    if (extB == 0) {
+                    if (vstate.getExtB() == 0) {
                         break;
                     } else {
                         throw unknownBytecode();
                     }
                 }
                 case BC.EXT_NOP:
-                    extA = extB = 0;
+                    vstate.resetExtAB();
                     break;
                 case BC.BYTECODE_PRIM_SIZE, BC.BYTECODE_PRIM_NEXT, BC.BYTECODE_PRIM_AT_END, BC.BYTECODE_PRIM_VALUE, BC.BYTECODE_PRIM_NEW, BC.BYTECODE_PRIM_POINT_X, BC.BYTECODE_PRIM_POINT_Y: {
                     setData(currentPC, insert(Dispatch0NodeGen.create(image.getSpecialSelector(b - BC.BYTECODE_PRIM_ADD))));
@@ -239,30 +271,28 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                 }
                 /* 2 byte bytecodes */
                 case BC.EXT_A: {
-                    extA = (extA << 8) + getUnsignedInt(bc, pc++);
+                    vstate.updateExtA(getUnsignedInt(bc, pc++));
                     break;
                 }
                 case BC.EXT_B: {
-                    final int byteValue = getUnsignedInt(bc, pc++);
-                    extB = extB == 0 && byteValue > 127 ? byteValue - 256 : (extB << 8) + byteValue;
-                    assert extB != 0 : "should use numExtB?";
+                    vstate.updateExtB(getUnsignedInt(bc, pc++));
                     break;
                 }
                 case BC.EXT_PUSH_RECEIVER_VARIABLE: {
                     setData(currentPC, insert(SqueakObjectAt0NodeGen.create()));
                     pc++;
-                    extA = 0;
+                    vstate.resetExtAB();
                     break;
                 }
                 case BC.EXT_PUSH_LITERAL_VARIABLE: {
-                    setData(currentPC, getLiteralVariableOrCreateLiteralNode(code.getAndResolveLiteral(getByteExtended(bc, pc, extA))));
+                    setData(currentPC, getLiteralVariableOrCreateLiteralNode(code.getAndResolveLiteral(getByteExtended(bc, pc, vstate.getExtA()))));
                     pc++;
-                    extA = 0;
+                    vstate.resetExtAB();
                     break;
                 }
                 case BC.EXT_PUSH_LITERAL, BC.EXT_PUSH_CHARACTER: {
                     pc++;
-                    extA = 0;
+                    vstate.resetExtAB();
                     break;
                 }
                 case BC.LONG_PUSH_TEMPORARY_VARIABLE, BC.PUSH_NEW_ARRAY, BC.LONG_STORE_AND_POP_TEMPORARY_VARIABLE, BC.LONG_STORE_TEMPORARY_VARIABLE: {
@@ -271,21 +301,21 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                 }
                 case BC.EXT_PUSH_INTEGER: {
                     pc++;
-                    extB = 0;
+                    vstate.resetExtAB();
                     break;
                 }
                 case BC.EXT_SEND: {
                     final int byte1 = getUnsignedInt(bc, pc++);
-                    final int literalIndex = (byte1 >> 3) + (extA << 5);
+                    final int literalIndex = (byte1 >> 3) + (vstate.getExtA() << 5);
                     final NativeObject selector = (NativeObject) code.getAndResolveLiteral(literalIndex);
                     setData(currentPC, insert(DispatchNaryNodeGen.create(selector)));
-                    extA = extB = 0;
+                    vstate.resetExtAB();
                     break;
                 }
                 case BC.EXT_SEND_SUPER: {
-                    final boolean isDirected = extB >= 64;
+                    final boolean isDirected = vstate.getExtB() >= 64;
                     final int byte1 = getUnsignedInt(bc, pc++);
-                    final int literalIndex = (byte1 >> 3) + (extA << 5);
+                    final int literalIndex = (byte1 >> 3) + (vstate.getExtA() << 5);
                     final NativeObject selector = (NativeObject) code.getAndResolveLiteral(literalIndex);
                     final Node node;
                     if (isDirected) {
@@ -295,27 +325,27 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                         node = DispatchSuperNaryNodeGen.create(methodClass, selector);
                     }
                     setData(currentPC, insert(node));
-                    extA = extB = 0;
+                    vstate.resetExtAB();
                     break;
                 }
                 case BC.EXT_UNCONDITIONAL_JUMP: {
-                    final int jumpOffset = calculateLongExtendedOffset(getByte(bc, pc++), extB);
+                    final int jumpOffset = calculateLongExtendedOffset(getByte(bc, pc++), vstate.getExtB());
                     if (jumpOffset < 0) {
                         setData(currentPC, insert(createCheckForInterruptsInLoopNode(currentPC, 2, jumpOffset)));
                     }
-                    extA = extB = 0;
+                    vstate.resetExtAB();
                     break;
                 }
                 case BC.EXT_JUMP_IF_TRUE, BC.EXT_JUMP_IF_FALSE: {
                     setData(currentPC, CountingConditionProfile.create());
                     pc++;
-                    extA = extB = 0;
+                    vstate.resetExtAB();
                     break;
                 }
                 case BC.EXT_STORE_AND_POP_RECEIVER_VARIABLE, BC.EXT_STORE_AND_POP_LITERAL_VARIABLE, BC.EXT_STORE_RECEIVER_VARIABLE, BC.EXT_STORE_LITERAL_VARIABLE: {
                     setData(currentPC, insert(SqueakObjectAtPut0NodeGen.create()));
                     pc++;
-                    extA = 0;
+                    vstate.resetExtAB();
                     break;
                 }
                 /* 3 byte bytecodes */
@@ -325,17 +355,18 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                 }
                 case BC.EXT_PUSH_FULL_CLOSURE: {
                     pc += 2;
-                    extA = 0;
+                    vstate.resetExtAB();
                     break;
                 }
                 case BC.EXT_PUSH_CLOSURE: {
                     final int byteA = getUnsignedInt(bc, pc++);
+                    final int extA = vstate.getExtA();
                     final int numArgs = (byteA & 0x07) + (extA & 0x0F) * 8;
                     final int numCopied = (byteA >> 3 & 0x7) + (extA >> 4) * 8;
-                    final int blockSize = getByteExtended(bc, pc++, extB);
+                    final int blockSize = getByteExtended(bc, pc++, vstate.getExtB());
                     setData(currentPC, createBlock(code, pc, numArgs, numCopied, blockSize));
                     pc += blockSize;
-                    extA = extB = 0;
+                    vstate.resetExtAB();
                     break;
                 }
                 case BC.PUSH_REMOTE_TEMP_LONG: {
@@ -384,8 +415,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
         while (pc != LOCAL_RETURN_PC) {
             CompilerAsserts.partialEvaluationConstant(pc);
             CompilerAsserts.partialEvaluationConstant(vstate.sp);
-            CompilerAsserts.partialEvaluationConstant(vstate.extA);
-            CompilerAsserts.partialEvaluationConstant(vstate.extB);
+            CompilerAsserts.partialEvaluationConstant(vstate.extBA);
             try {
                 switch (HostCompilerDirectives.markThreadedSwitch(currentBytecode(bc, pc))) {
                     /* 1 byte bytecodes */
@@ -1694,12 +1724,12 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
     @EarlyInline
     @BytecodeInterpreterHandler(value = BC.EXT_PUSH_PSEUDO_VARIABLE, safepoint = false)
     private int handlePushPseudoVariable(final VirtualFrame frame, final int pc, final VirtualState vstate, final State state) {
-        if (vstate.extB == 0) {
+        if (vstate.getExtB() == 0) {
             push(frame, vstate.sp++, getOrCreateContext(frame, pc));
         } else {
             throw unknownBytecode(pc, getByte(state.bytecode, pc));
         }
-        assert vstate.extA == 0;
+        assert vstate.getExtA() == 0;
         return pc + 1;
     }
 
@@ -1763,8 +1793,8 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
     @SuppressWarnings("static-method")
     @BytecodeInterpreterHandler(value = BC.EXT_PUSH_INTEGER, safepoint = false)
     private int handleExtendedPushInteger(final VirtualFrame frame, final int pc, final VirtualState vstate, final State state) {
-        push(frame, vstate.sp++, (long) getByteExtended(state.bytecode, pc + 1, vstate.extB));
-        vstate.resetExtB();
+        push(frame, vstate.sp++, (long) getByteExtended(state.bytecode, pc + 1, vstate.getExtB()));
+        vstate.resetExtAB();
         return pc + 2;
     }
 
@@ -1801,12 +1831,12 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
     @BytecodeInterpreterHandler(value = BC.EXT_PUSH_CLOSURE, safepoint = false)
     private int handleExtendedPushClosure(final VirtualFrame frame, final int pc, final VirtualState vstate, final State state) {
         final int byteA = getUnsignedInt(state.bytecode, pc + 1);
-        final int numCopied = (byteA >> 3 & 0x7) + (vstate.extA >> 4) * 8;
+        final int numCopied = (byteA >> 3 & 0x7) + (vstate.getExtA() >> 4) * 8;
         CompilerAsserts.partialEvaluationConstant(numCopied);
         final Object[] copiedValues = popN(frame, vstate.sp, numCopied);
         vstate.sp -= numCopied;
         push(frame, vstate.sp++, createBlockClosure(frame, ACCESS.uncheckedCast(getData(pc), CompiledCodeObject.class), copiedValues, getOrCreateContext(frame, pc)));
-        final int blockSize = getByteExtended(state.bytecode, pc + 2, vstate.extB);
+        final int blockSize = getByteExtended(state.bytecode, pc + 2, vstate.getExtB());
         CompilerAsserts.partialEvaluationConstant(blockSize);
         vstate.resetExtAB();
         return pc + 3 + blockSize;
@@ -2432,7 +2462,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
     private int handleExtendedSend(final VirtualFrame frame, final int pc, final VirtualState vstate, final State state) {
         int nextPC = pc + 2;
         final int byte1 = getUnsignedInt(state.bytecode, pc + 1);
-        final int numArgs = (byte1 & 7) + (vstate.extB << 3);
+        final int numArgs = (byte1 & 7) + (vstate.getExtB() << 3);
         CompilerAsserts.partialEvaluationConstant(numArgs);
         final Object[] arguments = popN(frame, vstate.sp, numArgs);
         vstate.sp -= numArgs;
@@ -2449,7 +2479,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
     private int handleExtendedSuperSend(final VirtualFrame frame, final int pc, final VirtualState vstate, final State state) {
         int nextPC = pc + 2;
         final boolean isDirected;
-        final int extB = vstate.extB;
+        final int extB = vstate.getExtB();
         final int extBValue;
         if (extB >= 64) {
             isDirected = true;
@@ -2662,7 +2692,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
     @EarlyInline
     @BytecodeInterpreterHandler(value = BC.EXT_UNCONDITIONAL_JUMP, safepoint = true)
     private int handleExtendedUnconditionalJump(final VirtualFrame frame, final int pc, final VirtualState vstate, final State state) {
-        final int jumpOffset = calculateLongExtendedOffset(getByte(state.bytecode, pc + 1), vstate.extB);
+        final int jumpOffset = calculateLongExtendedOffset(getByte(state.bytecode, pc + 1), vstate.getExtB());
         final int nextPC = pc + 2 + jumpOffset;
         if (jumpOffset < 0) {
             if (CompilerDirectives.hasNextTier()) {
@@ -2699,7 +2729,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
     @BytecodeInterpreterHandler(value = BC.EXT_JUMP_IF_TRUE, safepoint = false)
     private int handleExtendedConditionalJumpTrue(final VirtualFrame frame, final int pc, final VirtualState vstate, final State state) {
         final Object stackValue = pop(frame, --vstate.sp);
-        final int jumpOffset = getByteExtended(state.bytecode, pc + 1, vstate.extB);
+        final int jumpOffset = getByteExtended(state.bytecode, pc + 1, vstate.getExtB());
         final int nextPC = pc + 2;
         if (stackValue instanceof final Boolean condition) {
             vstate.resetExtAB();
@@ -2717,7 +2747,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
     @BytecodeInterpreterHandler(value = BC.EXT_JUMP_IF_FALSE, safepoint = false)
     private int handleExtendedConditionalJumpFalse(final VirtualFrame frame, final int pc, final VirtualState vstate, final State state) {
         final Object stackValue = pop(frame, --vstate.sp);
-        final int jumpOffset = getByteExtended(state.bytecode, pc + 1, vstate.extB);
+        final int jumpOffset = getByteExtended(state.bytecode, pc + 1, vstate.getExtB());
         final int nextPC = pc + 2;
         if (stackValue instanceof final Boolean condition) {
             vstate.resetExtAB();
@@ -2747,7 +2777,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
     @SuppressWarnings({"unused", "static-method"})
     @BytecodeInterpreterHandler(value = BC.EXT_A, safepoint = false)
     private int handleExtA(final VirtualFrame frame, final int pc, final VirtualState vstate, final State state) {
-        vstate.extA = (vstate.extA << 8) + getUnsignedInt(state.bytecode, pc + 1);
+        vstate.updateExtA(getUnsignedInt(state.bytecode, pc + 1));
         return pc + 2;
     }
 
@@ -2755,9 +2785,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
     @SuppressWarnings({"unused", "static-method"})
     @BytecodeInterpreterHandler(value = BC.EXT_B, safepoint = false)
     private int handleExtB(final VirtualFrame frame, final int pc, final VirtualState vstate, final State state) {
-        final int byteValue = getUnsignedInt(state.bytecode, pc + 1);
-        vstate.extB = vstate.extB == 0 && byteValue > 127 ? byteValue - 256 : (vstate.extB << 8) + byteValue;
-        assert vstate.extB != 0 : "is numExtB needed?";
+        vstate.updateExtB(getUnsignedInt(state.bytecode, pc + 1));
         return pc + 2;
     }
 
@@ -2775,9 +2803,9 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
 
     @EarlyInline
     private static int getByteExtendedWithExtA(final int pc, final VirtualState vstate, final State state) {
-        final int index = getByteExtended(state.bytecode, pc + 1, vstate.extA);
+        final int index = getByteExtended(state.bytecode, pc + 1, vstate.getExtA());
         CompilerAsserts.partialEvaluationConstant(index);
-        vstate.resetExtA();
+        vstate.resetExtAB();
         return index;
     }
 


### PR DESCRIPTION
This PR merges the `VirtualState` fields `extA` and `extB` (`int`s) into a single variable `extBA` (`long`). This will reduce the register pressure on the threaded interpreter, especially for Intel processors. This supercedes PR #235.

Changes:

- accessing `extA` and `extB` are now through helpers `getExtA()` and `getExtB()`
- replaced calls to `resetExtA()` and `resetExtB()` with `resetExtAB()`
- `processBytecode()` was modified to use `VirtualState` for tracking the extension register values
- decoding **EXT_A** and **EXT_B** byte codes and updating `extBA` is now handled in `VirtualState`
- decoding the **EXT_B** byte code now handles multibyte sequences properly

OSVM maintains a counter (`numExtB`) to determine whether an **EXT_B** byte code is the first in a series. Instead, we have been using `extB == 0` to indicate that the byte code is the first. At the moment, Squeak only emits single **EXT_B** byte codes, so this method will always work.

However, when the image starts using _sequences_ of **EXT_B** byte codes and the value being encoded is a positive integer with positions 7, 15 or 23 as the highest set bit, the decoded value will be interpreted as a negative integer. For example, the
emitted sequence for the value 0x8765 would be 0x00, 0x87, 0x65 and the second byte would be interpreted as a signed value in the current implementation.

If we assume that the encoder in the image will never try to encode the value 0 (which is safe since that is the default value without any emitted **EXT_B** byte codes), we can detect the case of the leading zero byte by setting the upper byte of `extB` and relying on the next byte to shift that byte out of the register.