### PR TITLE
Rework cannotReturn: to fix exception unwinding on dead contexts

### DIFF
--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
@@ -476,8 +476,20 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
         return FrameAccess.isDead(getTruffleFrame());
     }
 
-    public boolean canBeReturnedTo() {
-        return !isDead() && getFrameSender() != NilObject.SINGLETON;
+    /**
+     * Returns true if this Context is alive and its sender is a valid, live Context. Senders
+     * without a Truffle frame are executing JVM frames and are guaranteed to be alive. Senders with
+     * a Truffle frame must not be dead.
+     */
+    public boolean canReturnToSender() {
+        if (isDead()) {
+            return false;
+        }
+        final AbstractSqueakObject sender = getFrameSender();
+        if (sender instanceof ContextObject senderContext) {
+            return !senderContext.hasTruffleFrame() || !senderContext.isDead();
+        }
+        return false;
     }
 
     public void push(final Object value) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
@@ -30,10 +30,9 @@ import de.hpi.swa.trufflesqueak.model.AbstractSqueakObject;
 import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
 import de.hpi.swa.trufflesqueak.model.ContextObject;
 import de.hpi.swa.trufflesqueak.model.NilObject;
-import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector1Node.Dispatch1Node;
-import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector1NodeFactory.Dispatch1NodeGen;
+import de.hpi.swa.trufflesqueak.nodes.context.CreateCannotReturnContextNode;
+import de.hpi.swa.trufflesqueak.nodes.context.CreateCannotReturnContextNodeGen;
 import de.hpi.swa.trufflesqueak.nodes.process.GetNextActiveContextNode;
-import de.hpi.swa.trufflesqueak.nodes.process.WakeHighestPriorityNode;
 import de.hpi.swa.trufflesqueak.shared.SqueakLanguageConfig;
 import de.hpi.swa.trufflesqueak.util.DebugUtils;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
@@ -49,14 +48,13 @@ public final class ExecuteTopLevelContextNode extends RootNode {
 
     @Child private IndirectCallNode callNode = IndirectCallNode.create();
     @Child private GetNextActiveContextNode getNextActiveContextNode = GetNextActiveContextNode.create();
-    @Child private Dispatch1Node sendCannotReturnNode;
+    @Child private CreateCannotReturnContextNode createCannotReturnContextNode = CreateCannotReturnContextNodeGen.create();
 
     private ExecuteTopLevelContextNode(final SqueakImageContext image, final SqueakLanguage language, final ContextObject context, final boolean isImageResuming) {
         super(language, TOP_LEVEL_FRAME_DESCRIPTOR);
         this.image = image;
         initialContext = context;
         this.isImageResuming = isImageResuming;
-        sendCannotReturnNode = Dispatch1NodeGen.create(image.cannotReturn);
     }
 
     public static ExecuteTopLevelContextNode create(final SqueakImageContext image, final SqueakLanguage language, final ContextObject context, final boolean isImageResuming) {
@@ -103,13 +101,13 @@ public final class ExecuteTopLevelContextNode extends RootNode {
                     activeContext = returnTo(activeContext, sender, result);
                     LogUtils.SCHEDULING.log(Level.FINE, "Local Return on top-level: {0}", activeContext);
                 } catch (final NonLocalReturn nlr) {
-                    activeContext = commonNLReturn(sender, activeContext, nlr);
+                    activeContext = commonNLReturn(sender, nlr);
                     LogUtils.SCHEDULING.log(Level.FINE, "Non Local Return on top-level: {0}", activeContext);
                 } catch (final NonVirtualReturn nvr) {
-                    activeContext = commonNVReturn(activeContext, nvr);
+                    activeContext = commonNVReturn(nvr);
                     LogUtils.SCHEDULING.log(Level.FINE, "Non Virtual Return on top-level: {0}", activeContext);
                 } catch (final CannotReturnToTarget cr) {
-                    activeContext = sendCannotReturn(cr.getTargetContext(), cr.getReturnValue());
+                    activeContext = createCannotReturnContextNode.execute(cr.getTargetContext(), cr.getReturnValue());
                     LogUtils.SCHEDULING.log(Level.FINE, "Cannot Return on top-level: {0}", activeContext);
                 }
             } catch (final ProcessSwitch ps) {
@@ -120,72 +118,61 @@ public final class ExecuteTopLevelContextNode extends RootNode {
     }
 
     @TruffleBoundary
-    private ContextObject sendCannotReturnOrReturnToTopLevel(final ContextObject startContext, final ContextObject targetContext, final Object returnValue) {
+    private ContextObject sendCannotReturnOrReturnToTopLevel(final ContextObject returningContext, final Object returnValue) {
         // Exit the interpreter loop if the target is the context that started the loop.
-        if (targetContext != null && targetContext == initialContext) {
-            throw returnToTopLevel(targetContext, returnValue);
+        if (returningContext != null && returningContext == initialContext) {
+            throw returnToTopLevel(returningContext, returnValue);
         }
-        return sendCannotReturn(startContext, returnValue);
+        return createCannotReturnContextNode.execute(returningContext, returnValue);
     }
 
     @TruffleBoundary
-    private ContextObject returnTo(final ContextObject activeContext, final AbstractSqueakObject sender, final Object returnValue) {
-        if (!(sender instanceof final ContextObject senderContext)) {
-            assert sender == NilObject.SINGLETON;
-            return sendCannotReturnOrReturnToTopLevel(activeContext, activeContext, returnValue);
-        } else if (senderContext.isDead()) {
-            return sendCannotReturnOrReturnToTopLevel(activeContext, senderContext, returnValue);
+    private ContextObject returnTo(final ContextObject returningContext, final AbstractSqueakObject sender, final Object returnValue) {
+        // Normal returns end up here.
+        assert (sender instanceof ContextObject) || sender == NilObject.SINGLETON;
+        if ((sender instanceof final ContextObject senderContext) && !senderContext.isDead()) {
+            senderContext.push(returnValue);
+            return senderContext;
         }
-        senderContext.push(returnValue);
-        return senderContext;
+        // The returningContext was terminated on the fast path, breaking the sender chain.
+        // If the target is dead, we must restore the link so the exception handler can walk the
+        // stack.
+        if (sender instanceof ContextObject senderContext && senderContext.isDead()) {
+            returningContext.setSenderUnsafe(senderContext);
+        }
+        return sendCannotReturnOrReturnToTopLevel(returningContext, returnValue);
     }
 
     @TruffleBoundary
-    private ContextObject commonNVReturn(final ContextObject activeContext, final NonVirtualReturn nvr) {
-        // Normal returns with modified senders end up here with a target but no start Context.
+    private static ContextObject commonNVReturn(final NonVirtualReturn nvr) {
+        // Normal returns with modified senders end up here. The return Context has already been
+        // validated.
         final Object returnValue = nvr.getReturnValue();
-        final ContextObject targetContext = nvr.getTargetContext();
-        // Make sure that the targetContext can be returned to.
-        if (!targetContext.hasClosure() && !targetContext.canBeReturnedTo()) {
-            return sendCannotReturnOrReturnToTopLevel(activeContext, targetContext, returnValue);
-        }
-        // Return to the target context with the return value.
-        targetContext.push(returnValue);
-        return targetContext;
+        final ContextObject returnContext = nvr.getTargetContext();
+        returnContext.push(returnValue);
+        return returnContext;
     }
 
     @TruffleBoundary
-    private ContextObject commonNLReturn(final AbstractSqueakObject sender, final ContextObject activeContext, final NonLocalReturn nlr) {
-        final ContextObject targetContext = nlr.getTargetContext();
+    private static ContextObject commonNLReturn(final AbstractSqueakObject sender, final NonLocalReturn nlr) {
+        // Non-local returns with no intervening unwind-blocks end up here. The home Context has
+        // already been validated.
+        final ContextObject homeContext = nlr.getTargetContext();
         final Object returnValue = nlr.getReturnValue();
-        if (sender == NilObject.SINGLETON) {
-            return sendCannotReturnOrReturnToTopLevel(activeContext, targetContext, returnValue);
-        }
         // Terminate the Contexts on sender chain.
         ContextObject context = (ContextObject) sender;
-        while (context != targetContext) {
+        while (context != homeContext) {
             final ContextObject currentSender = (ContextObject) context.getSender();
             context.terminate();
             context = currentSender;
         }
-        targetContext.push(returnValue);
-        return targetContext;
+        homeContext.push(returnValue);
+        return homeContext;
     }
 
     private static TopLevelReturn returnToTopLevel(final ContextObject targetContext, final Object returnValue) {
         assert "DoIt".equals(targetContext.getCodeObject().getCompiledInSelector().asStringUnsafe()) : DebugUtils.getSqStackTrace(targetContext);
         throw new TopLevelReturn(returnValue);
-    }
-
-    @TruffleBoundary
-    private ContextObject sendCannotReturn(final ContextObject startContext, final Object returnValue) {
-        try {
-            sendCannotReturnNode.execute(startContext.getTruffleFrame(), startContext, returnValue);
-            WakeHighestPriorityNode.executeAndThrowUncached(startContext.getTruffleFrame(), image);
-        } catch (final NonVirtualReturn nvr) {
-            return commonNVReturn(startContext, nvr);
-        }
-        throw CompilerDirectives.shouldNotReachHere("cannotReturn should trigger a ProcessSwitch or a NonVirtualReturn");
     }
 
     private static void ensureCachedContextCanRunAgain(final ContextObject activeContext) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ExecuteTopLevelContextNode.java
@@ -8,7 +8,6 @@ package de.hpi.swa.trufflesqueak.nodes;
 
 import java.util.logging.Level;
 
-import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.frame.MaterializedFrame;
@@ -31,7 +30,6 @@ import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
 import de.hpi.swa.trufflesqueak.model.ContextObject;
 import de.hpi.swa.trufflesqueak.model.NilObject;
 import de.hpi.swa.trufflesqueak.nodes.context.CreateCannotReturnContextNode;
-import de.hpi.swa.trufflesqueak.nodes.context.CreateCannotReturnContextNodeGen;
 import de.hpi.swa.trufflesqueak.nodes.process.GetNextActiveContextNode;
 import de.hpi.swa.trufflesqueak.shared.SqueakLanguageConfig;
 import de.hpi.swa.trufflesqueak.util.DebugUtils;
@@ -48,13 +46,14 @@ public final class ExecuteTopLevelContextNode extends RootNode {
 
     @Child private IndirectCallNode callNode = IndirectCallNode.create();
     @Child private GetNextActiveContextNode getNextActiveContextNode = GetNextActiveContextNode.create();
-    @Child private CreateCannotReturnContextNode createCannotReturnContextNode = CreateCannotReturnContextNodeGen.create();
+    @Child private CreateCannotReturnContextNode createCannotReturnContextNode;
 
     private ExecuteTopLevelContextNode(final SqueakImageContext image, final SqueakLanguage language, final ContextObject context, final boolean isImageResuming) {
         super(language, TOP_LEVEL_FRAME_DESCRIPTOR);
         this.image = image;
         initialContext = context;
         this.isImageResuming = isImageResuming;
+        createCannotReturnContextNode = new CreateCannotReturnContextNode(image);
     }
 
     public static ExecuteTopLevelContextNode create(final SqueakImageContext image, final SqueakLanguage language, final ContextObject context, final boolean isImageResuming) {
@@ -119,7 +118,7 @@ public final class ExecuteTopLevelContextNode extends RootNode {
 
     @TruffleBoundary
     private ContextObject sendCannotReturnOrReturnToTopLevel(final ContextObject returningContext, final Object returnValue) {
-        // Exit the interpreter loop if the target is the context that started the loop.
+        /* Exit the interpreter loop if the target is the context that started the loop. */
         if (returningContext != null && returningContext == initialContext) {
             throw returnToTopLevel(returningContext, returnValue);
         }
@@ -128,15 +127,16 @@ public final class ExecuteTopLevelContextNode extends RootNode {
 
     @TruffleBoundary
     private ContextObject returnTo(final ContextObject returningContext, final AbstractSqueakObject sender, final Object returnValue) {
-        // Normal returns end up here.
+        /* Normal returns end up here. */
         assert (sender instanceof ContextObject) || sender == NilObject.SINGLETON;
         if ((sender instanceof final ContextObject senderContext) && !senderContext.isDead()) {
             senderContext.push(returnValue);
             return senderContext;
         }
-        // The returningContext was terminated on the fast path, breaking the sender chain.
-        // If the target is dead, we must restore the link so the exception handler can walk the
-        // stack.
+        /*
+         * The returningContext was terminated on the fast path, breaking the sender chain. If the
+         * target is dead, we must restore the link so the exception handler can walk the stack.
+         */
         if (sender instanceof ContextObject senderContext && senderContext.isDead()) {
             returningContext.setSenderUnsafe(senderContext);
         }
@@ -145,8 +145,10 @@ public final class ExecuteTopLevelContextNode extends RootNode {
 
     @TruffleBoundary
     private static ContextObject commonNVReturn(final NonVirtualReturn nvr) {
-        // Normal returns with modified senders end up here. The return Context has already been
-        // validated.
+        /*
+         * Normal returns with modified senders end up here. The return Context has already been
+         * validated.
+         */
         final Object returnValue = nvr.getReturnValue();
         final ContextObject returnContext = nvr.getTargetContext();
         returnContext.push(returnValue);
@@ -155,11 +157,13 @@ public final class ExecuteTopLevelContextNode extends RootNode {
 
     @TruffleBoundary
     private static ContextObject commonNLReturn(final AbstractSqueakObject sender, final NonLocalReturn nlr) {
-        // Non-local returns with no intervening unwind-blocks end up here. The home Context has
-        // already been validated.
+        /*
+         * Non-local returns with no intervening unwind-blocks end up here. The home Context has
+         * already been validated.
+         */
         final ContextObject homeContext = nlr.getTargetContext();
         final Object returnValue = nlr.getReturnValue();
-        // Terminate the Contexts on sender chain.
+        /* Terminate the Contexts on sender chain. */
         ContextObject context = (ContextObject) sender;
         while (context != homeContext) {
             final ContextObject currentSender = (ContextObject) context.getSender();

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/context/CreateCannotReturnContextNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/context/CreateCannotReturnContextNode.java
@@ -6,12 +6,9 @@
  */
 package de.hpi.swa.trufflesqueak.nodes.context;
 
-import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.Truffle;
-import com.oracle.truffle.api.dsl.Cached;
-import com.oracle.truffle.api.dsl.GenerateInline;
-import com.oracle.truffle.api.dsl.NeverDefault;
-import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 
 import de.hpi.swa.trufflesqueak.exceptions.SqueakExceptions.SqueakException;
@@ -19,58 +16,52 @@ import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
 import de.hpi.swa.trufflesqueak.model.ClassObject;
 import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
 import de.hpi.swa.trufflesqueak.model.ContextObject;
-import de.hpi.swa.trufflesqueak.model.NilObject;
 import de.hpi.swa.trufflesqueak.nodes.AbstractNode;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
 import de.hpi.swa.trufflesqueak.util.MethodCacheEntry;
 
-@GenerateInline(false)
-public abstract class CreateCannotReturnContextNode extends AbstractNode {
+public final class CreateCannotReturnContextNode extends AbstractNode {
+    private static final int INITIAL_PC = 0;
+    private static final int INITIAL_SP = 1;
+    private static final int NUM_ARGUMENTS = 1;
 
-    public abstract ContextObject execute(ContextObject returningContext, Object returnValue);
+    private final CompiledCodeObject cannotReturnMethod;
+    private final FrameDescriptor cannotReturnMethodFrameDescriptor;
 
-    @Specialization
-    protected static final ContextObject doCreate(final ContextObject returningContext, final Object returnValue,
-                    @Cached("lookupCannotReturn()") final CompiledCodeObject method) {
-        return createContext(returningContext, returnValue, method);
+    public CreateCannotReturnContextNode(final SqueakImageContext image) {
+        cannotReturnMethod = lookupCannotReturnMethod(image);
+        cannotReturnMethodFrameDescriptor = cannotReturnMethod.getFrameDescriptor();
     }
 
-    @TruffleBoundary
-    private static ContextObject createContext(final ContextObject returningContext, final Object returnValue, final CompiledCodeObject method) {
-        assert method.getNumArgs() == 1;
+    public ContextObject execute(final ContextObject returningContext, final Object returnValue) {
+        assert cannotReturnMethod.getStartPCZeroBased() == INITIAL_PC;
+        assert cannotReturnMethod.getNumTemps() == INITIAL_SP;
+        assert cannotReturnMethod.getNumArgs() == NUM_ARGUMENTS;
+        assert cannotReturnMethod.getFrameDescriptor() == cannotReturnMethodFrameDescriptor;
 
         final Object[] frameArgs = FrameAccess.newWith(returningContext, null, returningContext, returnValue);
-        final MaterializedFrame truffleFrame = Truffle.getRuntime().createMaterializedFrame(frameArgs, method.getFrameDescriptor());
+        final MaterializedFrame truffleFrame = Truffle.getRuntime().createMaterializedFrame(frameArgs, cannotReturnMethodFrameDescriptor);
         final ContextObject cannotReturnContext = new ContextObject(truffleFrame);
 
-        final int initialPC = method.getStartPCZeroBased();
-        final int initialSP = method.getNumTemps();
-
-        FrameAccess.setInstructionPointer(truffleFrame, initialPC);
-        FrameAccess.setStackPointer(truffleFrame, initialSP);
+        FrameAccess.setInstructionPointer(truffleFrame, INITIAL_PC);
+        FrameAccess.setStackPointer(truffleFrame, INITIAL_SP);
 
         // The arguments must be in both the frame arguments and the stack.
         cannotReturnContext.atTempPut(0, returnValue);
-        // Nil the temporary variables.
-        for (int i = method.getNumArgs(); i < initialSP; i++) {
-            cannotReturnContext.atTempPut(i, NilObject.SINGLETON);
-        }
+        // No temporary variables to nil out because INITIAL_SP == NUM_ARGUMENTS.
 
         return cannotReturnContext;
     }
 
-    @NeverDefault
-    protected final CompiledCodeObject lookupCannotReturn() {
-        final SqueakImageContext image = getContext();
+    private static CompiledCodeObject lookupCannotReturnMethod(final SqueakImageContext image) {
+        CompilerAsserts.neverPartOfCompilation();
         final ClassObject receiverClass = image.methodContextClass;
-
         final MethodCacheEntry cacheEntry = image.findMethodCacheEntry(receiverClass, image.cannotReturn);
         Object lookupResult = cacheEntry.getResult();
         if (lookupResult == null) {
             lookupResult = receiverClass.lookupMethodInMethodDictSlow(image.cannotReturn);
             cacheEntry.setResult(lookupResult);
         }
-
         if (!(lookupResult instanceof CompiledCodeObject)) {
             throw SqueakException.create("cannotReturn: must be a CompiledCodeObject");
         }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/context/CreateCannotReturnContextNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/context/CreateCannotReturnContextNode.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 Software Architecture Group, Hasso Plattner Institute
+ * Copyright (c) 2026 Oracle and/or its affiliates
+ *
+ * Licensed under the MIT License.
+ */
+package de.hpi.swa.trufflesqueak.nodes.context;
+
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.Truffle;
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.GenerateInline;
+import com.oracle.truffle.api.dsl.NeverDefault;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.MaterializedFrame;
+
+import de.hpi.swa.trufflesqueak.exceptions.SqueakExceptions.SqueakException;
+import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
+import de.hpi.swa.trufflesqueak.model.ClassObject;
+import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
+import de.hpi.swa.trufflesqueak.model.ContextObject;
+import de.hpi.swa.trufflesqueak.model.NilObject;
+import de.hpi.swa.trufflesqueak.nodes.AbstractNode;
+import de.hpi.swa.trufflesqueak.util.FrameAccess;
+import de.hpi.swa.trufflesqueak.util.MethodCacheEntry;
+
+@GenerateInline(false)
+public abstract class CreateCannotReturnContextNode extends AbstractNode {
+
+    public abstract ContextObject execute(ContextObject returningContext, Object returnValue);
+
+    @Specialization
+    protected static final ContextObject doCreate(final ContextObject returningContext, final Object returnValue,
+                    @Cached("lookupCannotReturn()") final CompiledCodeObject method) {
+        return createContext(returningContext, returnValue, method);
+    }
+
+    @TruffleBoundary
+    private static ContextObject createContext(final ContextObject returningContext, final Object returnValue, final CompiledCodeObject method) {
+        assert method.getNumArgs() == 1;
+
+        final Object[] frameArgs = FrameAccess.newWith(returningContext, null, returningContext, returnValue);
+        final MaterializedFrame truffleFrame = Truffle.getRuntime().createMaterializedFrame(frameArgs, method.getFrameDescriptor());
+        final ContextObject cannotReturnContext = new ContextObject(truffleFrame);
+
+        final int initialPC = method.getStartPCZeroBased();
+        final int initialSP = method.getNumTemps();
+
+        FrameAccess.setInstructionPointer(truffleFrame, initialPC);
+        FrameAccess.setStackPointer(truffleFrame, initialSP);
+
+        // The arguments must be in both the frame arguments and the stack.
+        cannotReturnContext.atTempPut(0, returnValue);
+        // Nil the temporary variables.
+        for (int i = method.getNumArgs(); i < initialSP; i++) {
+            cannotReturnContext.atTempPut(i, NilObject.SINGLETON);
+        }
+
+        return cannotReturnContext;
+    }
+
+    @NeverDefault
+    protected final CompiledCodeObject lookupCannotReturn() {
+        final SqueakImageContext image = getContext();
+        final ClassObject receiverClass = image.methodContextClass;
+
+        final MethodCacheEntry cacheEntry = image.findMethodCacheEntry(receiverClass, image.cannotReturn);
+        Object lookupResult = cacheEntry.getResult();
+        if (lookupResult == null) {
+            lookupResult = receiverClass.lookupMethodInMethodDictSlow(image.cannotReturn);
+            cacheEntry.setResult(lookupResult);
+        }
+
+        if (!(lookupResult instanceof CompiledCodeObject)) {
+            throw SqueakException.create("cannotReturn: must be a CompiledCodeObject");
+        }
+        return (CompiledCodeObject) lookupResult;
+    }
+}

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractInterpreterNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractInterpreterNode.java
@@ -271,22 +271,27 @@ public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrum
         if (isBlock) {
             return handleBlockReturn(frame, currentPC, pc, sp, result);
         } else {
-            return handleNormalReturn(frame, currentPC, result);
+            return handleNormalReturn(frame, currentPC, pc, sp, result);
         }
     }
 
-    protected final Object handleReturnFromBlock(final VirtualFrame frame, final int currentPC, final Object result, final int loopCounter) {
+    protected final Object handleReturnFromBlock(final VirtualFrame frame, final int currentPC, final int pc, final int sp, final Object result, final int loopCounter) {
         if (loopCounter > 0) {
             LoopNode.reportLoopCount(this, loopCounter);
         }
-        return handleNormalReturn(frame, currentPC, result);
+        return handleNormalReturn(frame, currentPC, pc, sp, result);
     }
 
-    protected final Object handleNormalReturn(final VirtualFrame frame, final int currentPC, final Object result) {
+    protected final Object handleNormalReturn(final VirtualFrame frame, final int currentPC, final int pc, final int sp, final Object result) {
         final byte profile = getProfile(currentPC);
         if (FrameAccess.hasModifiedSender(frame)) {
             enter(currentPC, profile, BRANCH1);
-            throw new NonVirtualReturn(result, FrameAccess.getSender(frame));
+            final AbstractSqueakObject sender = FrameAccess.getSender(frame);
+            if (sender instanceof ContextObject ctx && !ctx.isDead()) {
+                throw new NonVirtualReturn(result, sender);
+            } else {
+                throw cannotReturn(frame, pc, sp, result);
+            }
         } else {
             enter(currentPC, profile, BRANCH2);
             FrameAccess.terminateFrame(frame);
@@ -343,7 +348,6 @@ public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrum
 
     private static CannotReturnToTarget cannotReturn(final VirtualFrame frame, final int pc, final int sp, final Object returnValue) {
         CompilerDirectives.transferToInterpreter();
-        LogUtils.SCHEDULING.info("sendCannotReturn");
         FrameAccess.externalizePCAndSP(frame, pc, sp);
         throw new CannotReturnToTarget(returnValue, GetOrCreateContextWithFrameNode.executeUncached(frame));
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractInterpreterNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractInterpreterNode.java
@@ -48,7 +48,6 @@ import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNodeFactory.D
 import de.hpi.swa.trufflesqueak.nodes.interrupts.CheckForInterruptsInLoopNode;
 import de.hpi.swa.trufflesqueak.util.ArrayUtils;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
-import de.hpi.swa.trufflesqueak.util.LogUtils;
 import de.hpi.swa.trufflesqueak.util.UnsafeUtils;
 
 public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrumentableNode implements BytecodeOSRNode, InstrumentableNode {
@@ -302,7 +301,7 @@ public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrum
     private Object handleBlockReturn(final VirtualFrame frame, final int currentPC, final int pc, final int sp, final Object result) {
         // Target is sender of closure's home context.
         final ContextObject homeContext = FrameAccess.getClosure(frame).getHomeContext();
-        if (homeContext.canBeReturnedTo()) {
+        if (homeContext.canReturnToSender()) {
             final ContextObject firstMarkedContext = firstUnwindMarkedOrThrowNLR(FrameAccess.getSender(frame), homeContext, result);
             if (firstMarkedContext != null) {
                 FrameAccess.externalizePCAndSP(frame, pc, sp);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterSistaV1Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterSistaV1Node.java
@@ -796,13 +796,13 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                     }
                     case BC.RETURN_NIL_FROM_BLOCK: {
                         state.reportLoopCountOnReturn(this);
-                        returnValue = handleNormalReturn(frame, pc, NilObject.SINGLETON);
+                        returnValue = handleNormalReturn(frame, pc, pc + 1, vstate.sp, NilObject.SINGLETON);
                         pc = LOCAL_RETURN_PC;
                         break;
                     }
                     case BC.RETURN_TOP_FROM_BLOCK: {
                         state.reportLoopCountOnReturn(this);
-                        returnValue = handleNormalReturn(frame, pc, top(frame, vstate.sp));
+                        returnValue = handleNormalReturn(frame, pc, pc + 1, vstate.sp - 1, top(frame, vstate.sp));
                         pc = LOCAL_RETURN_PC;
                         break;
                     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterV3PlusClosuresNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterV3PlusClosuresNode.java
@@ -411,7 +411,7 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                         break;
                     }
                     case BC.RETURN_TOP_FROM_BLOCK: {
-                        returnValue = handleReturnFromBlock(frame, currentPC, top(frame, sp),
+                        returnValue = handleReturnFromBlock(frame, currentPC, pc, sp - 1, top(frame, sp),
                                         CompilerDirectives.inCompiledCode() && CompilerDirectives.hasNextTier() ? loopCounter.value : counter);
                         pc = LOCAL_RETURN_PC;
                         break;

--- a/src/image-tests/runCuisTests.st
+++ b/src/image-tests/runCuisTests.st
@@ -18,7 +18,6 @@ CompiledMethod preferredBytecodeSetEncoderClass == EncoderForSistaV1
 
 nonTerminatingTestCases := OrderedCollection new.
 {
-    #ProcessTest -> #(#testResumeWithEnsureAfterBCR).
     #TestValueWithinFix -> TestValueWithinFix allTestSelectors.
 } collect: [:assoc | | testCase |
     testCase := Smalltalk at: assoc key.

--- a/src/image-tests/runSqueakTests.st
+++ b/src/image-tests/runSqueakTests.st
@@ -253,7 +253,7 @@
 
     exitCode := result hasPassed ifTrue: [ 0 ] ifFalse: [ 1 ].
 
-    "Presist image before retrying failures"
+    "Persist image before retrying failures"
     Smalltalk snapshot: true andQuit: false.
 
     retries := 3.


### PR DESCRIPTION
Normal returns are supposed to send `cannotReturn:` to the current `Context` if either the `sender` is `nil` or the `Context` is dead.

This PR modifies normal returns in 2 ways:

1. **If `sender` has been modified:** Check that the new `sender` is not nil and not dead before throwing a `NonVirtualReturn`. Otherwise, throw `CannotReturn`. 
2. **If `sender` has not been modified:** Return the result (as before). If the sender is nil or dead, the current `Context` must be running within a `ResumeContextRootNode`, so control returns to `ExecuteTopLevelContextNode.returnTo()`.  In `returnTo()`, if the `sender` is not nil but is dead, we restore the `sender` in the returning `Context` *before* triggering the cannot-return logic. This keeps the sender chain intact so exception handlers can traverse it. (Previously, the sender was not restored so unwind and exception blocks below the sender were not found during exception handling.)

Additional changes:

* **Simplified NLR and NVR handlers:** By checking that the `sender` can be returned to *before* throwing NLR or NVR, we can remove checks for sending `#cannotReturn:`.
* **Explicit Context Creation (`CreateCannotReturnContextNode`):** Replaced the `Dispatch1Node` dispatch for `#cannotReturn:` with a dedicated node that manually creates a `Context` for evaluating `#cannotReturn:`. This lets us use `ExecuteTopLevelContextNode.executeLoop()` to handle the execution of `#cannotReturn:` without needing to separately handle any of the exceptions that could arise during its execution.
* **Test Un-skipping:** Removed `ProcessTest>>#testResumeWithEnsureAfterBCR` from the `nonTerminatingTestCases` list in `runCuisTests.st` since it now passes successfully.

This PR is based on changes in PRs #257 and #258 