### PR TITLE
Do not skip restarted Contexts on marked CompiledMethods

### DIFF
--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
@@ -580,7 +580,9 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
 
     // The context represents primitive call which needs to be skipped when unwinding call stack.
     public boolean isPrimitiveContext() {
-        return !hasClosure() && getCodeObject().hasPrimitive() && getInstructionPointerForBytecodeLoop() == 0;
+        return getInstructionPointerForBytecodeLoop() == 0 && //
+                        !hasClosure() && !isUnwindMarked() && !isExceptionHandlerMarked() && //
+                        getCodeObject().hasPrimitive();
     }
 
     @TruffleBoundary

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
@@ -578,13 +578,6 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
         senderOrFrameOrSize = frame;
     }
 
-    // The context represents primitive call which needs to be skipped when unwinding call stack.
-    public boolean isPrimitiveContext() {
-        return getInstructionPointerForBytecodeLoop() == 0 && //
-                        !hasClosure() && !isUnwindMarked() && !isExceptionHandlerMarked() && //
-                        getCodeObject().hasPrimitive();
-    }
-
     @TruffleBoundary
     public boolean pointsTo(final Object thang) {
         // TODO: make sure this works correctly

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
@@ -136,28 +136,15 @@ public final class ExecuteTopLevelContextNode extends RootNode {
         } else if (senderContext.isDead()) {
             return sendCannotReturnOrReturnToTopLevel(activeContext, senderContext, returnValue);
         }
-        final ContextObject context;
-        if (senderContext.isPrimitiveContext()) {
-            context = (ContextObject) senderContext.getFrameSender(); // skip primitive contexts.
-        } else {
-            context = senderContext;
-        }
-        context.push(returnValue);
-        return context;
+        senderContext.push(returnValue);
+        return senderContext;
     }
 
     @TruffleBoundary
     private ContextObject commonNVReturn(final ContextObject activeContext, final NonVirtualReturn nvr) {
         // Normal returns with modified senders end up here with a target but no start Context.
         final Object returnValue = nvr.getReturnValue();
-        final ContextObject possibleTargetContext = nvr.getTargetContext();
-        final ContextObject targetContext;
-        // Skip over primitive contexts.
-        if (possibleTargetContext.isPrimitiveContext()) {
-            targetContext = (ContextObject) possibleTargetContext.getFrameSender();
-        } else {
-            targetContext = possibleTargetContext;
-        }
+        final ContextObject targetContext = nvr.getTargetContext();
         // Make sure that the targetContext can be returned to.
         if (!targetContext.hasClosure() && !targetContext.canBeReturnedTo()) {
             return sendCannotReturnOrReturnToTopLevel(activeContext, targetContext, returnValue);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterSistaV1Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterSistaV1Node.java
@@ -790,7 +790,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                     }
                     case BC.RETURN_TOP_FROM_METHOD: {
                         state.reportLoopCountOnReturn(this);
-                        returnValue = handleReturn(frame, pc, pc + 1, vstate.sp, top(frame, vstate.sp));
+                        returnValue = handleReturn(frame, pc, pc + 1, vstate.sp - 1, top(frame, vstate.sp));
                         pc = LOCAL_RETURN_PC;
                         break;
                     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterV3PlusClosuresNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterV3PlusClosuresNode.java
@@ -405,7 +405,7 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                         break;
                     }
                     case BC.RETURN_TOP_FROM_METHOD: {
-                        returnValue = handleReturn(frame, currentPC, pc, sp, top(frame, sp),
+                        returnValue = handleReturn(frame, currentPC, pc, sp - 1, top(frame, sp),
                                         CompilerDirectives.inCompiledCode() && CompilerDirectives.hasNextTier() ? loopCounter.value : counter);
                         pc = LOCAL_RETURN_PC;
                         break;

--- a/src/image-tests/runCuisTests.st
+++ b/src/image-tests/runCuisTests.st
@@ -31,7 +31,6 @@ failingTests := OrderedCollection new.
 {
     #FloatTest -> #(#testHashWithSmallishLargeNegativeInteger #testHashWithSmallishLargePositiveInteger #testIsDenormalized #testPrimTruncated).
     #IntegerTest -> #(#testRange).
-    #StringTest -> #("flaky" #testFindSelector).
     #SmallIntegerTest -> #(#testDivideMayOverflow).
 } collect: [:assoc | | testCase |
     testCase := Smalltalk at: assoc key.

--- a/src/image-tests/runSqueakTests.st
+++ b/src/image-tests/runSqueakTests.st
@@ -213,7 +213,6 @@
         SequenceableCollectionTest -> #(#testCollectWithIndexDeprecation).
         SetInspectorTest -> #(#testExpressions).
         SHParserST80Test -> #(#testNumbers).
-        StringTest ->#(#testFindSelector).
         TestValueWithinFix -> #(#testValueWithinTimingBasic #testValueWithinTimingNestedInner #testValueWithinTimingNestedOuter #testValueWithinTimingRepeat).
         WeakIdentityDictionaryTest -> #(#testIsEmpty).
         WeakKeyDictionaryTest -> #(#testIsEmpty).


### PR DESCRIPTION
In `ExecuteTopLevelContextNode`, `returnTo()` and `commonNVReturn()` skip over primitive Contexts assuming that the returned value is really destined for the sender of the primitive.

The current test checks if the Context is not for a closure, has an assigned primitive, and has PC = 0. However, the test does not take into account that unwind-marked and exception-handler-marked methods have primitives (without implementations, so always failing) and whose PC could be reset to zero when an exception handler is retried.

This can cause the Cuis 5 ExceptionTests #testSimpleRetry and #testSimpleRetryUsing to fail randomly: when the exception handler is restarted on the Truffle frame stack, the restart works and the test passes; if not on the Truffle stack, the test will fail.

I am not certain, but this may also be the cause of random failures of StringTest #testFindSelector.

This PR refines `ContextObject` `isPrimitiveContext()` to account for these marked Contexts and rearranges the conditions for the fewest number of tests during normal execution.

This PR also changes the handling of the return-top-from-method bytecodes in both Interpreters to pass a decremented stack pointer to `handleReturn()` since those bytecodes are supposed to pop the stack and return the value to the sender. This only makes a difference for block returns that send either #aboutToReturn:through: or #cannotReturn: