### PR TITLE
Rework interrupts to be thread safe

### DIFF
--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractInterpreterNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractInterpreterNode.java
@@ -429,8 +429,8 @@ public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrum
         return (bytecode & 7) + 1;
     }
 
-    protected final CheckForInterruptsInLoopNode createCheckForInterruptsInLoopNode(final int pc, final int numBytecodes, final int offset) {
-        return CheckForInterruptsInLoopNode.createForLoop(data, pc, numBytecodes, offset);
+    protected final CheckForInterruptsInLoopNode createCheckForInterruptsInLoopNode(final int targetPC, final int jumpOpcodePC) {
+        return CheckForInterruptsInLoopNode.createForLoop(data, targetPC, jumpOpcodePC);
     }
 
     /**

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterSistaV1Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterSistaV1Node.java
@@ -265,7 +265,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                 case BC.SHORT_UJUMP_0, BC.SHORT_UJUMP_1, BC.SHORT_UJUMP_2, BC.SHORT_UJUMP_3, BC.SHORT_UJUMP_4, BC.SHORT_UJUMP_5, BC.SHORT_UJUMP_6, BC.SHORT_UJUMP_7: {
                     final int jumpOffset = calculateShortOffset(b);
                     if (jumpOffset < 0) {
-                        setData(currentPC, insert(createCheckForInterruptsInLoopNode(pc, 1, jumpOffset)));
+                        setData(currentPC, insert(createCheckForInterruptsInLoopNode(pc + jumpOffset, currentPC)));
                     }
                     break;
                 }
@@ -340,7 +340,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                 case BC.EXT_UNCONDITIONAL_JUMP: {
                     final int jumpOffset = calculateLongExtendedOffset(getByte(bc, pc++), vstate.getExtB());
                     if (jumpOffset < 0) {
-                        setData(currentPC, insert(createCheckForInterruptsInLoopNode(currentPC, 2, jumpOffset)));
+                        setData(currentPC, insert(createCheckForInterruptsInLoopNode(pc + jumpOffset, currentPC)));
                     }
                     vstate.resetExtAB();
                     break;

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterV3PlusClosuresNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterV3PlusClosuresNode.java
@@ -222,7 +222,7 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                 case BC.SHORT_UJUMP_0, BC.SHORT_UJUMP_1, BC.SHORT_UJUMP_2, BC.SHORT_UJUMP_3, BC.SHORT_UJUMP_4, BC.SHORT_UJUMP_5, BC.SHORT_UJUMP_6, BC.SHORT_UJUMP_7: {
                     final int offset = calculateShortOffset(b);
                     if (offset < 0) {
-                        setData(currentPC, insert(createCheckForInterruptsInLoopNode(pc, 1, offset)));
+                        setData(currentPC, insert(createCheckForInterruptsInLoopNode(pc + offset, currentPC)));
                     }
                     break;
                 }
@@ -234,7 +234,7 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                 case BC.LONG_UJUMP_0, BC.LONG_UJUMP_1, BC.LONG_UJUMP_2, BC.LONG_UJUMP_3, BC.LONG_UJUMP_4, BC.LONG_UJUMP_5, BC.LONG_UJUMP_6, BC.LONG_UJUMP_7: {
                     final int offset = ((b & 7) - 4 << 8) + getUnsignedInt(bc, pc++);
                     if (offset < 0) {
-                        setData(currentPC, insert(createCheckForInterruptsInLoopNode(pc, 1, offset)));
+                        setData(currentPC, insert(createCheckForInterruptsInLoopNode(pc + offset, currentPC)));
                     }
                     break;
                 }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interrupts/CheckForInterruptsInLoopNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interrupts/CheckForInterruptsInLoopNode.java
@@ -28,14 +28,12 @@ public final class CheckForInterruptsInLoopNode extends AbstractNode {
     private CheckForInterruptsInLoopNode() {
     }
 
-    public static CheckForInterruptsInLoopNode createForLoop(final Object[] data, final int currentPC, final int numBytecodes, final int offset) {
+    public static CheckForInterruptsInLoopNode createForLoop(final Object[] data, final int targetPC, final int jumpOpcodePC) {
         CompilerAsserts.neverPartOfCompilation();
         if (SqueakImageContext.getSlow().interruptHandlerDisabled()) {
             return null;
         }
-        final int loopStart = currentPC + numBytecodes + offset;
-        assert offset < 0 : "back jumps only";
-        for (int i = loopStart; i < currentPC; i++) {
+        for (int i = targetPC; i < jumpOpcodePC; i++) {
             /*
              * FIXME?: Search for call nodes but reject the ones from closure primitives as they do
              * not check for interrupts.

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interrupts/CheckForInterruptsState.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interrupts/CheckForInterruptsState.java
@@ -6,10 +6,13 @@
  */
 package de.hpi.swa.trufflesqueak.nodes.interrupts;
 
-import java.util.ArrayDeque;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.locks.LockSupport;
 
 import com.oracle.truffle.api.CompilerAsserts;
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 
 import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
@@ -21,8 +24,25 @@ public final class CheckForInterruptsState {
 
     private static final int DEFAULT_INTERRUPT_CHECK_NANOS = 2_000_000;
 
+    /**
+     * Support for safely accessing the `shouldTrigger` flag across threads. We use a VarHandle with
+     * opaque access (rather than a standard `volatile` boolean) to guarantee memory visibility
+     * between the background interrupt thread and the main interpreter thread. This prevents the
+     * Graal compiler from improperly loop-hoisting the read during JIT compilation, while
+     * explicitly avoiding the performance penalty of full hardware memory barriers on weakly
+     * ordered architectures like ARM64.
+     */
+    private static final VarHandle SHOULD_TRIGGER;
+    static {
+        try {
+            SHOULD_TRIGGER = MethodHandles.lookup().findVarHandle(CheckForInterruptsState.class, "shouldTrigger", boolean.class);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw CompilerDirectives.shouldNotReachHere("Unable to find a VarHandle for shouldTrigger", e);
+        }
+    }
+
     private final SqueakImageContext image;
-    private final ArrayDeque<Integer> semaphoresToSignal = new ArrayDeque<>();
+    private final ConcurrentLinkedDeque<Integer> semaphoresToSignal = new ConcurrentLinkedDeque<>();
 
     /**
      * `interruptCheckNanos` is the interval between updates to 'shouldTrigger'. This controls the
@@ -41,7 +61,7 @@ public final class CheckForInterruptsState {
      * cannot be moved by the Graal compiler during compilation. Since atomicity is not needed for
      * the interrupt handler mechanism, we can use a standard boolean here for better compilation.
      */
-    private boolean shouldTrigger;
+    @SuppressWarnings("unused") private boolean shouldTrigger;
 
     private Thread thread;
 
@@ -71,7 +91,10 @@ public final class CheckForInterruptsState {
         public void run() {
             while (true) {
                 // Check for interrupts
-                shouldTrigger |= interruptPending || nextWakeUpTickTrigger() || hasPendingFinalizations || hasSemaphoresToSignal();
+                final boolean hasInterrupts = interruptPending || nextWakeUpTickTrigger() || hasPendingFinalizations || hasSemaphoresToSignal();
+                if (hasInterrupts) {
+                    SHOULD_TRIGGER.setOpaque(CheckForInterruptsState.this, true);
+                }
                 LockSupport.parkNanos(interruptCheckNanos);
                 // Handle thread interrupts
                 if (Thread.interrupted()) {
@@ -104,8 +127,10 @@ public final class CheckForInterruptsState {
         if (!isActive) {
             return true;
         }
-        if (shouldTrigger) {
-            shouldTrigger = false; // reset trigger
+        // Force an opaque read from memory
+        if ((boolean) SHOULD_TRIGGER.getOpaque(this)) {
+            // Force an opaque write to memory to reset it
+            SHOULD_TRIGGER.setOpaque(this, false);
             return false;
         } else {
             return true;
@@ -138,7 +163,7 @@ public final class CheckForInterruptsState {
 
     public void setInterruptPending() {
         interruptPending = true;
-        shouldTrigger = true;
+        SHOULD_TRIGGER.setOpaque(this, true);
     }
 
     /* Timer interrupt */
@@ -189,7 +214,7 @@ public final class CheckForInterruptsState {
 
     public void setPendingFinalizations() {
         hasPendingFinalizations = true;
-        shouldTrigger = true;
+        SHOULD_TRIGGER.setOpaque(this, true);
     }
 
     /* Semaphore interrupts */
@@ -214,7 +239,7 @@ public final class CheckForInterruptsState {
     @TruffleBoundary
     public void signalSemaphoreWithIndex(final int index) {
         semaphoresToSignal.addLast(index);
-        shouldTrigger = true;
+        SHOULD_TRIGGER.setOpaque(this, true);
     }
 
     /*

--- a/src/image-tests/runCuisTests.st
+++ b/src/image-tests/runCuisTests.st
@@ -18,8 +18,6 @@ CompiledMethod preferredBytecodeSetEncoderClass == EncoderForSistaV1
 
 nonTerminatingTestCases := OrderedCollection new.
 {
-    #ProcessTest -> #(#testResumeWithEnsureAfterBCR).
-    #TestValueWithinFix -> TestValueWithinFix allTestSelectors.
 } collect: [:assoc | | testCase |
     testCase := Smalltalk at: assoc key.
     assoc value do: [:sel | nonTerminatingTestCases add: (testCase selector: sel) ]].

--- a/src/image-tests/runCuisTests.st
+++ b/src/image-tests/runCuisTests.st
@@ -18,6 +18,7 @@ CompiledMethod preferredBytecodeSetEncoderClass == EncoderForSistaV1
 
 nonTerminatingTestCases := OrderedCollection new.
 {
+    #ProcessTest -> #(#testResumeWithEnsureAfterBCR).
 } collect: [:assoc | | testCase |
     testCase := Smalltalk at: assoc key.
     assoc value do: [:sel | nonTerminatingTestCases add: (testCase selector: sel) ]].


### PR DESCRIPTION
**Possibly fixes 30-minute test hangs on macOS ARM64 CI runners.**

There are two concurrency bugs:

1. **Silent Thread Crashes:** Replaced the non-thread-safe `ArrayDeque` with `ConcurrentLinkedDeque` for `semaphoresToSignal`. This prevents concurrent modification exceptions from silently killing the background timer thread.
2. **JMM Visibility Deadlock:** Changed `shouldTrigger` to use `VarHandle` with opaque access. This prevents GraalVM's JIT from caching the boolean in a CPU register (which possibly blinded the main thread to interrupts), while avoiding the heavy performance penalty of a `volatile` memory fence.

Restored the **TestValueWithinFix** tests since they may have been failing because of the problem this PR fixes.