### PR TITLE
FilePlugin fixes

### DIFF
--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/FilePlugin.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/FilePlugin.java
@@ -666,12 +666,11 @@ public final class FilePlugin extends AbstractPrimitiveFactoryHolder {
         protected static final long doWriteInt(@SuppressWarnings("unused") final Object receiver, final PointersObject fd, final NativeObject content, final long startIndex, final long count) {
             // TODO: use ByteBuffer or UnsafeUtils here?
             final int[] ints = content.getIntStorage();
-            final int intsLength = ints.length;
-            final byte[] bytes = new byte[intsLength * Integer.BYTES];
-            for (int i = 0; i < intsLength; i++) {
-                VarHandleUtils.putIntReversed(bytes, i, ints[i]);
+            final byte[] bytes = new byte[(int) count * Integer.BYTES];
+            for (int i = 0; i < count; i++) {
+                VarHandleUtils.putIntReversed(bytes, i, ints[(int) (startIndex - 1 + i)]);
             }
-            return fileWriteFromAt(fd, count, bytes, startIndex, 4);
+            return fileWriteFromAt(fd, count, bytes, 1, 4);
         }
 
         @Specialization(guards = {"!isStdioFileDescriptor(fd)", "inBounds(startIndex, count, WORD_LENGTH)"})

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/FilePlugin.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/FilePlugin.java
@@ -705,7 +705,6 @@ public final class FilePlugin extends AbstractPrimitiveFactoryHolder {
         private static void writeToOutputStream(final OutputStream outputStream, final byte[] content, final int offset, final int length) {
             try {
                 outputStream.write(content, offset, length);
-                outputStream.flush();
             } catch (final IOException e) {
                 log("Failed to write to OutputStream", e);
                 throw PrimitiveFailed.GENERIC_ERROR;

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/FilePlugin.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/FilePlugin.java
@@ -490,9 +490,9 @@ public final class FilePlugin extends AbstractPrimitiveFactoryHolder {
         protected static final long doReadInts(@SuppressWarnings("unused") final Object receiver, final PointersObject fd, final NativeObject target, final long startIndex, final long count) {
             final ByteBuffer dst = allocate((int) count * Integer.BYTES);
             final long readBytes = readFrom(getChannelOrPrimFail(fd), dst);
+            final long actualReadBytes = Math.max(readBytes, 0L);
             final byte[] bytes = getBytes(dst);
-            assert readBytes % Integer.BYTES == 0 && readBytes == bytes.length;
-            final long readInts = readBytes / Integer.BYTES;
+            final long readInts = actualReadBytes / Integer.BYTES;
             // TODO: could use UnsafeUtils.copyMemory here?
             for (int index = 0; index < readInts; index++) {
                 target.setInt(startIndex - 1 + index, VarHandleUtils.getInt(bytes, index));
@@ -668,7 +668,7 @@ public final class FilePlugin extends AbstractPrimitiveFactoryHolder {
             final int[] ints = content.getIntStorage();
             final byte[] bytes = new byte[(int) count * Integer.BYTES];
             for (int i = 0; i < count; i++) {
-                VarHandleUtils.putIntReversed(bytes, i, ints[(int) (startIndex - 1 + i)]);
+                VarHandleUtils.putInt(bytes, i, ints[(int) (startIndex - 1 + i)]);
             }
             return fileWriteFromAt(fd, count, bytes, 1, 4);
         }


### PR DESCRIPTION
It is possible that the cause of random timeouts of tests on GitHub is due to the servers getting overwhelmed with stdout flushes, so I'm experimenting with removing the flush from stdout writes. Smalltalk-originated flushes are still available, so this should not cause any visible change to the output.

Along the way, I found an optimization (use buffer as same as write) and a bug (integer file writes were the wrong endianness, I think?) ;)