### PR TITLE
Remove internalizePC()

### DIFF
--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
@@ -8,6 +8,8 @@ package de.hpi.swa.trufflesqueak.model;
 
 import java.util.Arrays;
 
+import com.oracle.truffle.api.frame.Frame;
+import com.oracle.truffle.api.frame.FrameInstance;
 import org.graalvm.collections.UnmodifiableEconomicMap;
 
 import com.oracle.truffle.api.CallTarget;
@@ -370,6 +372,24 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
         FrameAccess.setInstructionPointer(truffleFrame, instructionPointer);
         FrameAccess.setStackPointer(truffleFrame, stackPointer);
         return truffleFrame;
+    }
+
+    @TruffleBoundary
+    public boolean isActiveOnTruffleStack() {
+        // No Truffle frame means the receiver is not yet executing.
+        if (!hasTruffleFrame()) {
+            return false;
+        }
+        final Object result = Truffle.getRuntime().iterateFrames(frameInstance -> {
+            final Frame current = frameInstance.getFrame(FrameInstance.FrameAccess.READ_ONLY);
+            if (FrameAccess.isTruffleSqueakFrame(current)) {
+                if (this == FrameAccess.getContext(current)) {
+                    return Boolean.TRUE;
+                }
+            }
+            return null;
+        });
+        return result != null;
     }
 
     public BlockClosureObject getClosure() {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
@@ -382,10 +382,8 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
         }
         final Object result = Truffle.getRuntime().iterateFrames(frameInstance -> {
             final Frame current = frameInstance.getFrame(FrameInstance.FrameAccess.READ_ONLY);
-            if (FrameAccess.isTruffleSqueakFrame(current)) {
-                if (this == FrameAccess.getContext(current)) {
-                    return Boolean.TRUE;
-                }
+            if (FrameAccess.isTruffleSqueakFrame(current) && this == FrameAccess.getContext(current)) {
+                return Boolean.TRUE;
             }
             return null;
         });

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
@@ -15,7 +15,9 @@ import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.Truffle;
+import com.oracle.truffle.api.frame.Frame;
 import com.oracle.truffle.api.frame.FrameDescriptor;
+import com.oracle.truffle.api.frame.FrameInstance;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.Node;
@@ -372,22 +374,18 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
         return truffleFrame;
     }
 
-    public boolean isActiveOnTruffleStack(final VirtualFrame frame) {
+    public boolean isActiveOnTruffleStack() {
         if (!hasTruffleFrame()) {
             return false; // No Truffle frame means the receiver is not yet executing.
         }
-        if (FrameAccess.getContext(frame) == this) {
-            return true; // Found it.
-        }
-        // Continue walking the sender chain.
-        AbstractSqueakObject currentContextOrNil = FrameAccess.getSenderContext(frame);
-        while (currentContextOrNil != NilObject.SINGLETON) {
-            if (currentContextOrNil == this) {
+        final Object result = Truffle.getRuntime().iterateFrames(frameInstance -> {
+            final Frame current = frameInstance.getFrame(FrameInstance.FrameAccess.READ_ONLY);
+            if (current != null && FrameAccess.isTruffleSqueakFrame(current) && this == FrameAccess.getContext(current)) {
                 return true;
             }
-            currentContextOrNil = ((ContextObject) currentContextOrNil).getFrameSender();
-        }
-        return false;
+            return null;
+        });
+        return result != null;
     }
 
     public BlockClosureObject getClosure() {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
@@ -270,6 +270,35 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
     }
 
     /**
+     * Returns true if the Context might be currently executing on the Truffle stack. This acts as a
+     * fast-path flag to avoid expensive {@link #isActiveOnTruffleStackSlow()} checks. Returns false
+     * if it is guaranteed to have been forced to the heap or suspended.
+     * <p>
+     * Note: We use inverted bit logic (0 = potentially active, 1 = inactive) to take advantage of
+     * default zero-initialization. This ensures newly created Contexts safely default to requiring
+     * a stack check.
+     */
+    public boolean isPotentiallyActiveOnTruffleStack() {
+        return !isBooleanDSet();
+    }
+
+    /**
+     * Caches the state indicating this Context is no longer active on the stack. Used to avoid
+     * repeated Truffle frame iterations when a suspended context is modified multiple times.
+     */
+    public void markAsInactiveOnTruffleStack() {
+        setBooleanDBit();
+    }
+
+    /**
+     * Indicates that this Context has resumed execution. Resets the flag so that future external
+     * modifications to this Context will trigger a proper stack check.
+     */
+    public void markAsPotentiallyActiveOnTruffleStack() {
+        clearBooleanDBit();
+    }
+
+    /**
      * Sets the sender of a ContextObject.
      */
     public void setSender(final AbstractSqueakObject value) {
@@ -374,7 +403,7 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
         return truffleFrame;
     }
 
-    public boolean isActiveOnTruffleStack() {
+    public boolean isActiveOnTruffleStackSlow() {
         if (!hasTruffleFrame()) {
             return false; // No Truffle frame means the receiver is not yet executing.
         }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
@@ -8,8 +8,6 @@ package de.hpi.swa.trufflesqueak.model;
 
 import java.util.Arrays;
 
-import com.oracle.truffle.api.frame.Frame;
-import com.oracle.truffle.api.frame.FrameInstance;
 import org.graalvm.collections.UnmodifiableEconomicMap;
 
 import com.oracle.truffle.api.CallTarget;
@@ -374,20 +372,22 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
         return truffleFrame;
     }
 
-    @TruffleBoundary
-    public boolean isActiveOnTruffleStack() {
-        // No Truffle frame means the receiver is not yet executing.
+    public boolean isActiveOnTruffleStack(final VirtualFrame frame) {
         if (!hasTruffleFrame()) {
-            return false;
+            return false; // No Truffle frame means the receiver is not yet executing.
         }
-        final Object result = Truffle.getRuntime().iterateFrames(frameInstance -> {
-            final Frame current = frameInstance.getFrame(FrameInstance.FrameAccess.READ_ONLY);
-            if (FrameAccess.isTruffleSqueakFrame(current) && this == FrameAccess.getContext(current)) {
-                return Boolean.TRUE;
+        if (FrameAccess.getContext(frame) == this) {
+            return true; // Found it.
+        }
+        // Continue walking the sender chain.
+        AbstractSqueakObject currentContextOrNil = FrameAccess.getSenderContext(frame);
+        while (currentContextOrNil != NilObject.SINGLETON) {
+            if (currentContextOrNil == this) {
+                return true;
             }
-            return null;
-        });
-        return result != null;
+            currentContextOrNil = ((ContextObject) currentContextOrNil).getFrameSender();
+        }
+        return false;
     }
 
     public BlockClosureObject getClosure() {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ResumeContextRootNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ResumeContextRootNode.java
@@ -42,6 +42,12 @@ public final class ResumeContextRootNode extends AbstractRootNode {
          * the active context.
          */
         FrameAccess.setContext(frame, activeContext);
+        /*
+         * Reset the fast-path flag to indicate this Context has resumed execution. Future external
+         * modifications to this Context's instruction pointer will now trigger a proper stack
+         * check. See AbstractInterpreterNode#checkForAndHandlePCModification
+         */
+        activeContext.markAsPotentiallyActiveOnTruffleStack();
         activeContext.clearModifiedSender();
         final int pc = instructionPointerProfile.profile(activeContext.getInstructionPointerForBytecodeLoop());
         final int sp = stackPointerProfile.profile(activeContext.getStackPointer());

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractInterpreterNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractInterpreterNode.java
@@ -25,6 +25,7 @@ import com.oracle.truffle.api.nodes.NodeVisitor;
 import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.source.SourceSection;
 
+import de.hpi.swa.trufflesqueak.exceptions.ProcessSwitch;
 import de.hpi.swa.trufflesqueak.exceptions.Returns.AbstractStandardSendReturn;
 import de.hpi.swa.trufflesqueak.exceptions.Returns.CannotReturnToTarget;
 import de.hpi.swa.trufflesqueak.exceptions.Returns.NonLocalReturn;
@@ -38,7 +39,10 @@ import de.hpi.swa.trufflesqueak.model.BlockClosureObject;
 import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
 import de.hpi.swa.trufflesqueak.model.ContextObject;
 import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.ASSOCIATION;
+import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.CONTEXT;
+import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.PROCESS;
 import de.hpi.swa.trufflesqueak.nodes.AbstractNode;
+import de.hpi.swa.trufflesqueak.nodes.accessing.AbstractPointersObjectNodes.AbstractPointersObjectWriteNode;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectAt0NodeGen;
 import de.hpi.swa.trufflesqueak.nodes.context.GetOrCreateContextWithFrameNode;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector0NodeFactory.Dispatch0NodeGen;
@@ -349,6 +353,19 @@ public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrum
         CompilerDirectives.transferToInterpreter();
         FrameAccess.externalizePCAndSP(frame, pc, sp);
         throw new CannotReturnToTarget(returnValue, GetOrCreateContextWithFrameNode.executeUncached(frame));
+    }
+
+    protected final void checkForAndHandlePCModification(final VirtualFrame frame, final int pc, final int sp, final int index, final Object receiver, final int nextPC) {
+        if (index == CONTEXT.INSTRUCTION_POINTER && receiver instanceof ContextObject context) {
+            enter(pc, getProfile(pc), BRANCH1);
+            if (context.isActiveOnTruffleStack(frame)) {
+                CompilerDirectives.transferToInterpreter();
+                FrameAccess.externalizePCAndSP(frame, nextPC, sp);
+                final ContextObject activeContext = GetOrCreateContextWithFrameNode.executeUncached(frame);
+                AbstractPointersObjectWriteNode.executeUncached(getContext().getActiveProcessSlow(), PROCESS.SUSPENDED_CONTEXT, activeContext);
+                throw ProcessSwitch.SINGLETON;
+            }
+        }
     }
 
     /*

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractInterpreterNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractInterpreterNode.java
@@ -358,7 +358,7 @@ public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrum
     protected final void checkForAndHandlePCModification(final VirtualFrame frame, final int pc, final int sp, final int index, final Object receiver, final int nextPC) {
         if (index == CONTEXT.INSTRUCTION_POINTER && receiver instanceof ContextObject context) {
             enter(pc, getProfile(pc), BRANCH1);
-            if (context.isActiveOnTruffleStack(frame)) {
+            if (context.isActiveOnTruffleStack()) {
                 CompilerDirectives.transferToInterpreter();
                 FrameAccess.externalizePCAndSP(frame, nextPC, sp);
                 final ContextObject activeContext = GetOrCreateContextWithFrameNode.executeUncached(frame);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractInterpreterNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractInterpreterNode.java
@@ -358,12 +358,21 @@ public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrum
     protected final void checkForAndHandlePCModification(final VirtualFrame frame, final int pc, final int sp, final int index, final Object receiver, final int nextPC) {
         if (index == CONTEXT.INSTRUCTION_POINTER && receiver instanceof ContextObject context) {
             enter(pc, getProfile(pc), BRANCH1);
-            if (context.isActiveOnTruffleStack()) {
-                CompilerDirectives.transferToInterpreter();
-                FrameAccess.externalizePCAndSP(frame, nextPC, sp);
-                final ContextObject activeContext = GetOrCreateContextWithFrameNode.executeUncached(frame);
-                AbstractPointersObjectWriteNode.executeUncached(getContext().getActiveProcessSlow(), PROCESS.SUSPENDED_CONTEXT, activeContext);
-                throw ProcessSwitch.SINGLETON;
+            if (context.isPotentiallyActiveOnTruffleStack()) {
+                // Fast-path optimization: Preemptively mark the Context as inactive.
+                // If the PC is modified multiple times while suspended, we avoid paying
+                // the expensive cost of iterateFrames() on subsequent modifications.
+                context.markAsInactiveOnTruffleStack();
+                if (context.isActiveOnTruffleStackSlow()) {
+                    // The context was actually active. Throwing ProcessSwitch will unwind the
+                    // Truffle stack and force all contexts to the heap. This renders our
+                    // preemptive "inactive" mark factually correct.
+                    CompilerDirectives.transferToInterpreter();
+                    FrameAccess.externalizePCAndSP(frame, nextPC, sp);
+                    final ContextObject activeContext = GetOrCreateContextWithFrameNode.executeUncached(frame);
+                    AbstractPointersObjectWriteNode.executeUncached(getContext().getActiveProcessSlow(), PROCESS.SUSPENDED_CONTEXT, activeContext);
+                    throw ProcessSwitch.SINGLETON;
+                }
             }
         }
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterSistaV1Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterSistaV1Node.java
@@ -30,6 +30,7 @@ import com.oracle.truffle.api.nodes.LoopNode;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.CountingConditionProfile;
 
+import de.hpi.swa.trufflesqueak.exceptions.ProcessSwitch;
 import de.hpi.swa.trufflesqueak.exceptions.Returns.AbstractStandardSendReturn;
 import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
 import de.hpi.swa.trufflesqueak.model.ArrayObject;
@@ -42,6 +43,10 @@ import de.hpi.swa.trufflesqueak.model.ContextObject;
 import de.hpi.swa.trufflesqueak.model.NativeObject;
 import de.hpi.swa.trufflesqueak.model.NilObject;
 import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.ASSOCIATION;
+import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.CONTEXT;
+import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.PROCESS;
+import de.hpi.swa.trufflesqueak.nodes.accessing.AbstractPointersObjectNodes.AbstractPointersObjectWriteNode;
+import de.hpi.swa.trufflesqueak.nodes.context.GetOrCreateContextWithFrameNode;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectAt0NodeGen;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectAtPut0Node;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectAtPut0NodeGen;
@@ -1873,7 +1878,8 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
     @EarlyInline
     @BytecodeInterpreterHandler(value = BC.POP_INTO_RCVR_VAR_1, safepoint = false)
     private int handlePopIntoReceiverVariable1(final VirtualFrame frame, final int pc, final VirtualState vstate, @SuppressWarnings("unused") final State state) {
-        return handlePopIntoReceiverVariable(frame, pc, vstate, 1);
+        // assert CONTEXT.INSTRUCTION_POINTER == 1;
+        return doStoreIntoReceiverVariable(frame, pc, vstate, 1, pop(frame, --vstate.sp), pc + 1);
     }
 
     @EarlyInline
@@ -1989,8 +1995,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
     @BytecodeInterpreterHandler(value = BC.EXT_STORE_AND_POP_RECEIVER_VARIABLE, safepoint = false)
     private int handleExtendedStoreAndPopReceiverVariable(final VirtualFrame frame, final int pc, final VirtualState vstate, final State state) {
         final int index = getByteExtendedWithExtA(pc, vstate, state);
-        ACCESS.uncheckedCast(getData(pc), SqueakObjectAtPut0Node.class).execute(this, FrameAccess.getReceiver(frame), index, pop(frame, --vstate.sp));
-        return pc + 2;
+        return doStoreIntoReceiverVariable(frame, pc, vstate, index, pop(frame, --vstate.sp), pc + 2);
     }
 
     @EarlyInline
@@ -2013,8 +2018,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
     @BytecodeInterpreterHandler(value = BC.EXT_STORE_RECEIVER_VARIABLE, safepoint = false)
     private int handleExtendedStoreReceiverVariable(final VirtualFrame frame, final int pc, final VirtualState vstate, final State state) {
         final int index = getByteExtendedWithExtA(pc, vstate, state);
-        ACCESS.uncheckedCast(getData(pc), SqueakObjectAtPut0Node.class).execute(this, FrameAccess.getReceiver(frame), index, top(frame, vstate.sp));
-        return pc + 2;
+        return doStoreIntoReceiverVariable(frame, pc, vstate, index, top(frame, vstate.sp), pc + 2);
     }
 
     @EarlyInline
@@ -2061,7 +2065,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
         final Object arg = pop(frame, --vstate.sp);
         final Object receiver = pop(frame, --vstate.sp);
         final byte profile = getProfile(pc);
-        int nextPC = pc + 1;
+        final int nextPC = pc + 1;
         final Object result;
         if (receiver instanceof final Long lhs && arg instanceof final Long rhs) {
             enter(pc, profile, BRANCH2);
@@ -2081,7 +2085,6 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
             enter(pc, profile, BRANCH1);
             FrameAccess.externalizePCAndSP(frame, nextPC, vstate.sp);
             result = send(frame, pc, receiver, arg);
-            nextPC = FrameAccess.internalizePC(frame, nextPC);
         }
         push(frame, vstate.sp++, result);
         return nextPC;
@@ -2093,7 +2096,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
         final Object arg = pop(frame, --vstate.sp);
         final Object receiver = pop(frame, --vstate.sp);
         final byte profile = getProfile(pc);
-        int nextPC = pc + 1;
+        final int nextPC = pc + 1;
         final Object result;
         if (receiver instanceof final Long lhs && arg instanceof final Long rhs) {
             enter(pc, profile, BRANCH2);
@@ -2113,7 +2116,6 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
             enter(pc, profile, BRANCH1);
             FrameAccess.externalizePCAndSP(frame, nextPC, vstate.sp);
             result = send(frame, pc, receiver, arg);
-            nextPC = FrameAccess.internalizePC(frame, nextPC);
         }
         push(frame, vstate.sp++, result);
         return nextPC;
@@ -2125,7 +2127,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
         final Object arg = pop(frame, --vstate.sp);
         final Object receiver = pop(frame, --vstate.sp);
         final byte profile = getProfile(pc);
-        int nextPC = pc + 1;
+        final int nextPC = pc + 1;
         final Object result;
         if (receiver instanceof final Long lhs && arg instanceof final Long rhs) {
             enter(pc, profile, BRANCH2);
@@ -2137,7 +2139,6 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
             enter(pc, profile, BRANCH1);
             FrameAccess.externalizePCAndSP(frame, nextPC, vstate.sp);
             result = send(frame, pc, receiver, arg);
-            nextPC = FrameAccess.internalizePC(frame, nextPC);
         }
         push(frame, vstate.sp++, result);
         return nextPC;
@@ -2149,7 +2150,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
         final Object arg = pop(frame, --vstate.sp);
         final Object receiver = pop(frame, --vstate.sp);
         final byte profile = getProfile(pc);
-        int nextPC = pc + 1;
+        final int nextPC = pc + 1;
         final Object result;
         if (receiver instanceof final Long lhs && arg instanceof final Long rhs) {
             enter(pc, profile, BRANCH2);
@@ -2161,7 +2162,6 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
             enter(pc, profile, BRANCH1);
             FrameAccess.externalizePCAndSP(frame, nextPC, vstate.sp);
             result = send(frame, pc, receiver, arg);
-            nextPC = FrameAccess.internalizePC(frame, nextPC);
         }
         push(frame, vstate.sp++, result);
         return nextPC;
@@ -2173,7 +2173,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
         final Object arg = pop(frame, --vstate.sp);
         final Object receiver = pop(frame, --vstate.sp);
         final byte profile = getProfile(pc);
-        int nextPC = pc + 1;
+        final int nextPC = pc + 1;
         final Object result;
         if (receiver instanceof final Long lhs && arg instanceof final Long rhs) {
             enter(pc, profile, BRANCH2);
@@ -2185,7 +2185,6 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
             enter(pc, profile, BRANCH1);
             FrameAccess.externalizePCAndSP(frame, nextPC, vstate.sp);
             result = send(frame, pc, receiver, arg);
-            nextPC = FrameAccess.internalizePC(frame, nextPC);
         }
         push(frame, vstate.sp++, result);
         return nextPC;
@@ -2197,7 +2196,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
         final Object arg = pop(frame, --vstate.sp);
         final Object receiver = pop(frame, --vstate.sp);
         final byte profile = getProfile(pc);
-        int nextPC = pc + 1;
+        final int nextPC = pc + 1;
         final Object result;
         if (receiver instanceof final Long lhs && arg instanceof final Long rhs) {
             enter(pc, profile, BRANCH2);
@@ -2209,7 +2208,6 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
             enter(pc, profile, BRANCH1);
             FrameAccess.externalizePCAndSP(frame, nextPC, vstate.sp);
             result = send(frame, pc, receiver, arg);
-            nextPC = FrameAccess.internalizePC(frame, nextPC);
         }
         push(frame, vstate.sp++, result);
         return nextPC;
@@ -2221,7 +2219,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
         final Object arg = pop(frame, --vstate.sp);
         final Object receiver = pop(frame, --vstate.sp);
         final byte profile = getProfile(pc);
-        int nextPC = pc + 1;
+        final int nextPC = pc + 1;
         final Object result;
         if (receiver instanceof final Long lhs && arg instanceof final Long rhs) {
             enter(pc, profile, BRANCH2);
@@ -2233,7 +2231,6 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
             enter(pc, profile, BRANCH1);
             FrameAccess.externalizePCAndSP(frame, nextPC, vstate.sp);
             result = send(frame, pc, receiver, arg);
-            nextPC = FrameAccess.internalizePC(frame, nextPC);
         }
         push(frame, vstate.sp++, result);
         return nextPC;
@@ -2245,7 +2242,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
         final Object arg = pop(frame, --vstate.sp);
         final Object receiver = pop(frame, --vstate.sp);
         final byte profile = getProfile(pc);
-        int nextPC = pc + 1;
+        final int nextPC = pc + 1;
         final Object result;
         if (receiver instanceof final Long lhs && arg instanceof final Long rhs) {
             enter(pc, profile, BRANCH2);
@@ -2257,7 +2254,6 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
             enter(pc, profile, BRANCH1);
             FrameAccess.externalizePCAndSP(frame, nextPC, vstate.sp);
             result = send(frame, pc, receiver, arg);
-            nextPC = FrameAccess.internalizePC(frame, nextPC);
         }
         push(frame, vstate.sp++, result);
         return nextPC;
@@ -2269,7 +2265,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
         final Object arg = pop(frame, --vstate.sp);
         final Object receiver = pop(frame, --vstate.sp);
         final byte profile = getProfile(pc);
-        int nextPC = pc + 1;
+        final int nextPC = pc + 1;
         final Object result;
         if (receiver instanceof final Long lhs && arg instanceof final Long rhs) {
             enter(pc, profile, BRANCH2);
@@ -2278,7 +2274,6 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
             enter(pc, profile, BRANCH1);
             FrameAccess.externalizePCAndSP(frame, nextPC, vstate.sp);
             result = send(frame, pc, receiver, arg);
-            nextPC = FrameAccess.internalizePC(frame, nextPC);
         }
         push(frame, vstate.sp++, result);
         return nextPC;
@@ -2305,7 +2300,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
         final Object arg = pop(frame, --vstate.sp);
         final Object receiver = pop(frame, --vstate.sp);
         final byte profile = getProfile(pc);
-        int nextPC = pc + 1;
+        final int nextPC = pc + 1;
         final Object result;
         if (receiver instanceof final Long lhs && arg instanceof final Long rhs && rhs != 0 && !isOverflowDivision(lhs, rhs)) {
             enter(pc, profile, BRANCH2);
@@ -2321,7 +2316,6 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
             enter(pc, profile, BRANCH1);
             FrameAccess.externalizePCAndSP(frame, nextPC, vstate.sp);
             result = send(frame, pc, receiver, arg);
-            nextPC = FrameAccess.internalizePC(frame, nextPC);
         }
         push(frame, vstate.sp++, result);
         return nextPC;
@@ -2333,7 +2327,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
         final Object arg = pop(frame, --vstate.sp);
         final Object receiver = pop(frame, --vstate.sp);
         final byte profile = getProfile(pc);
-        int nextPC = pc + 1;
+        final int nextPC = pc + 1;
         final Object result;
         if (receiver instanceof final Long lhs && arg instanceof final Long rhs) {
             enter(pc, profile, BRANCH2);
@@ -2342,7 +2336,6 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
             enter(pc, profile, BRANCH1);
             FrameAccess.externalizePCAndSP(frame, nextPC, vstate.sp);
             result = send(frame, pc, receiver, arg);
-            nextPC = FrameAccess.internalizePC(frame, nextPC);
         }
         push(frame, vstate.sp++, result);
         return nextPC;
@@ -2354,7 +2347,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
         final Object arg = pop(frame, --vstate.sp);
         final Object receiver = pop(frame, --vstate.sp);
         final byte profile = getProfile(pc);
-        int nextPC = pc + 1;
+        final int nextPC = pc + 1;
         final Object result;
         if (receiver instanceof final Long lhs && arg instanceof final Long rhs) {
             enter(pc, profile, BRANCH2);
@@ -2363,7 +2356,6 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
             enter(pc, profile, BRANCH1);
             FrameAccess.externalizePCAndSP(frame, nextPC, vstate.sp);
             result = send(frame, pc, receiver, arg);
-            nextPC = FrameAccess.internalizePC(frame, nextPC);
         }
         push(frame, vstate.sp++, result);
         return nextPC;
@@ -2374,7 +2366,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
     private int handlePrimitiveSize(final VirtualFrame frame, final int pc, final VirtualState vstate, @SuppressWarnings("unused") final State state) {
         final Object receiver = pop(frame, --vstate.sp);
         final byte profile = getProfile(pc);
-        int nextPC = pc + 1;
+        final int nextPC = pc + 1;
         final Object result;
         if (receiver instanceof final NativeObject nativeObject && getContext().isByteString(nativeObject)) {
             enter(pc, profile, BRANCH2);
@@ -2383,7 +2375,6 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
             enter(pc, profile, BRANCH1);
             FrameAccess.externalizePCAndSP(frame, nextPC, vstate.sp);
             result = send(frame, pc, receiver);
-            nextPC = FrameAccess.internalizePC(frame, nextPC);
         }
         push(frame, vstate.sp++, result);
         return nextPC;
@@ -2423,11 +2414,10 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                     BC.SEND_LIT_SEL0_8, BC.SEND_LIT_SEL0_9, BC.SEND_LIT_SEL0_A, BC.SEND_LIT_SEL0_B,
                     BC.SEND_LIT_SEL0_C, BC.SEND_LIT_SEL0_D, BC.SEND_LIT_SEL0_E, BC.SEND_LIT_SEL0_F}, safepoint = false)
     private int handleSend0(final VirtualFrame frame, final int pc, final VirtualState vstate, @SuppressWarnings("unused") final State state) {
-        int nextPC = pc + 1;
+        final int nextPC = pc + 1;
         final Object receiver = pop(frame, --vstate.sp);
         FrameAccess.externalizePCAndSP(frame, nextPC, vstate.sp);
         push(frame, vstate.sp++, send(frame, pc, receiver));
-        nextPC = FrameAccess.internalizePC(frame, nextPC);
         return nextPC;
     }
 
@@ -2440,12 +2430,11 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                     BC.SEND_LIT_SEL1_8, BC.SEND_LIT_SEL1_9, BC.SEND_LIT_SEL1_A, BC.SEND_LIT_SEL1_B,
                     BC.SEND_LIT_SEL1_C, BC.SEND_LIT_SEL1_D, BC.SEND_LIT_SEL1_E, BC.SEND_LIT_SEL1_F}, safepoint = false)
     private int handleSend1(final VirtualFrame frame, final int pc, final VirtualState vstate, @SuppressWarnings("unused") final State state) {
-        int nextPC = pc + 1;
+        final int nextPC = pc + 1;
         final Object arg = pop(frame, --vstate.sp);
         final Object receiver = pop(frame, --vstate.sp);
         FrameAccess.externalizePCAndSP(frame, nextPC, vstate.sp);
         push(frame, vstate.sp++, send(frame, pc, receiver, arg));
-        nextPC = FrameAccess.internalizePC(frame, nextPC);
         return nextPC;
     }
 
@@ -2456,20 +2445,19 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                     BC.SEND_LIT_SEL2_8, BC.SEND_LIT_SEL2_9, BC.SEND_LIT_SEL2_A, BC.SEND_LIT_SEL2_B,
                     BC.SEND_LIT_SEL2_C, BC.SEND_LIT_SEL2_D, BC.SEND_LIT_SEL2_E, BC.SEND_LIT_SEL2_F}, safepoint = false)
     private int handleSend2(final VirtualFrame frame, final int pc, final VirtualState vstate, @SuppressWarnings("unused") final State state) {
-        int nextPC = pc + 1;
+        final int nextPC = pc + 1;
         final Object arg2 = pop(frame, --vstate.sp);
         final Object arg1 = pop(frame, --vstate.sp);
         final Object receiver = pop(frame, --vstate.sp);
         FrameAccess.externalizePCAndSP(frame, nextPC, vstate.sp);
         push(frame, vstate.sp++, send(frame, pc, receiver, arg1, arg2));
-        nextPC = FrameAccess.internalizePC(frame, nextPC);
         return nextPC;
     }
 
     @EarlyInline
     @BytecodeInterpreterHandler(value = BC.EXT_SEND, safepoint = false)
     private int handleExtendedSend(final VirtualFrame frame, final int pc, final VirtualState vstate, final State state) {
-        int nextPC = pc + 2;
+        final int nextPC = pc + 2;
         final int byte1 = getUnsignedInt(state.bytecode, pc + 1);
         final int numArgs = (byte1 & 7) + (vstate.getExtB() << 3);
         CompilerAsserts.partialEvaluationConstant(numArgs);
@@ -2478,7 +2466,6 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
         final Object receiver = pop(frame, --vstate.sp);
         FrameAccess.externalizePCAndSP(frame, nextPC, vstate.sp);
         push(frame, vstate.sp++, sendNary(frame, pc, receiver, arguments));
-        nextPC = FrameAccess.internalizePC(frame, nextPC);
         vstate.resetExtAB();
         return nextPC;
     }
@@ -2486,7 +2473,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
     @EarlyInline
     @BytecodeInterpreterHandler(value = BC.EXT_SEND_SUPER, safepoint = false)
     private int handleExtendedSuperSend(final VirtualFrame frame, final int pc, final VirtualState vstate, final State state) {
-        int nextPC = pc + 2;
+        final int nextPC = pc + 2;
         final boolean isDirected;
         final int extB = vstate.getExtB();
         final int extBValue;
@@ -2507,7 +2494,6 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
         FrameAccess.externalizePCAndSP(frame, nextPC, vstate.sp);
         CompilerAsserts.partialEvaluationConstant(isDirected);
         pushFollowed(frame, pc, vstate.sp++, sendSuper(frame, isDirected, pc, lookupClass, receiver, arguments));
-        nextPC = FrameAccess.internalizePC(frame, nextPC);
         vstate.resetExtAB();
         return nextPC;
     }
@@ -2833,6 +2819,38 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
         } catch (final AbstractStandardSendReturn r) {
             return handleReturnException(frame, currentPC, r);
         }
+    }
+
+    @EarlyInline
+    private int doStoreIntoReceiverVariable(final VirtualFrame frame, final int pc, final VirtualState vstate, final int index, final Object value, final int nextPC) {
+        final Object receiver = FrameAccess.getReceiver(frame);
+        final SqueakObjectAtPut0Node atPutNode = ACCESS.uncheckedCast(getData(pc), SqueakObjectAtPut0Node.class);
+
+        if (index == CONTEXT.INSTRUCTION_POINTER) {
+            final byte profile = getProfile(pc);
+            if (receiver instanceof ContextObject context) {
+                // In order to avoid a check for an altered PC after every message send, we
+                // force a flush of the Truffle execution stack; the updated PC will be used
+                // when the Context resumes execution.
+                enter(pc, profile, BRANCH1);
+                atPutNode.execute(this, receiver, index, value);
+
+                if (context.isActiveOnTruffleStack()) {
+                    CompilerDirectives.transferToInterpreter();
+                    FrameAccess.externalizePCAndSP(frame, nextPC, vstate.sp);
+                    final ContextObject activeContext = GetOrCreateContextWithFrameNode.executeUncached(frame);
+                    AbstractPointersObjectWriteNode.executeUncached(getContext().getActiveProcessSlow(), PROCESS.SUSPENDED_CONTEXT, activeContext);
+                    throw ProcessSwitch.SINGLETON;
+                }
+            } else {
+                enter(pc, profile, BRANCH2);
+                atPutNode.execute(this, receiver, index, value);
+            }
+        } else {
+            atPutNode.execute(this, receiver, index, value);
+        }
+
+        return nextPC;
     }
 
     public static int calculateLongExtendedOffset(final byte bytecode, final int extB) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterSistaV1Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterSistaV1Node.java
@@ -30,7 +30,6 @@ import com.oracle.truffle.api.nodes.LoopNode;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.CountingConditionProfile;
 
-import de.hpi.swa.trufflesqueak.exceptions.ProcessSwitch;
 import de.hpi.swa.trufflesqueak.exceptions.Returns.AbstractStandardSendReturn;
 import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
 import de.hpi.swa.trufflesqueak.model.ArrayObject;
@@ -43,10 +42,6 @@ import de.hpi.swa.trufflesqueak.model.ContextObject;
 import de.hpi.swa.trufflesqueak.model.NativeObject;
 import de.hpi.swa.trufflesqueak.model.NilObject;
 import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.ASSOCIATION;
-import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.CONTEXT;
-import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.PROCESS;
-import de.hpi.swa.trufflesqueak.nodes.accessing.AbstractPointersObjectNodes.AbstractPointersObjectWriteNode;
-import de.hpi.swa.trufflesqueak.nodes.context.GetOrCreateContextWithFrameNode;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectAt0NodeGen;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectAtPut0Node;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectAtPut0NodeGen;
@@ -1925,6 +1920,14 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
     }
 
     @EarlyInline
+    private int doStoreIntoReceiverVariable(final VirtualFrame frame, final int pc, final VirtualState vstate, final int index, final Object value, final int nextPC) {
+        final Object receiver = FrameAccess.getReceiver(frame);
+        ACCESS.uncheckedCast(getData(pc), SqueakObjectAtPut0Node.class).execute(this, receiver, index, value);
+        checkForAndHandlePCModification(frame, pc, vstate.sp, index, receiver, nextPC);
+        return nextPC;
+    }
+
+    @EarlyInline
     @BytecodeInterpreterHandler(value = BC.POP_INTO_TEMP_VAR_0, safepoint = false)
     private int handlePopIntoTemporaryVariable0(final VirtualFrame frame, final int pc, final VirtualState vstate, @SuppressWarnings("unused") final State state) {
         return handlePopIntoTemporaryVariable(frame, pc, vstate, 0);
@@ -2819,38 +2822,6 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
         } catch (final AbstractStandardSendReturn r) {
             return handleReturnException(frame, currentPC, r);
         }
-    }
-
-    @EarlyInline
-    private int doStoreIntoReceiverVariable(final VirtualFrame frame, final int pc, final VirtualState vstate, final int index, final Object value, final int nextPC) {
-        final Object receiver = FrameAccess.getReceiver(frame);
-        final SqueakObjectAtPut0Node atPutNode = ACCESS.uncheckedCast(getData(pc), SqueakObjectAtPut0Node.class);
-
-        if (index == CONTEXT.INSTRUCTION_POINTER) {
-            final byte profile = getProfile(pc);
-            if (receiver instanceof ContextObject context) {
-                // In order to avoid a check for an altered PC after every message send, we
-                // force a flush of the Truffle execution stack; the updated PC will be used
-                // when the Context resumes execution.
-                enter(pc, profile, BRANCH1);
-                atPutNode.execute(this, receiver, index, value);
-
-                if (context.isActiveOnTruffleStack()) {
-                    CompilerDirectives.transferToInterpreter();
-                    FrameAccess.externalizePCAndSP(frame, nextPC, vstate.sp);
-                    final ContextObject activeContext = GetOrCreateContextWithFrameNode.executeUncached(frame);
-                    AbstractPointersObjectWriteNode.executeUncached(getContext().getActiveProcessSlow(), PROCESS.SUSPENDED_CONTEXT, activeContext);
-                    throw ProcessSwitch.SINGLETON;
-                }
-            } else {
-                enter(pc, profile, BRANCH2);
-                atPutNode.execute(this, receiver, index, value);
-            }
-        } else {
-            atPutNode.execute(this, receiver, index, value);
-        }
-
-        return nextPC;
     }
 
     public static int calculateLongExtendedOffset(final byte bytecode, final int extB) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterV3PlusClosuresNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterV3PlusClosuresNode.java
@@ -8,6 +8,7 @@ package de.hpi.swa.trufflesqueak.nodes.interpreter;
 
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.CompilerDirectives.EarlyInline;
 import com.oracle.truffle.api.HostCompilerDirectives;
 import com.oracle.truffle.api.HostCompilerDirectives.BytecodeInterpreterSwitch;
 import com.oracle.truffle.api.frame.VirtualFrame;
@@ -17,6 +18,7 @@ import com.oracle.truffle.api.nodes.LoopNode;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.CountingConditionProfile;
 
+import de.hpi.swa.trufflesqueak.exceptions.ProcessSwitch;
 import de.hpi.swa.trufflesqueak.exceptions.Returns.AbstractStandardSendReturn;
 import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
 import de.hpi.swa.trufflesqueak.model.AbstractSqueakObjectWithClassAndHash;
@@ -24,14 +26,19 @@ import de.hpi.swa.trufflesqueak.model.ArrayObject;
 import de.hpi.swa.trufflesqueak.model.BooleanObject;
 import de.hpi.swa.trufflesqueak.model.ClassObject;
 import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
+import de.hpi.swa.trufflesqueak.model.ContextObject;
 import de.hpi.swa.trufflesqueak.model.NativeObject;
 import de.hpi.swa.trufflesqueak.model.NilObject;
+import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts;
 import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.ASSOCIATION;
+import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.CONTEXT;
+import de.hpi.swa.trufflesqueak.nodes.accessing.AbstractPointersObjectNodes;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectAt0NodeGen;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectAtPut0Node;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectAtPut0NodeGen;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectClassNodeGen;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectIdentityNodeGen;
+import de.hpi.swa.trufflesqueak.nodes.context.GetOrCreateContextWithFrameNode;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector0NodeFactory.Dispatch0NodeGen;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector1NodeFactory.Dispatch1NodeGen;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector2NodeFactory.Dispatch2NodeGen;
@@ -340,8 +347,12 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                         push(frame, sp++, readLiteralVariable(currentPC, b & 0x1F));
                         break;
                     }
-                    case BC.POP_INTO_RCVR_VAR_0, BC.POP_INTO_RCVR_VAR_1, BC.POP_INTO_RCVR_VAR_2, BC.POP_INTO_RCVR_VAR_3, BC.POP_INTO_RCVR_VAR_4, BC.POP_INTO_RCVR_VAR_5, BC.POP_INTO_RCVR_VAR_6, BC.POP_INTO_RCVR_VAR_7: {
+                    case BC.POP_INTO_RCVR_VAR_0, BC.POP_INTO_RCVR_VAR_2, BC.POP_INTO_RCVR_VAR_3, BC.POP_INTO_RCVR_VAR_4, BC.POP_INTO_RCVR_VAR_5, BC.POP_INTO_RCVR_VAR_6, BC.POP_INTO_RCVR_VAR_7: {
                         ACCESS.uncheckedCast(getData(currentPC), SqueakObjectAtPut0Node.class).execute(this, FrameAccess.getReceiver(frame), b & 7, pop(frame, --sp));
+                        break;
+                    }
+                    case BC.POP_INTO_RCVR_VAR_1: {
+                        doStoreIntoReceiverVariable(frame, currentPC, pc, sp, 1, pop(frame, --sp));
                         break;
                     }
                     case BC.POP_INTO_TEMP_VAR_0, BC.POP_INTO_TEMP_VAR_1, BC.POP_INTO_TEMP_VAR_2, BC.POP_INTO_TEMP_VAR_3, BC.POP_INTO_TEMP_VAR_4, BC.POP_INTO_TEMP_VAR_5, BC.POP_INTO_TEMP_VAR_6, BC.POP_INTO_TEMP_VAR_7: {
@@ -452,7 +463,7 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                         CompilerAsserts.partialEvaluationConstant(variableType);
                         switch (variableType) {
                             case 0: {
-                                ACCESS.uncheckedCast(getData(currentPC), SqueakObjectAtPut0Node.class).execute(this, FrameAccess.getReceiver(frame), variableIndex, stackTop);
+                                doStoreIntoReceiverVariable(frame, currentPC, pc, sp, variableIndex, stackTop);
                                 break;
                             }
                             case 1: {
@@ -477,7 +488,7 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                         CompilerAsserts.partialEvaluationConstant(variableType);
                         switch (variableType) {
                             case 0: {
-                                ACCESS.uncheckedCast(getData(currentPC), SqueakObjectAtPut0Node.class).execute(this, FrameAccess.getReceiver(frame), variableIndex, stackValue);
+                                doStoreIntoReceiverVariable(frame, currentPC, pc, sp, variableIndex, stackValue);
                                 break;
                             }
                             case 1: {
@@ -501,7 +512,6 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                         final Object receiver = pop(frame, --sp);
                         FrameAccess.externalizePCAndSP(frame, pc, sp);
                         push(frame, sp++, sendNary(frame, currentPC, receiver, arguments));
-                        pc = FrameAccess.internalizePC(frame, pc);
                         break;
                     }
                     case BC.DOUBLE_EXTENDED_DO_ANYTHING: {
@@ -517,7 +527,6 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                                 final Object receiver = pop(frame, --sp);
                                 FrameAccess.externalizePCAndSP(frame, pc, sp);
                                 push(frame, sp++, sendNary(frame, currentPC, receiver, arguments));
-                                pc = FrameAccess.internalizePC(frame, pc);
                                 break;
                             }
                             case 1: {
@@ -527,7 +536,6 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                                 final Object receiver = AbstractSqueakObjectWithClassAndHash.resolveForwardingPointer(pop(frame, --sp));
                                 FrameAccess.externalizePCAndSP(frame, pc, sp);
                                 pushFollowed(frame, currentPC, sp++, sendSuper(frame, currentPC, receiver, arguments));
-                                pc = FrameAccess.internalizePC(frame, pc);
                                 break;
                             }
                             case 2: {
@@ -545,11 +553,11 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                                 break;
                             }
                             case 5: {
-                                ACCESS.uncheckedCast(getData(currentPC), SqueakObjectAtPut0Node.class).execute(this, FrameAccess.getReceiver(frame), byte3, top(frame, sp));
+                                doStoreIntoReceiverVariable(frame, currentPC, pc, sp, byte3, top(frame, sp));
                                 break;
                             }
                             case 6: {
-                                ACCESS.uncheckedCast(getData(currentPC), SqueakObjectAtPut0Node.class).execute(this, FrameAccess.getReceiver(frame), byte3, pop(frame, --sp));
+                                doStoreIntoReceiverVariable(frame, currentPC, pc, sp, byte3, pop(frame, --sp));
                                 break;
                             }
                             case 7: {
@@ -569,7 +577,6 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                         final Object receiver = AbstractSqueakObjectWithClassAndHash.resolveForwardingPointer(pop(frame, --sp));
                         FrameAccess.externalizePCAndSP(frame, pc, sp);
                         pushFollowed(frame, currentPC, sp++, sendSuper(frame, currentPC, receiver, arguments));
-                        pc = FrameAccess.internalizePC(frame, pc);
                         break;
                     }
                     case BC.SECOND_EXTENDED_SEND: {
@@ -579,7 +586,6 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                         final Object receiver = pop(frame, --sp);
                         FrameAccess.externalizePCAndSP(frame, pc, sp);
                         push(frame, sp++, sendNary(frame, currentPC, receiver, arguments));
-                        pc = FrameAccess.internalizePC(frame, pc);
                         break;
                     }
                     case BC.POP_STACK: {
@@ -743,7 +749,6 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                             enter(currentPC, profile, BRANCH1);
                             FrameAccess.externalizePCAndSP(frame, pc, sp);
                             result = send(frame, currentPC, receiver, arg);
-                            pc = FrameAccess.internalizePC(frame, pc);
                         }
                         push(frame, sp++, result);
                         break;
@@ -771,7 +776,6 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                             enter(currentPC, profile, BRANCH1);
                             FrameAccess.externalizePCAndSP(frame, pc, sp);
                             result = send(frame, currentPC, receiver, arg);
-                            pc = FrameAccess.internalizePC(frame, pc);
                         }
                         push(frame, sp++, result);
                         break;
@@ -791,7 +795,6 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                             enter(currentPC, profile, BRANCH1);
                             FrameAccess.externalizePCAndSP(frame, pc, sp);
                             result = send(frame, currentPC, receiver, arg);
-                            pc = FrameAccess.internalizePC(frame, pc);
                         }
                         push(frame, sp++, result);
                         break;
@@ -811,7 +814,6 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                             enter(currentPC, profile, BRANCH1);
                             FrameAccess.externalizePCAndSP(frame, pc, sp);
                             result = send(frame, currentPC, receiver, arg);
-                            pc = FrameAccess.internalizePC(frame, pc);
                         }
                         push(frame, sp++, result);
                         break;
@@ -831,7 +833,6 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                             enter(currentPC, profile, BRANCH1);
                             FrameAccess.externalizePCAndSP(frame, pc, sp);
                             result = send(frame, currentPC, receiver, arg);
-                            pc = FrameAccess.internalizePC(frame, pc);
                         }
                         push(frame, sp++, result);
                         break;
@@ -851,7 +852,6 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                             enter(currentPC, profile, BRANCH1);
                             FrameAccess.externalizePCAndSP(frame, pc, sp);
                             result = send(frame, currentPC, receiver, arg);
-                            pc = FrameAccess.internalizePC(frame, pc);
                         }
                         push(frame, sp++, result);
                         break;
@@ -871,7 +871,6 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                             enter(currentPC, profile, BRANCH1);
                             FrameAccess.externalizePCAndSP(frame, pc, sp);
                             result = send(frame, currentPC, receiver, arg);
-                            pc = FrameAccess.internalizePC(frame, pc);
                         }
                         push(frame, sp++, result);
                         break;
@@ -891,7 +890,6 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                             enter(currentPC, profile, BRANCH1);
                             FrameAccess.externalizePCAndSP(frame, pc, sp);
                             result = send(frame, currentPC, receiver, arg);
-                            pc = FrameAccess.internalizePC(frame, pc);
                         }
                         push(frame, sp++, result);
                         break;
@@ -908,7 +906,6 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                             enter(currentPC, profile, BRANCH1);
                             FrameAccess.externalizePCAndSP(frame, pc, sp);
                             result = send(frame, currentPC, receiver, arg);
-                            pc = FrameAccess.internalizePC(frame, pc);
                         }
                         push(frame, sp++, result);
                         break;
@@ -925,7 +922,6 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                             enter(currentPC, profile, BRANCH1);
                             FrameAccess.externalizePCAndSP(frame, pc, sp);
                             result = send(frame, currentPC, receiver, arg);
-                            pc = FrameAccess.internalizePC(frame, pc);
                         }
                         push(frame, sp++, result);
                         break;
@@ -953,7 +949,6 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                         final Object receiver = pop(frame, --sp);
                         FrameAccess.externalizePCAndSP(frame, pc, sp);
                         push(frame, sp++, send(frame, currentPC, receiver));
-                        pc = FrameAccess.internalizePC(frame, pc);
                         break;
                     }
                     case BC.BYTECODE_PRIM_MULTIPLY, BC.BYTECODE_PRIM_DIVIDE, BC.BYTECODE_PRIM_MOD, BC.BYTECODE_PRIM_MAKE_POINT, BC.BYTECODE_PRIM_BIT_SHIFT, //
@@ -964,7 +959,6 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                         final Object receiver = pop(frame, --sp);
                         FrameAccess.externalizePCAndSP(frame, pc, sp);
                         push(frame, sp++, send(frame, currentPC, receiver, arg));
-                        pc = FrameAccess.internalizePC(frame, pc);
                         break;
                     }
                     case BC.BYTECODE_PRIM_AT_PUT, //
@@ -975,7 +969,6 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                         final Object receiver = pop(frame, --sp);
                         FrameAccess.externalizePCAndSP(frame, pc, sp);
                         push(frame, sp++, send(frame, currentPC, receiver, arg1, arg2));
-                        pc = FrameAccess.internalizePC(frame, pc);
                         break;
                     }
                     default: {
@@ -1000,6 +993,36 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
             return ACCESS.uncheckedCast(getData(currentPC), DispatchSuperNaryNodeGen.class).execute(frame, receiver, arguments);
         } catch (final AbstractStandardSendReturn r) {
             return handleReturnException(frame, currentPC, r);
+        }
+    }
+
+    @EarlyInline
+    private void doStoreIntoReceiverVariable(final VirtualFrame frame, final int pc, final int nextPC, final int sp, final int index, final Object value) {
+        final Object receiver = FrameAccess.getReceiver(frame);
+        final SqueakObjectAtPut0Node atPutNode = ACCESS.uncheckedCast(getData(pc), SqueakObjectAtPut0Node.class);
+
+        if (index == CONTEXT.INSTRUCTION_POINTER) {
+            final byte profile = getProfile(pc);
+            if (receiver instanceof ContextObject context) {
+                // In order to avoid a check for an altered PC after every message send, we
+                // force a flush of the Truffle execution stack; the updated PC will be used
+                // when the Context resumes execution.
+                enter(pc, profile, BRANCH1);
+                atPutNode.execute(this, receiver, index, value);
+
+                if (context.isActiveOnTruffleStack()) {
+                    CompilerDirectives.transferToInterpreter();
+                    FrameAccess.externalizePCAndSP(frame, nextPC, sp);
+                    final ContextObject activeContext = GetOrCreateContextWithFrameNode.executeUncached(frame);
+                    AbstractPointersObjectNodes.AbstractPointersObjectWriteNode.executeUncached(getContext().getActiveProcessSlow(), ObjectLayouts.PROCESS.SUSPENDED_CONTEXT, activeContext);
+                    throw ProcessSwitch.SINGLETON;
+                }
+            } else {
+                enter(pc, profile, BRANCH2);
+                atPutNode.execute(this, receiver, index, value);
+            }
+        } else {
+            atPutNode.execute(this, receiver, index, value);
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterV3PlusClosuresNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterV3PlusClosuresNode.java
@@ -18,7 +18,6 @@ import com.oracle.truffle.api.nodes.LoopNode;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.CountingConditionProfile;
 
-import de.hpi.swa.trufflesqueak.exceptions.ProcessSwitch;
 import de.hpi.swa.trufflesqueak.exceptions.Returns.AbstractStandardSendReturn;
 import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
 import de.hpi.swa.trufflesqueak.model.AbstractSqueakObjectWithClassAndHash;
@@ -26,19 +25,14 @@ import de.hpi.swa.trufflesqueak.model.ArrayObject;
 import de.hpi.swa.trufflesqueak.model.BooleanObject;
 import de.hpi.swa.trufflesqueak.model.ClassObject;
 import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
-import de.hpi.swa.trufflesqueak.model.ContextObject;
 import de.hpi.swa.trufflesqueak.model.NativeObject;
 import de.hpi.swa.trufflesqueak.model.NilObject;
-import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts;
 import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.ASSOCIATION;
-import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.CONTEXT;
-import de.hpi.swa.trufflesqueak.nodes.accessing.AbstractPointersObjectNodes;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectAt0NodeGen;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectAtPut0Node;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectAtPut0NodeGen;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectClassNodeGen;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectIdentityNodeGen;
-import de.hpi.swa.trufflesqueak.nodes.context.GetOrCreateContextWithFrameNode;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector0NodeFactory.Dispatch0NodeGen;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector1NodeFactory.Dispatch1NodeGen;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector2NodeFactory.Dispatch2NodeGen;
@@ -999,31 +993,8 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
     @EarlyInline
     private void doStoreIntoReceiverVariable(final VirtualFrame frame, final int pc, final int nextPC, final int sp, final int index, final Object value) {
         final Object receiver = FrameAccess.getReceiver(frame);
-        final SqueakObjectAtPut0Node atPutNode = ACCESS.uncheckedCast(getData(pc), SqueakObjectAtPut0Node.class);
-
-        if (index == CONTEXT.INSTRUCTION_POINTER) {
-            final byte profile = getProfile(pc);
-            if (receiver instanceof ContextObject context) {
-                // In order to avoid a check for an altered PC after every message send, we
-                // force a flush of the Truffle execution stack; the updated PC will be used
-                // when the Context resumes execution.
-                enter(pc, profile, BRANCH1);
-                atPutNode.execute(this, receiver, index, value);
-
-                if (context.isActiveOnTruffleStack()) {
-                    CompilerDirectives.transferToInterpreter();
-                    FrameAccess.externalizePCAndSP(frame, nextPC, sp);
-                    final ContextObject activeContext = GetOrCreateContextWithFrameNode.executeUncached(frame);
-                    AbstractPointersObjectNodes.AbstractPointersObjectWriteNode.executeUncached(getContext().getActiveProcessSlow(), ObjectLayouts.PROCESS.SUSPENDED_CONTEXT, activeContext);
-                    throw ProcessSwitch.SINGLETON;
-                }
-            } else {
-                enter(pc, profile, BRANCH2);
-                atPutNode.execute(this, receiver, index, value);
-            }
-        } else {
-            atPutNode.execute(this, receiver, index, value);
-        }
+        ACCESS.uncheckedCast(getData(pc), SqueakObjectAtPut0Node.class).execute(this, receiver, index, value);
+        checkForAndHandlePCModification(frame, pc, sp, index, receiver, nextPC);
     }
 
     static int longJump(final int b, final int nextByte) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/FrameAccess.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/FrameAccess.java
@@ -374,7 +374,8 @@ public final class FrameAccess {
     }
 
     public static boolean isTruffleSqueakFrame(final Frame frame) {
-        return frame.getFrameDescriptor().getInfo() instanceof CompiledCodeObject;
+        // Guard against elided Truffle frames (null) from READ_ONLY getFrame() requests
+        return frame != null && frame.getFrameDescriptor().getInfo() instanceof CompiledCodeObject;
     }
 
     public static Object[] newWith(final AbstractSqueakObject sender, final BlockClosureObject closure, final Object[] receiverAndArguments) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/FrameAccess.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/FrameAccess.java
@@ -374,8 +374,7 @@ public final class FrameAccess {
     }
 
     public static boolean isTruffleSqueakFrame(final Frame frame) {
-        // Guard against elided Truffle frames (null) from READ_ONLY getFrame() requests
-        return frame != null && frame.getFrameDescriptor().getInfo() instanceof CompiledCodeObject;
+        return frame.getFrameDescriptor().getInfo() instanceof CompiledCodeObject;
     }
 
     public static Object[] newWith(final AbstractSqueakObject sender, final BlockClosureObject closure, final Object[] receiverAndArguments) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/FrameAccess.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/FrameAccess.java
@@ -214,17 +214,6 @@ public final class FrameAccess {
         setStackPointer(frame, sp);
     }
 
-    @CompilerDirectives.EarlyInline
-    public static int internalizePC(final VirtualFrame frame, final int pc) {
-        final int framePC = getInstructionPointer(frame);
-        if (pc != framePC) {
-            CompilerDirectives.transferToInterpreter();
-            return framePC;
-        } else {
-            return pc;
-        }
-    }
-
     public static int getStackStart() {
         return SlotIndices.STACK_START;
     }


### PR DESCRIPTION
In order to avoid a check for an updated PC after every message send, in this PR we force a flush of the Truffle execution stack; the updated PC will be used when the Context resumes execution.

It accomplishes this by checking bytecodes that write to receiver instance variables: when writing to the second instance variable (the program counter) of a Context object, it checks to see if the Context is on the Truffle frame stack. If the Context is found on the stack, a `ProcessSwitch` is raised to flush the Truffle stack and cause execution to resume with the updated program counter.

As a side effect of this PR, stack pointer resets caused by `Context>>privRefresh` will be properly picked up if the Context is on the Truffle stack, rather than being ignored as they are now.

This PR is based on changes in PR #257 
