### PR TITLE
Fix SDL display crashes on Wayland with HiDPI scaling

### DIFF
--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/io/SqueakDisplay.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/io/SqueakDisplay.java
@@ -447,6 +447,11 @@ public final class SqueakDisplay {
             resetDamage();
             frameRequested = false;
 
+            // Skip frame if staging buffer is outdated (e.g. after HiDPI resize)
+            if (stagingPitchBytes != width * Integer.BYTES) {
+                return;
+            }
+
             if (safeTop >= safeBottom || safeLeft >= safeRight) {
                 return;
             }
@@ -729,7 +734,9 @@ public final class SqueakDisplay {
                 final MemorySegment iconSurface = checkSdlError(SDL_LoadPNG_IO(ioStream, true));
 
                 if (iconSurface != MemorySegment.NULL) {
-                    checkSdlError(SDL_SetWindowIcon(window, iconSurface));
+                    if (!SDL_SetWindowIcon(window, iconSurface)) {
+                        warning(getSDLError());
+                    }
                     SDL_DestroySurface(iconSurface);
                 } else {
                     warning(getSDLError());


### PR DESCRIPTION
This PR fixes two crashes that occured on my Laptop when launching TruffleSqueak on Wayland with HiDPI displays.

1. Window icon crash on Wayland
Setting the window icon fails on wayland desktop environments that don't support the xdg_toplevel_icon_v1 protocol. Previously this was treated as a fatal error, terminating the VM. Since the window icon is imo purely cosmetic, the failure is now logged as a warning instead. Any recommemdation for a better solution?

2. SIGSEGV after HiDPI resize
On HiDPI displays (e.g. scaleFactor=1.5), the display is initially opened at logical dimensions (e.g. 1024×749), then Smalltalk re-opens it at physical dimensions (e.g. 1536×1124) after discovering the scale factor. This triggers a render before the pixel staging buffer has been re-allocated for the larger size, causing an out-of-bounds read that crashes the GPU driver. The fix skips the render when the staging buffer dimensions don't match the current display size. The next display update will re-allocate the buffer and render correctly.

### Tested on
- HP Envy x360 15-fh0xxx
- AMD Ryzen 7 7730U (Radeon Graphics)
- Ubuntu 25.10 with Wayland
- scaleFactor=1.5
- Mesa 25.2.8
- GraalVM CE 25.0.2
