### PR TITLE
Wait for PlatformEventLoop to start before trying to open SqueakDisplay

### DIFF
--- a/src/de.hpi.swa.trufflesqueak.shared/src/de/hpi/swa/trufflesqueak/shared/PlatformEventLoop.java
+++ b/src/de.hpi.swa.trufflesqueak.shared/src/de/hpi/swa/trufflesqueak/shared/PlatformEventLoop.java
@@ -43,6 +43,7 @@ import de.hpi.swa.trufflesqueak.sdl3.bindings.SDL_Event;
 public final class PlatformEventLoop {
     private static final int EVENT_FETCH_BATCH_SIZE = 32;
     private static final CountDownLatch startLatch = new CountDownLatch(1);
+    private static final CountDownLatch initLatch = new CountDownLatch(1);
     private static volatile boolean isRunning = false;
     private static volatile boolean shutdownRequested = false;
     private static volatile Consumer<MemorySegment> eventHandler;
@@ -70,6 +71,14 @@ public final class PlatformEventLoop {
         if (isRunning) {
             isRunning = false;
             pushWakeUpEvent();
+        }
+    }
+
+    public static void waitUntilInitialized() {
+        try {
+            initLatch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
         }
     }
 
@@ -125,6 +134,7 @@ public final class PlatformEventLoop {
              * accidentally get trapped in the while-loop below.
              */
             isRunning = true;
+            initLatch.countDown();
             if (shutdownRequested) {
                 isRunning = false;
             } else {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/io/SqueakDisplay.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/io/SqueakDisplay.java
@@ -654,6 +654,9 @@ public final class SqueakDisplay {
 
         clampDamageToBounds();
 
+        // Wait for the main thread to finish SDL_Init
+        PlatformEventLoop.waitUntilInitialized();
+
         if (window == MemorySegment.NULL) {
             final String imageFileName = new File(image.getImagePath()).getName();
             final String title = imageFileName.contains(SqueakLanguageConfig.IMPLEMENTATION_NAME) ? imageFileName


### PR DESCRIPTION
When starting, it is possible for the image to start running and request a Display refresh before the PlaformEventLoop has completed initializing SDL3. This PR adds a latch that PlatformEventLoop uses to indicate it has finished the initializations and that SqueakDisplay waits on before opening the window for Display.