### PR TITLE
Rework interrupts to be thread safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
       # NOTE: If a dedicated Windows step is added for Cuis 7.5, update the step ID below
       cuis75_windows_2022: ${{ steps.timer_cuis75.outputs.cuis75_windows_2022 }}
     env:
-      VM_ARGS: "--vm.ea --vm.Xmx6G --experimental-options --smalltalk.resource-summary=true --smalltalk.watchdog-timeout=25 --compiler.TreatPerformanceWarningsAsErrors=call,instanceof,store,trivial --compiler.DeoptCycleDetectionThreshold=-1 --engine.CompilationFailureAction=Diagnose --engine.CompilationStatistics"
+      VM_ARGS: "--vm.ea --vm.Xmx6G --experimental-options --smalltalk.resource-summary=true --watchdog-timeout=25 --sdl-poll-timeout=16 --compiler.TreatPerformanceWarningsAsErrors=call,instanceof,store,trivial --compiler.DeoptCycleDetectionThreshold=-1 --engine.CompilationFailureAction=Diagnose --engine.CompilationStatistics"
     name: build ${{ matrix.type }} ${{ matrix.os }}
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
@@ -301,7 +301,7 @@ jobs:
       # NOTE: If a dedicated Windows step is added for Cuis 7.5, update the step ID below
       cuis75_windows_2022: ${{ steps.timer_cuis75.outputs.cuis75_windows_2022 }}
     env:
-      VM_ARGS: "--vm.Xmx6G --headless --experimental-options --smalltalk.watchdog-timeout=25 --compiler.DeoptCycleDetectionThreshold=-1 --engine.CompilationFailureAction=Diagnose"
+      VM_ARGS: "--vm.Xmx6G --headless --experimental-options --watchdog-timeout=25 --sdl-poll-timeout=16 --compiler.DeoptCycleDetectionThreshold=-1 --engine.CompilationFailureAction=Diagnose"
     name: build ${{ matrix.type }} ${{ matrix.os }}
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
       # NOTE: If a dedicated Windows step is added for Cuis 7.5, update the step ID below
       cuis75_windows_2022: ${{ steps.timer_cuis75.outputs.cuis75_windows_2022 }}
     env:
-      VM_ARGS: "--vm.ea --vm.Xmx6G --experimental-options --smalltalk.resource-summary=true --compiler.TreatPerformanceWarningsAsErrors=call,instanceof,store,trivial --compiler.DeoptCycleDetectionThreshold=-1 --engine.CompilationFailureAction=Diagnose --engine.CompilationStatistics"
+      VM_ARGS: "--vm.ea --vm.Xmx6G --experimental-options --smalltalk.resource-summary=true --smalltalk.watchdog-timeout=25 --compiler.TreatPerformanceWarningsAsErrors=call,instanceof,store,trivial --compiler.DeoptCycleDetectionThreshold=-1 --engine.CompilationFailureAction=Diagnose --engine.CompilationStatistics"
     name: build ${{ matrix.type }} ${{ matrix.os }}
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}
@@ -301,7 +301,7 @@ jobs:
       # NOTE: If a dedicated Windows step is added for Cuis 7.5, update the step ID below
       cuis75_windows_2022: ${{ steps.timer_cuis75.outputs.cuis75_windows_2022 }}
     env:
-      VM_ARGS: "--vm.Xmx6G --headless --experimental-options --compiler.DeoptCycleDetectionThreshold=-1 --engine.CompilationFailureAction=Diagnose"
+      VM_ARGS: "--vm.Xmx6G --headless --experimental-options --smalltalk.watchdog-timeout=25 --compiler.DeoptCycleDetectionThreshold=-1 --engine.CompilationFailureAction=Diagnose"
     name: build ${{ matrix.type }} ${{ matrix.os }}
     timeout-minutes: 45
     runs-on: ${{ matrix.os }}

--- a/mx.trufflesqueak/suite.py
+++ b/mx.trufflesqueak/suite.py
@@ -179,6 +179,7 @@ suite = {
             ],
             "requires": [
                 "java.desktop",
+                "java.management",
             ],
             "checkstyle": "de.hpi.swa.trufflesqueak",
             "jacoco": "include",

--- a/src/de.hpi.swa.trufflesqueak.launcher/src/de/hpi/swa/trufflesqueak/launcher/TruffleSqueakLauncher.java
+++ b/src/de.hpi.swa.trufflesqueak.launcher/src/de/hpi/swa/trufflesqueak/launcher/TruffleSqueakLauncher.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.IntConsumer;
 
 import org.graalvm.launcher.AbstractLanguageLauncher;
 import org.graalvm.maven.downloader.Main;
@@ -30,13 +31,12 @@ import de.hpi.swa.trufflesqueak.shared.PlatformEventLoop;
 import de.hpi.swa.trufflesqueak.shared.SqueakImageLocator;
 import de.hpi.swa.trufflesqueak.shared.SqueakLanguageConfig;
 import de.hpi.swa.trufflesqueak.shared.SqueakLanguageOptions;
+import de.hpi.swa.trufflesqueak.shared.WatchdogBridge;
 
 public final class TruffleSqueakLauncher extends AbstractLanguageLauncher {
     private static final String ENGINE_MODE_OPTION = "engine.Mode";
     private static final String ENGINE_MODE_LATENCY = "latency";
     private static final String ENGINE_DYNAMIC_COMPILATION_THRESHOLDS_OPTION = "engine.DynamicCompilationThresholds";
-
-    private static final String[] EMPTY_STRING_ARRAY = new String[0];
 
     private boolean headless;
     private boolean printImagePath;
@@ -47,6 +47,8 @@ public final class TruffleSqueakLauncher extends AbstractLanguageLauncher {
     private boolean enableTranscriptForwarding;
     private boolean addEnableEngineModeLatency = true;
     private boolean addDisableDynamicCompilationThresholds = true;
+    private int sdlPollTimeoutMilliseconds;
+    private int watchdogTimeoutMinutes;
 
     public static void main(final String[] arguments) throws RuntimeException {
         new TruffleSqueakLauncher().launch(arguments);
@@ -84,6 +86,10 @@ public final class TruffleSqueakLauncher extends AbstractLanguageLauncher {
                 quiet = true;
             } else if (SqueakLanguageOptions.TRANSCRIPT_FORWARDING_FLAG.equals(arg)) {
                 enableTranscriptForwarding = true;
+            } else if (arg.startsWith(SqueakLanguageOptions.WATCHDOG_TIMEOUT_FLAG)) {
+                i = handleIntOption(arguments, i, arg, SqueakLanguageOptions.WATCHDOG_TIMEOUT_FLAG, val -> watchdogTimeoutMinutes = val, unrecognized);
+            } else if (arg.startsWith(SqueakLanguageOptions.SDL_POLL_TIMEOUT_FLAG)) {
+                i = handleIntOption(arguments, i, arg, SqueakLanguageOptions.SDL_POLL_TIMEOUT_FLAG, val -> sdlPollTimeoutMilliseconds = val, unrecognized);
             } else {
                 // Check for options explicitly set by user
                 if (arg.contains(ENGINE_MODE_OPTION)) {
@@ -97,8 +103,44 @@ public final class TruffleSqueakLauncher extends AbstractLanguageLauncher {
         return unrecognized;
     }
 
+    /**
+     * Handles parsing a non-negative integer option, routing it to 'unrecognized' if it is a false prefix match.
+     * @return the updated argument index 'i'
+     */
+    private int handleIntOption(final List<String> arguments, final int i, final String arg, final String flagName, final IntConsumer setter, final List<String> unrecognized) {
+        int index = i;
+        final String targetValue;
+
+        if (arg.equals(flagName)) {
+            if (index + 1 < arguments.size()) {
+                targetValue = arguments.get(++index);
+            } else {
+                throw abort("Missing value for option " + arg);
+            }
+        } else if (arg.startsWith(flagName + "=")) {
+            targetValue = arg.substring(flagName.length() + 1);
+        } else {
+            // Fallback for malformed options starting with the same prefix.
+            // Add to unrecognized and return the unmodified index.
+            unrecognized.add(arg);
+            return index;
+        }
+
+        try {
+            final int parsedValue = Integer.parseInt(targetValue);
+            if (parsedValue < 0) {
+                throw abort(String.format("Value '%d' for option '%s' cannot be negative", parsedValue, arg));
+            }
+            setter.accept(parsedValue);
+        } catch (final NumberFormatException e) {
+            throw abort(String.format("Invalid integer value '%s' for option '%s'", targetValue, arg));
+        }
+
+        return index;
+    }
+
     private static String[] getRemainingArguments(final List<String> arguments, final int index) {
-        return arguments.subList(index + 1, arguments.size()).toArray(new String[0]);
+        return arguments.subList(index + 1, arguments.size()).toArray(String[]::new);
     }
 
     @Override
@@ -122,14 +164,17 @@ public final class TruffleSqueakLauncher extends AbstractLanguageLauncher {
         contextBuilder.arguments(getLanguageId(), imageArguments);
         final String runtimeName = getRuntimeName();
         final boolean hasGraalCompiler = runtimeName.contains("Graal");
-        addEnableEngineModeLatency = addEnableEngineModeLatency && hasGraalCompiler;
-        if (addEnableEngineModeLatency) {
+
+        final boolean enableEngineModeLatency = addEnableEngineModeLatency && hasGraalCompiler;
+        if (enableEngineModeLatency) {
             contextBuilder.option(ENGINE_MODE_OPTION, ENGINE_MODE_LATENCY);
         }
-        addDisableDynamicCompilationThresholds = addDisableDynamicCompilationThresholds && hasGraalCompiler;
-        if (addDisableDynamicCompilationThresholds) {
+
+        final boolean disableDynamicCompilationThresholds = addDisableDynamicCompilationThresholds && hasGraalCompiler;
+        if (disableDynamicCompilationThresholds) {
             contextBuilder.option(ENGINE_DYNAMIC_COMPILATION_THRESHOLDS_OPTION, Boolean.toString(false));
         }
+
         contextBuilder.allowAllAccess(true);
         final SqueakTranscriptForwarder out;
         final SqueakTranscriptForwarder err;
@@ -143,8 +188,11 @@ public final class TruffleSqueakLauncher extends AbstractLanguageLauncher {
             err = null;
         }
         try (Context context = contextBuilder.build()) {
+            if (watchdogTimeoutMinutes > 0) {
+                startWatchdog(watchdogTimeoutMinutes);
+            }
             if (!quiet) {
-                final String engineModeSuffix = addEnableEngineModeLatency ? " (" + ENGINE_MODE_LATENCY + " mode)" : "";
+                final String engineModeSuffix = enableEngineModeLatency ? " (" + ENGINE_MODE_LATENCY + " mode)" : "";
                 println(String.format("[trufflesqueak] Running %s on %s%s...", new File(imagePath).getName(), runtimeName, engineModeSuffix));
             }
             if (sourceCode != null) {
@@ -201,7 +249,7 @@ public final class TruffleSqueakLauncher extends AbstractLanguageLauncher {
             }
         }, "TruffleSqueakVM-Thread");
         vmThread.start();
-        PlatformEventLoop.run();
+        PlatformEventLoop.run(sdlPollTimeoutMilliseconds);
         System.exit(vmExitCode[0]);
     }
 
@@ -224,11 +272,13 @@ public final class TruffleSqueakLauncher extends AbstractLanguageLauncher {
         launcherOption(SqueakLanguageOptions.HEADLESS_FLAG, SqueakLanguageOptions.HEADLESS_HELP);
         launcherOption(SqueakLanguageOptions.PRINT_IMAGE_PATH_FLAG, SqueakLanguageOptions.PRINT_IMAGE_PATH_HELP);
         launcherOption(SqueakLanguageOptions.QUIET_FLAG, SqueakLanguageOptions.QUIET_HELP);
+        launcherOption(SqueakLanguageOptions.SDL_POLL_TIMEOUT_FLAG + " <milliseconds>", SqueakLanguageOptions.SDL_POLL_TIMEOUT_HELP);
+        launcherOption(SqueakLanguageOptions.WATCHDOG_TIMEOUT_FLAG + " <minutes>", SqueakLanguageOptions.WATCHDOG_TIMEOUT_HELP);
     }
 
     @Override
     protected void collectArguments(final Set<String> options) {
-        options.addAll(List.of(SqueakLanguageOptions.CODE_FLAG, SqueakLanguageOptions.CODE_FLAG_SHORT, SqueakLanguageOptions.HEADLESS_FLAG,
+        options.addAll(List.of(SqueakLanguageOptions.WATCHDOG_TIMEOUT_FLAG, SqueakLanguageOptions.CODE_FLAG, SqueakLanguageOptions.CODE_FLAG_SHORT, SqueakLanguageOptions.HEADLESS_FLAG,
                         SqueakLanguageOptions.QUIET_FLAG, SqueakLanguageOptions.PRINT_IMAGE_PATH_FLAG, SqueakLanguageOptions.RESOURCE_SUMMARY_FLAG, SqueakLanguageOptions.TRANSCRIPT_FORWARDING_FLAG));
     }
 
@@ -266,7 +316,7 @@ public final class TruffleSqueakLauncher extends AbstractLanguageLauncher {
         }
         args.addAll(arguments);
         try {
-            Main.main(args.toArray(EMPTY_STRING_ARRAY));
+            Main.main(args.toArray(String[]::new));
         } catch (Exception e) {
             throw new Error(e);
         }
@@ -279,5 +329,46 @@ public final class TruffleSqueakLauncher extends AbstractLanguageLauncher {
             throw new UnsupportedOperationException("Expected system property '" + property + "' to be set");
         }
         return value;
+    }
+
+    /* Watchdog support */
+
+    private void startWatchdog(final int timeoutMinutes) {
+        final Thread watchdog = new Thread(() -> {
+            try {
+                final long sleepMillis = timeoutMinutes * 60L * 1000L;
+                Thread.sleep(sleepMillis);
+
+                println("\n\n==========================================================");
+                println("[!!!] WATCHDOG TIMEOUT TRIGGERED: " + timeoutMinutes + " MINUTES REACHED [!!!]");
+                println("==========================================================\n");
+
+                try {
+                    println("Attempting state dump (JVM + Squeak)...");
+                    WatchdogBridge.triggerAction();
+                } catch (final Throwable t) {
+                    println("-> Primary state dump failed: " + t.getMessage());
+                    println("\n=======================================================");
+                    println("FALLBACK: FORCING RAW JVM THREAD DUMP...");
+                    println("=======================================================\n");
+
+                    final java.lang.management.ThreadMXBean threadMXBean = java.lang.management.ManagementFactory.getThreadMXBean();
+                    for (final java.lang.management.ThreadInfo info : threadMXBean.dumpAllThreads(true, true)) {
+                        println(info.toString());
+                    }
+                }
+
+                println("\n=======================================================");
+                println("END OF DUMP. KILLING PROCESS.");
+                println("=======================================================\n");
+                System.exit(1);
+
+            } catch (final InterruptedException e) {
+                // The VM is shutting down cleanly before the timeout, let the watchdog die
+            }
+        }, "TruffleSqueakWatchdog");
+
+        watchdog.setDaemon(true);
+        watchdog.start();
     }
 }

--- a/src/de.hpi.swa.trufflesqueak.sdl3/jextract.args
+++ b/src/de.hpi.swa.trufflesqueak.sdl3/jextract.args
@@ -20,7 +20,7 @@ src/SDL-release-3.4.2/include/SDL3/SDL.h
 --include-function SDL_PushEvent
 --include-function SDL_SetEventEnabled
 --include-struct SDL_TextInputEvent
---include-function SDL_WaitEvent
+--include-function SDL_WaitEventTimeout
 --include-struct SDL_WindowEvent
 --include-struct SDL_AudioDeviceEvent
 --include-struct SDL_CameraDeviceEvent

--- a/src/de.hpi.swa.trufflesqueak.sdl3/src/de/hpi/swa/trufflesqueak/sdl3/bindings/SDL_h.java
+++ b/src/de.hpi.swa.trufflesqueak.sdl3/src/de/hpi/swa/trufflesqueak/sdl3/bindings/SDL_h.java
@@ -1467,14 +1467,72 @@ public class SDL_h extends SDL_h$shared {
         } catch (Error | RuntimeException ex) {
            throw ex;
         } catch (Throwable ex$) {
-            throw new AssertionError("should not reach here", ex$);
+           throw new AssertionError("should not reach here", ex$);
+        }
+    }
+
+    private static class SDL_DestroyCursor {
+        public static final FunctionDescriptor DESC = FunctionDescriptor.ofVoid(
+            SDL_h.C_POINTER
+        );
+
+        public static final MemorySegment ADDR = SYMBOL_LOOKUP.findOrThrow("SDL_DestroyCursor");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
+    }
+
+    /**
+     * Function descriptor for:
+     * {@snippet lang=c :
+     * extern void SDL_DestroyCursor(SDL_Cursor *cursor)
+     * }
+     */
+    public static FunctionDescriptor SDL_DestroyCursor$descriptor() {
+        return SDL_DestroyCursor.DESC;
+    }
+
+    /**
+     * Downcall method handle for:
+     * {@snippet lang=c :
+     * extern void SDL_DestroyCursor(SDL_Cursor *cursor)
+     * }
+     */
+    public static MethodHandle SDL_DestroyCursor$handle() {
+        return SDL_DestroyCursor.HANDLE;
+    }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * extern void SDL_DestroyCursor(SDL_Cursor *cursor)
+     * }
+     */
+    public static MemorySegment SDL_DestroyCursor$address() {
+        return SDL_DestroyCursor.ADDR;
+    }
+
+    /**
+     * {@snippet lang=c :
+     * extern void SDL_DestroyCursor(SDL_Cursor *cursor)
+     * }
+     */
+    public static void SDL_DestroyCursor(MemorySegment cursor) {
+        var mh$ = SDL_DestroyCursor.HANDLE;
+        try {
+            if (TRACE_DOWNCALLS) {
+                traceDowncall("SDL_DestroyCursor", cursor);
+            }
+            mh$.invokeExact(cursor);
+        } catch (Error | RuntimeException ex) {
+           throw ex;
+        } catch (Throwable ex$) {
+           throw new AssertionError("should not reach here", ex$);
         }
     }
 
     private static class SDL_ShowCursor {
         public static final FunctionDescriptor DESC = FunctionDescriptor.of(
-            SDL_h.C_BOOL
-        );
+            SDL_h.C_BOOL    );
 
         public static final MemorySegment ADDR = SYMBOL_LOOKUP.findOrThrow("SDL_ShowCursor");
 
@@ -1532,8 +1590,7 @@ public class SDL_h extends SDL_h$shared {
 
     private static class SDL_HideCursor {
         public static final FunctionDescriptor DESC = FunctionDescriptor.of(
-            SDL_h.C_BOOL
-        );
+            SDL_h.C_BOOL    );
 
         public static final MemorySegment ADDR = SYMBOL_LOOKUP.findOrThrow("SDL_HideCursor");
 
@@ -1582,65 +1639,6 @@ public class SDL_h extends SDL_h$shared {
                 traceDowncall("SDL_HideCursor");
             }
             return (boolean)mh$.invokeExact();
-        } catch (Error | RuntimeException ex) {
-           throw ex;
-        } catch (Throwable ex$) {
-           throw new AssertionError("should not reach here", ex$);
-        }
-    }
-
-    private static class SDL_DestroyCursor {
-        public static final FunctionDescriptor DESC = FunctionDescriptor.ofVoid(
-            SDL_h.C_POINTER
-        );
-
-        public static final MemorySegment ADDR = SYMBOL_LOOKUP.findOrThrow("SDL_DestroyCursor");
-
-        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
-    }
-
-    /**
-     * Function descriptor for:
-     * {@snippet lang=c :
-     * extern void SDL_DestroyCursor(SDL_Cursor *cursor)
-     * }
-     */
-    public static FunctionDescriptor SDL_DestroyCursor$descriptor() {
-        return SDL_DestroyCursor.DESC;
-    }
-
-    /**
-     * Downcall method handle for:
-     * {@snippet lang=c :
-     * extern void SDL_DestroyCursor(SDL_Cursor *cursor)
-     * }
-     */
-    public static MethodHandle SDL_DestroyCursor$handle() {
-        return SDL_DestroyCursor.HANDLE;
-    }
-
-    /**
-     * Address for:
-     * {@snippet lang=c :
-     * extern void SDL_DestroyCursor(SDL_Cursor *cursor)
-     * }
-     */
-    public static MemorySegment SDL_DestroyCursor$address() {
-        return SDL_DestroyCursor.ADDR;
-    }
-
-    /**
-     * {@snippet lang=c :
-     * extern void SDL_DestroyCursor(SDL_Cursor *cursor)
-     * }
-     */
-    public static void SDL_DestroyCursor(MemorySegment cursor) {
-        var mh$ = SDL_DestroyCursor.HANDLE;
-        try {
-            if (TRACE_DOWNCALLS) {
-                traceDowncall("SDL_DestroyCursor", cursor);
-            }
-            mh$.invokeExact(cursor);
         } catch (Error | RuntimeException ex) {
            throw ex;
         } catch (Throwable ex$) {
@@ -1712,13 +1710,14 @@ public class SDL_h extends SDL_h$shared {
         }
     }
 
-    private static class SDL_WaitEvent {
+    private static class SDL_WaitEventTimeout {
         public static final FunctionDescriptor DESC = FunctionDescriptor.of(
             SDL_h.C_BOOL,
-            SDL_h.C_POINTER
+            SDL_h.C_POINTER,
+            SDL_h.C_INT
         );
 
-        public static final MemorySegment ADDR = SYMBOL_LOOKUP.findOrThrow("SDL_WaitEvent");
+        public static final MemorySegment ADDR = SYMBOL_LOOKUP.findOrThrow("SDL_WaitEventTimeout");
 
         public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
     }
@@ -1726,45 +1725,45 @@ public class SDL_h extends SDL_h$shared {
     /**
      * Function descriptor for:
      * {@snippet lang=c :
-     * extern bool SDL_WaitEvent(SDL_Event *event)
+     * extern bool SDL_WaitEventTimeout(SDL_Event *event, Sint32 timeoutMS)
      * }
      */
-    public static FunctionDescriptor SDL_WaitEvent$descriptor() {
-        return SDL_WaitEvent.DESC;
+    public static FunctionDescriptor SDL_WaitEventTimeout$descriptor() {
+        return SDL_WaitEventTimeout.DESC;
     }
 
     /**
      * Downcall method handle for:
      * {@snippet lang=c :
-     * extern bool SDL_WaitEvent(SDL_Event *event)
+     * extern bool SDL_WaitEventTimeout(SDL_Event *event, Sint32 timeoutMS)
      * }
      */
-    public static MethodHandle SDL_WaitEvent$handle() {
-        return SDL_WaitEvent.HANDLE;
+    public static MethodHandle SDL_WaitEventTimeout$handle() {
+        return SDL_WaitEventTimeout.HANDLE;
     }
 
     /**
      * Address for:
      * {@snippet lang=c :
-     * extern bool SDL_WaitEvent(SDL_Event *event)
+     * extern bool SDL_WaitEventTimeout(SDL_Event *event, Sint32 timeoutMS)
      * }
      */
-    public static MemorySegment SDL_WaitEvent$address() {
-        return SDL_WaitEvent.ADDR;
+    public static MemorySegment SDL_WaitEventTimeout$address() {
+        return SDL_WaitEventTimeout.ADDR;
     }
 
     /**
      * {@snippet lang=c :
-     * extern bool SDL_WaitEvent(SDL_Event *event)
+     * extern bool SDL_WaitEventTimeout(SDL_Event *event, Sint32 timeoutMS)
      * }
      */
-    public static boolean SDL_WaitEvent(MemorySegment event) {
-        var mh$ = SDL_WaitEvent.HANDLE;
+    public static boolean SDL_WaitEventTimeout(MemorySegment event, int timeoutMS) {
+        var mh$ = SDL_WaitEventTimeout.HANDLE;
         try {
             if (TRACE_DOWNCALLS) {
-                traceDowncall("SDL_WaitEvent", event);
+                traceDowncall("SDL_WaitEventTimeout", event, timeoutMS);
             }
-            return (boolean)mh$.invokeExact(event);
+            return (boolean)mh$.invokeExact(event, timeoutMS);
         } catch (Error | RuntimeException ex) {
            throw ex;
         } catch (Throwable ex$) {
@@ -2779,3 +2778,4 @@ public class SDL_h extends SDL_h$shared {
         return Holder.SDL_PROP_APP_METADATA_IDENTIFIER_STRING;
     }
 }
+

--- a/src/de.hpi.swa.trufflesqueak.shared/src/de/hpi/swa/trufflesqueak/shared/PlatformEventLoop.java
+++ b/src/de.hpi.swa.trufflesqueak.shared/src/de/hpi/swa/trufflesqueak/shared/PlatformEventLoop.java
@@ -31,7 +31,7 @@ import static de.hpi.swa.trufflesqueak.sdl3.bindings.SDL_h.SDL_Quit;
 import static de.hpi.swa.trufflesqueak.sdl3.bindings.SDL_h.SDL_SetAppMetadataProperty;
 import static de.hpi.swa.trufflesqueak.sdl3.bindings.SDL_h.SDL_SetEventEnabled;
 import static de.hpi.swa.trufflesqueak.sdl3.bindings.SDL_h.SDL_SetHint;
-import static de.hpi.swa.trufflesqueak.sdl3.bindings.SDL_h.SDL_WaitEvent;
+import static de.hpi.swa.trufflesqueak.sdl3.bindings.SDL_h.SDL_WaitEventTimeout;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -146,9 +146,13 @@ public final class PlatformEventLoop {
             final MemorySegment eventBuffer = SDL_Event.allocateArray(EVENT_FETCH_BATCH_SIZE, arena);
             final MemorySegment firstEvent = eventBuffer.asSlice(0, eventSize);
 
+            // Determine timeout: 16ms for CI, -1 (infinite) for GUI
+            final boolean isCI = Boolean.parseBoolean(System.getenv("CI"));
+            final int timeoutMS = isCI ? 16 : -1;
+
             while (isRunning) {
                 // Sleep until an event (or wakeUp() ping) arrives
-                if (SDL_WaitEvent(firstEvent)) {
+                if (SDL_WaitEventTimeout(firstEvent, timeoutMS)) {
                     eventHandler.accept(firstEvent);
                     // Peep additional events from the queue into our buffer
                     int eventsRead;

--- a/src/de.hpi.swa.trufflesqueak.shared/src/de/hpi/swa/trufflesqueak/shared/PlatformEventLoop.java
+++ b/src/de.hpi.swa.trufflesqueak.shared/src/de/hpi/swa/trufflesqueak/shared/PlatformEventLoop.java
@@ -94,7 +94,7 @@ public final class PlatformEventLoop {
         }
     }
 
-    public static void run() {
+    public static void run(final int sdlPollTimeoutMilliseconds) {
         try {
             startLatch.await();
         } catch (InterruptedException e) {
@@ -146,9 +146,7 @@ public final class PlatformEventLoop {
             final MemorySegment eventBuffer = SDL_Event.allocateArray(EVENT_FETCH_BATCH_SIZE, arena);
             final MemorySegment firstEvent = eventBuffer.asSlice(0, eventSize);
 
-            // Determine timeout: 16ms for CI, -1 (infinite) for GUI
-            final boolean isCI = Boolean.parseBoolean(System.getenv("CI"));
-            final int timeoutMS = isCI ? 16 : -1;
+            final int timeoutMS = sdlPollTimeoutMilliseconds > 0 ? sdlPollTimeoutMilliseconds : -1;
 
             while (isRunning) {
                 // Sleep until an event (or wakeUp() ping) arrives

--- a/src/de.hpi.swa.trufflesqueak.shared/src/de/hpi/swa/trufflesqueak/shared/SqueakLanguageOptions.java
+++ b/src/de.hpi.swa.trufflesqueak.shared/src/de/hpi/swa/trufflesqueak/shared/SqueakLanguageOptions.java
@@ -43,6 +43,9 @@ public final class SqueakLanguageOptions {
     public static final String TESTING_HELP = "For internal testing purposes only";
     public static final String TRANSCRIPT_FORWARDING_FLAG = "--enable-transcript-forwarding";
     public static final String TRANSCRIPT_FORWARDING_HELP = "Forward stdio to Smalltalk transcript";
+    public static final String WATCHDOG_TIMEOUT = "watchdog-timeout";
+    public static final String WATCHDOG_TIMEOUT_FLAG = "--" + WATCHDOG_TIMEOUT;
+    public static final String WATCHDOG_TIMEOUT_HELP = "Timeout in minutes for the watchdog (0 = disabled)";
 
     private SqueakLanguageOptions() {
     }

--- a/src/de.hpi.swa.trufflesqueak.shared/src/de/hpi/swa/trufflesqueak/shared/SqueakLanguageOptions.java
+++ b/src/de.hpi.swa.trufflesqueak.shared/src/de/hpi/swa/trufflesqueak/shared/SqueakLanguageOptions.java
@@ -35,6 +35,9 @@ public final class SqueakLanguageOptions {
     public static final String RESOURCE_SUMMARY = "resource-summary";
     public static final String RESOURCE_SUMMARY_FLAG = "--" + RESOURCE_SUMMARY;
     public static final String RESOURCE_SUMMARY_HELP = "Print resource summary on context exit";
+    public static final String SDL_POLL_TIMEOUT = "sdl-poll-timeout";
+    public static final String SDL_POLL_TIMEOUT_FLAG = "--" + SDL_POLL_TIMEOUT;
+    public static final String SDL_POLL_TIMEOUT_HELP = "Timeout in milliseconds for the SDL event loop (0 = disabled)";
     public static final String SIGNAL_INPUT_SEMAPHORE = "signal-input-semaphore";
     public static final String SIGNAL_INPUT_SEMAPHORE_HELP = "Signal the input semaphore";
     public static final String STARTUP = "disable-startup";

--- a/src/de.hpi.swa.trufflesqueak.shared/src/de/hpi/swa/trufflesqueak/shared/WatchdogBridge.java
+++ b/src/de.hpi.swa.trufflesqueak.shared/src/de/hpi/swa/trufflesqueak/shared/WatchdogBridge.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026 Software Architecture Group, Hasso Plattner Institute
+ * Copyright (c) 2026 Oracle and/or its affiliates
+ *
+ * Licensed under the MIT License.
+ */
+package de.hpi.swa.trufflesqueak.shared;
+
+public final class WatchdogBridge {
+    private static volatile Runnable timeoutAction;
+
+    public static void setAction(final Runnable dumper) {
+        timeoutAction = dumper;
+    }
+
+    public static void triggerAction() {
+        if (timeoutAction != null) {
+            timeoutAction.run();
+        }
+    }
+}

--- a/src/de.hpi.swa.trufflesqueak.shared/src/de/hpi/swa/trufflesqueak/shared/WatchdogBridge.java
+++ b/src/de.hpi.swa.trufflesqueak.shared/src/de/hpi/swa/trufflesqueak/shared/WatchdogBridge.java
@@ -16,6 +16,8 @@ public final class WatchdogBridge {
     public static void triggerAction() {
         if (timeoutAction != null) {
             timeoutAction.run();
+        } else {
+            throw new IllegalStateException("Watchdog timeout action not set");
         }
     }
 }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/SqueakOptions.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/SqueakOptions.java
@@ -55,6 +55,9 @@ public final class SqueakOptions {
     @Option(name = SqueakLanguageOptions.TESTING, category = OptionCategory.INTERNAL, stability = OptionStability.STABLE, help = SqueakLanguageOptions.TESTING_HELP, usageSyntax = "false|true")//
     public static final OptionKey<Boolean> Testing = new OptionKey<>(false);
 
+    @Option(name = SqueakLanguageOptions.WATCHDOG_TIMEOUT, category = OptionCategory.USER, stability = OptionStability.EXPERIMENTAL, help = SqueakLanguageOptions.WATCHDOG_TIMEOUT_HELP, usageSyntax = "number")//
+    public static final OptionKey<Integer> WatchdogTimeout = new OptionKey<>(0);
+
     private SqueakOptions() { // no instances
     }
 
@@ -63,7 +66,7 @@ public final class SqueakOptions {
     }
 
     public record SqueakContextOptions(String imagePath, String[] imageArguments, boolean printResourceSummary, boolean isHeadless, boolean disableInterruptHandler,
-                    int maxContextStackDepth, boolean disableStartup, boolean isTesting, boolean signalInputSemaphore) {
+                    int maxContextStackDepth, boolean disableStartup, boolean isTesting, boolean signalInputSemaphore, int watchdogTimeoutMinutes) {
         public static SqueakContextOptions create(final OptionValues options) {
             return new SqueakContextOptions(
                             options.get(ImagePath).isEmpty() ? null : options.get(ImagePath),
@@ -74,7 +77,8 @@ public final class SqueakOptions {
                             Math.max(1, options.get(ContextStackDepth)),
                             options.get(Startup),
                             options.get(Testing),
-                            options.get(SignalInputSemaphore));
+                            options.get(SignalInputSemaphore),
+                            options.get(WatchdogTimeout));
         }
     }
 }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/SqueakOptions.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/SqueakOptions.java
@@ -55,9 +55,6 @@ public final class SqueakOptions {
     @Option(name = SqueakLanguageOptions.TESTING, category = OptionCategory.INTERNAL, stability = OptionStability.STABLE, help = SqueakLanguageOptions.TESTING_HELP, usageSyntax = "false|true")//
     public static final OptionKey<Boolean> Testing = new OptionKey<>(false);
 
-    @Option(name = SqueakLanguageOptions.WATCHDOG_TIMEOUT, category = OptionCategory.USER, stability = OptionStability.EXPERIMENTAL, help = SqueakLanguageOptions.WATCHDOG_TIMEOUT_HELP, usageSyntax = "number")//
-    public static final OptionKey<Integer> WatchdogTimeout = new OptionKey<>(0);
-
     private SqueakOptions() { // no instances
     }
 
@@ -66,7 +63,7 @@ public final class SqueakOptions {
     }
 
     public record SqueakContextOptions(String imagePath, String[] imageArguments, boolean printResourceSummary, boolean isHeadless, boolean disableInterruptHandler,
-                    int maxContextStackDepth, boolean disableStartup, boolean isTesting, boolean signalInputSemaphore, int watchdogTimeoutMinutes) {
+                    int maxContextStackDepth, boolean disableStartup, boolean isTesting, boolean signalInputSemaphore) {
         public static SqueakContextOptions create(final OptionValues options) {
             return new SqueakContextOptions(
                             options.get(ImagePath).isEmpty() ? null : options.get(ImagePath),
@@ -77,8 +74,7 @@ public final class SqueakOptions {
                             Math.max(1, options.get(ContextStackDepth)),
                             options.get(Startup),
                             options.get(Testing),
-                            options.get(SignalInputSemaphore),
-                            options.get(WatchdogTimeout));
+                            options.get(SignalInputSemaphore));
         }
     }
 }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
@@ -235,10 +235,7 @@ public final class SqueakImageContext {
         assert homePath != null && homePath.exists() : "Home directory does not exist: " + homePath;
         initializeMethodCache();
 
-        final int timeoutMinutes = options.watchdogTimeoutMinutes();
-        if (timeoutMinutes > 0) {
-            DebugUtils.startWatchdog(this, timeoutMinutes);
-        }
+        DebugUtils.registerContext(this);
     }
 
     public static SqueakImageContext get(final Node node) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 
+import de.hpi.swa.trufflesqueak.util.DebugUtils;
 import org.graalvm.collections.UnmodifiableEconomicMap;
 
 import com.oracle.truffle.api.Assumption;
@@ -233,6 +234,11 @@ public final class SqueakImageContext {
         }
         assert homePath != null && homePath.exists() : "Home directory does not exist: " + homePath;
         initializeMethodCache();
+
+        final int timeoutMinutes = options.watchdogTimeoutMinutes();
+        if (timeoutMinutes > 0) {
+            DebugUtils.startWatchdog(this, timeoutMinutes);
+        }
     }
 
     public static SqueakImageContext get(final Node node) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractInterpreterNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractInterpreterNode.java
@@ -485,7 +485,7 @@ public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrum
         return (bytecode & 7) + 1;
     }
 
-    protected abstract boolean isFastPathedMessageSend(final int bytecode);
+    protected abstract boolean isFastPathedMessageSend(int bytecode);
 
     protected final CheckForInterruptsInLoopNode createCheckForInterruptsInLoopNode(final int targetPC, final int jumpOpcodePC) {
         // No need to check for interrupts if there is a message dispatch within the loop.

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractInterpreterNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractInterpreterNode.java
@@ -45,6 +45,7 @@ import de.hpi.swa.trufflesqueak.nodes.AbstractNode;
 import de.hpi.swa.trufflesqueak.nodes.accessing.AbstractPointersObjectNodes.AbstractPointersObjectWriteNode;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectAt0NodeGen;
 import de.hpi.swa.trufflesqueak.nodes.context.GetOrCreateContextWithFrameNode;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.AbstractDispatchNode;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector0NodeFactory.Dispatch0NodeGen;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector1NodeFactory.Dispatch1NodeGen;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector2NodeFactory.Dispatch2NodeGen;
@@ -484,8 +485,22 @@ public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrum
         return (bytecode & 7) + 1;
     }
 
+    protected abstract boolean isFastPathedMessageSend(final int bytecode);
+
     protected final CheckForInterruptsInLoopNode createCheckForInterruptsInLoopNode(final int targetPC, final int jumpOpcodePC) {
-        return CheckForInterruptsInLoopNode.createForLoop(data, targetPC, jumpOpcodePC);
+        // No need to check for interrupts if there is a message dispatch within the loop.
+        final byte[] bc = code.getBytes();
+        for (int i = targetPC; i < jumpOpcodePC; i++) {
+            if (data[i] instanceof AbstractDispatchNode) {
+                final int bytecode = getUnsignedInt(bc, i);
+                if (isFastPathedMessageSend(bytecode)) {
+                    // The interpreter could handle this directly and might not check for interrupts.
+                    continue;
+                }
+                return null;
+            }
+        }
+        return CheckForInterruptsInLoopNode.createForLoop();
     }
 
     /**

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterSistaV1Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterSistaV1Node.java
@@ -2867,6 +2867,17 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
         return Byte.toUnsignedInt(bytecode) + (extB << 8);
     }
 
+    @Override
+    protected boolean isFastPathedMessageSend(final int bytecode) {
+        return switch (bytecode) {
+            case BC.BYTECODE_PRIM_ADD, BC.BYTECODE_PRIM_SUBTRACT, BC.BYTECODE_PRIM_LESS_THAN, BC.BYTECODE_PRIM_GREATER_THAN, //
+                BC.BYTECODE_PRIM_LESS_OR_EQUAL, BC.BYTECODE_PRIM_GREATER_OR_EQUAL, BC.BYTECODE_PRIM_EQUAL, BC.BYTECODE_PRIM_NOT_EQUAL, //
+                BC.BYTECODE_PRIM_MULTIPLY, BC.BYTECODE_PRIM_DIV, BC.BYTECODE_PRIM_BIT_AND, BC.BYTECODE_PRIM_BIT_OR, //
+                BC.BYTECODE_PRIM_SIZE -> true;
+            default -> false;
+        };
+    }
+
     static class BC {
         /* 1 byte bytecodes */
         static final int PUSH_RCVR_VAR_0 = 0;

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterV3PlusClosuresNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterV3PlusClosuresNode.java
@@ -1032,6 +1032,16 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
         return (byte) (i >> 6 & 3);
     }
 
+    @Override
+    protected boolean isFastPathedMessageSend(final int bytecode) {
+        return switch (bytecode) {
+            case BC.BYTECODE_PRIM_ADD, BC.BYTECODE_PRIM_SUBTRACT, BC.BYTECODE_PRIM_LESS_THAN, BC.BYTECODE_PRIM_GREATER_THAN, //
+                BC.BYTECODE_PRIM_LESS_OR_EQUAL, BC.BYTECODE_PRIM_GREATER_OR_EQUAL, BC.BYTECODE_PRIM_EQUAL, BC.BYTECODE_PRIM_NOT_EQUAL, //
+                BC.BYTECODE_PRIM_BIT_AND, BC.BYTECODE_PRIM_BIT_OR -> true;
+            default -> false;
+        };
+    }
+
     static class BC {
         /* 1 byte bytecodes */
         static final int PUSH_RCVR_VAR_0 = 0;

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interrupts/CheckForInterruptsNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interrupts/CheckForInterruptsNode.java
@@ -85,19 +85,10 @@ public abstract class CheckForInterruptsNode extends AbstractNode {
         private CheckForInterruptsInLoopNode() {
         }
 
-        public static CheckForInterruptsInLoopNode createForLoop(final Object[] data, final int targetPC, final int jumpOpcodePC) {
+        public static CheckForInterruptsInLoopNode createForLoop() {
             CompilerAsserts.neverPartOfCompilation();
             if (SqueakImageContext.getSlow().interruptHandlerDisabled()) {
                 return null;
-            }
-            for (int i = targetPC; i < jumpOpcodePC; i++) {
-                /*
-                 * FIXME?: Search for call nodes but reject the ones from closure primitives as they
-                 * do not check for interrupts.
-                 */
-                if (data[i] instanceof AbstractDispatchNode) {
-                    return null;
-                }
             }
             return SINGLETON;
         }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interrupts/CheckForInterruptsState.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interrupts/CheckForInterruptsState.java
@@ -252,6 +252,7 @@ public final class CheckForInterruptsState {
         hasPendingFinalizations = false;
         clearWeakPointersQueue();
         semaphoresToSignal.clear();
+        clearShouldTrigger();
     }
 
     public void reset() {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interrupts/CheckForInterruptsState.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interrupts/CheckForInterruptsState.java
@@ -125,11 +125,16 @@ public final class CheckForInterruptsState {
             return true;
         }
         if ((boolean) SHOULD_TRIGGER.getOpaque(this)) {
-            SHOULD_TRIGGER.setOpaque(this, false);
+            clearShouldTrigger();
             return false;
         } else {
             return true;
         }
+    }
+
+    @TruffleBoundary
+    private void clearShouldTrigger() {
+        SHOULD_TRIGGER.setOpaque(this, false);
     }
 
     /* Enable / disable interrupts */

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interrupts/CheckForInterruptsState.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interrupts/CheckForInterruptsState.java
@@ -6,10 +6,14 @@
  */
 package de.hpi.swa.trufflesqueak.nodes.interrupts;
 
-import java.util.ArrayDeque;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.locks.LockSupport;
+import java.util.logging.Level;
 
 import com.oracle.truffle.api.CompilerAsserts;
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 
 import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
@@ -21,8 +25,25 @@ public final class CheckForInterruptsState {
 
     private static final int DEFAULT_INTERRUPT_CHECK_NANOS = 2_000_000;
 
+    /**
+     * Support for safely accessing the `shouldTrigger` flag across threads. We use a VarHandle with
+     * opaque access (rather than a standard `volatile` boolean) to guarantee memory visibility
+     * between the background interrupt thread and the main interpreter thread. This prevents the
+     * Graal compiler from improperly loop-hoisting the read during JIT compilation, while
+     * explicitly avoiding the performance penalty of full hardware memory barriers on weakly
+     * ordered architectures like ARM64.
+     */
+    private static final VarHandle SHOULD_TRIGGER;
+    static {
+        try {
+            SHOULD_TRIGGER = MethodHandles.lookup().findVarHandle(CheckForInterruptsState.class, "shouldTrigger", boolean.class);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw CompilerDirectives.shouldNotReachHere("Unable to find a VarHandle for shouldTrigger", e);
+        }
+    }
+
     private final SqueakImageContext image;
-    private final ArrayDeque<Integer> semaphoresToSignal = new ArrayDeque<>();
+    private final ConcurrentLinkedDeque<Integer> semaphoresToSignal = new ConcurrentLinkedDeque<>();
 
     /**
      * `interruptCheckNanos` is the interval between updates to 'shouldTrigger'. This controls the
@@ -31,17 +52,10 @@ public final class CheckForInterruptsState {
     private long interruptCheckNanos = DEFAULT_INTERRUPT_CHECK_NANOS;
 
     private boolean isActive = true;
-    private long nextWakeupTick;
-    private boolean interruptPending;
-    private boolean hasPendingFinalizations;
-
-    /**
-     * `shouldTrigger` is set to `true` by a dedicated thread. To guarantee atomicity, it would be
-     * necessary to mark this field as `volatile` or use an `AtomicBoolean`. However, such a field
-     * cannot be moved by the Graal compiler during compilation. Since atomicity is not needed for
-     * the interrupt handler mechanism, we can use a standard boolean here for better compilation.
-     */
-    private boolean shouldTrigger;
+    private volatile long nextWakeupTick;
+    private volatile boolean interruptPending;
+    private volatile boolean hasPendingFinalizations;
+    @SuppressWarnings("unused") private boolean shouldTrigger;
 
     private Thread thread;
 
@@ -69,14 +83,19 @@ public final class CheckForInterruptsState {
 
         @Override
         public void run() {
-            while (true) {
-                // Check for interrupts
-                shouldTrigger |= interruptPending || nextWakeUpTickTrigger() || hasPendingFinalizations || hasSemaphoresToSignal();
-                LockSupport.parkNanos(interruptCheckNanos);
-                // Handle thread interrupts
-                if (Thread.interrupted()) {
-                    break;
+            try {
+                while (!Thread.interrupted()) {
+                    /*
+                     * Check for wake up interrupts; all other interrupt sources signal immediately.
+                     */
+                    if (nextWakeUpTickTrigger()) {
+                        SHOULD_TRIGGER.setOpaque(CheckForInterruptsState.this, true);
+                    }
+                    LockSupport.parkNanos(interruptCheckNanos);
                 }
+            } catch (Throwable t) {
+                LogUtils.INTERRUPTS.log(Level.SEVERE, "CheckForInterruptsThread FATAL CRASH", t);
+                System.exit(1);
             }
         }
     }
@@ -85,6 +104,7 @@ public final class CheckForInterruptsState {
     public void shutdown() {
         if (thread != null) {
             thread.interrupt();
+            thread = null;
         }
     }
 
@@ -104,8 +124,8 @@ public final class CheckForInterruptsState {
         if (!isActive) {
             return true;
         }
-        if (shouldTrigger) {
-            shouldTrigger = false; // reset trigger
+        if ((boolean) SHOULD_TRIGGER.getOpaque(this)) {
+            SHOULD_TRIGGER.setOpaque(this, false);
             return false;
         } else {
             return true;
@@ -138,7 +158,7 @@ public final class CheckForInterruptsState {
 
     public void setInterruptPending() {
         interruptPending = true;
-        shouldTrigger = true;
+        SHOULD_TRIGGER.setOpaque(this, true);
     }
 
     /* Timer interrupt */
@@ -189,7 +209,7 @@ public final class CheckForInterruptsState {
 
     public void setPendingFinalizations() {
         hasPendingFinalizations = true;
-        shouldTrigger = true;
+        SHOULD_TRIGGER.setOpaque(this, true);
     }
 
     /* Semaphore interrupts */
@@ -214,7 +234,7 @@ public final class CheckForInterruptsState {
     @TruffleBoundary
     public void signalSemaphoreWithIndex(final int index) {
         semaphoresToSignal.addLast(index);
-        shouldTrigger = true;
+        SHOULD_TRIGGER.setOpaque(this, true);
     }
 
     /*

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/DebugUtils.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/DebugUtils.java
@@ -11,6 +11,7 @@ import java.lang.management.LockInfo;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MonitorInfo;
 import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
 import java.util.List;
 
 import com.oracle.truffle.api.CompilerAsserts;
@@ -36,6 +37,7 @@ import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.SPECIAL_OBJECT;
  */
 public final class DebugUtils {
     public static final boolean UNDER_DEBUG = isDebugging(ManagementFactory.getRuntimeMXBean().getInputArguments());
+    private static final String WATCHDOG_THREAD_NAME = "TruffleSqueakCheckForInterrupts";
 
     private static boolean isDebugging(final List<String> arguments) {
         for (final String argument : arguments) {
@@ -49,12 +51,17 @@ public final class DebugUtils {
     }
 
     public static void dumpState() {
+        final SqueakImageContext image = SqueakImageContext.getSlow();
+        dumpState(image);
+    }
+
+    public static void dumpState(final SqueakImageContext image) {
         CompilerAsserts.neverPartOfCompilation("For debugging purposes only");
         MiscUtils.systemGC();
         final StringBuilder sb = new StringBuilder("Thread dump");
         dumpThreads(sb);
         println(sb.toString());
-        println(currentState());
+        println(currentState(image));
     }
 
     public static void dumpThreads(final StringBuilder sb) {
@@ -118,8 +125,11 @@ public final class DebugUtils {
     }
 
     public static String currentState() {
-        CompilerAsserts.neverPartOfCompilation("For debugging purposes only");
         final SqueakImageContext image = SqueakImageContext.getSlow();
+        return currentState(image);
+    }
+
+    public static String currentState(final SqueakImageContext image) {
         final StringBuilder b = new StringBuilder(64);
         b.append("\nImage processes state\n");
         final PointersObject activeProcess = image.getActiveProcessSlow();
@@ -210,7 +220,12 @@ public final class DebugUtils {
             } else {
                 b.append(":\n");
             }
+            int failsafeDepth = 0;
             while (temp instanceof final PointersObject aProcess) {
+                if (failsafeDepth++ > 1000) {
+                    b.append("\t[... linked list traversal aborted (exceeded 1000 items, likely circular due to concurrent mutation)]\n");
+                    break;
+                }
                 final Object aContext = aProcess.instVarAt0Slow(PROCESS.SUSPENDED_CONTEXT);
                 if (aContext instanceof final ContextObject c) {
                     b.append("\tprocess @").append(Integer.toHexString(aProcess.hashCode())).append(" with suspended context ").append(aContext).append(" and stack trace:\n");
@@ -238,6 +253,77 @@ public final class DebugUtils {
                 current = (ContextObject) sender;
             }
         }
+    }
+
+    /* Watchdog */
+
+    public static void startWatchdog(final SqueakImageContext image, final int timeoutMinutes) {
+        final Thread watchdog = new Thread(() -> {
+            try {
+                final long sleepMillis = timeoutMinutes * 60L * 1000L;
+                Thread.sleep(sleepMillis);
+
+                println("\n\n==========================================================");
+                println("[!!!] WATCHDOG TIMEOUT TRIGGERED: " + timeoutMinutes + " MINUTES REACHED [!!!]");
+                println("==========================================================\n");
+
+                try {
+                    println("Attempting state dump (JVM + Squeak)...");
+
+                    Object prevTruffleContext = null;
+                    try {
+                        prevTruffleContext = image.env.getContext().enter(null);
+                    } catch (Throwable t) {
+                        println("-> Warning: Could not bind Truffle Context.");
+                    }
+
+                    try {
+                        // This handles both the JVM thread dump AND the Squeak process dump
+                        DebugUtils.dumpState(image);
+                    } finally {
+                        if (prevTruffleContext != null) {
+                            image.env.getContext().leave(null, prevTruffleContext);
+                        }
+                    }
+
+                } catch (Throwable t) {
+                    println("-> Primary state dump failed: " + t.toString());
+                    t.printStackTrace();
+
+                    println("\n=======================================================");
+                    println("FALLBACK: FORCING RAW JVM THREAD DUMP...");
+                    println("=======================================================\n");
+
+                    // Fallback: Only dump raw JVM threads if DebugUtils crashed
+                    final ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+                    final ThreadInfo[] threadInfos = threadMXBean.dumpAllThreads(true, true);
+
+                    for (ThreadInfo info : threadInfos) {
+                        print(info.toString());
+                    }
+                }
+
+                println("\n=======================================================");
+                println("END OF DUMP. KILLING PROCESS.");
+                println("=======================================================\n");
+
+                // Hard exit to fail the CI step immediately
+                System.exit(1);
+
+            } catch (InterruptedException e) {
+                // The VM is shutting down cleanly before the timeout, let the watchdog die
+            }
+        }, WATCHDOG_THREAD_NAME);
+
+        // Daemon ensures it won't keep the JVM alive if tests finish early
+        watchdog.setDaemon(true);
+        watchdog.start();
+    }
+
+    private static void print(final String message) {
+        // Checkstyle: stop
+        System.out.print(message);
+        // Checkstyle: resume
     }
 
     private static void println(final Object object) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/DebugUtils.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/DebugUtils.java
@@ -11,8 +11,11 @@ import java.lang.management.LockInfo;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MonitorInfo;
 import java.lang.management.ThreadInfo;
-import java.lang.management.ThreadMXBean;
+import java.lang.ref.WeakReference;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.Truffle;
@@ -31,13 +34,20 @@ import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.PROCESS;
 import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.PROCESS_SCHEDULER;
 import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.SEMAPHORE;
 import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.SPECIAL_OBJECT;
+import de.hpi.swa.trufflesqueak.shared.WatchdogBridge;
 
 /**
  * Helper functions for debugging purposes.
  */
 public final class DebugUtils {
     public static final boolean UNDER_DEBUG = isDebugging(ManagementFactory.getRuntimeMXBean().getInputArguments());
-    private static final String WATCHDOG_THREAD_NAME = "TruffleSqueakCheckForInterrupts";
+
+    private static final Set<WeakReference<SqueakImageContext>> CONTEXTS = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+    public static void registerContext(final SqueakImageContext image) {
+        CONTEXTS.add(new WeakReference<>(image));
+        WatchdogBridge.setAction(DebugUtils::dumpState);
+    }
 
     private static boolean isDebugging(final List<String> arguments) {
         for (final String argument : arguments) {
@@ -51,8 +61,35 @@ public final class DebugUtils {
     }
 
     public static void dumpState() {
-        final SqueakImageContext image = SqueakImageContext.getSlow();
-        dumpState(image);
+        CompilerAsserts.neverPartOfCompilation("For debugging purposes only");
+        MiscUtils.systemGC();
+        final StringBuilder sb = new StringBuilder("Thread dump");
+        dumpThreads(sb);
+        println(sb.toString());
+
+        int contextIndex = 1;
+        for (final WeakReference<SqueakImageContext> ref : CONTEXTS) {
+            final SqueakImageContext image = ref.get();
+            if (image != null) {
+                // Temporarily bind the Truffle context to the watchdog thread
+                Object prevTruffleContext = null;
+                try {
+                    prevTruffleContext = image.env.getContext().enter(null);
+                } catch (final Throwable t) {
+                    println("-> Warning: Could not bind Truffle Context.");
+                }
+
+                try {
+                    println("\n== Squeak Context State (" + contextIndex++ + "/" + CONTEXTS.size() + ") =======================");
+                    println(currentState(image));
+                } finally {
+                    // Always cleanly leave the context
+                    if (prevTruffleContext != null) {
+                        image.env.getContext().leave(null, prevTruffleContext);
+                    }
+                }
+            }
+        }
     }
 
     public static void dumpState(final SqueakImageContext image) {
@@ -253,77 +290,6 @@ public final class DebugUtils {
                 current = (ContextObject) sender;
             }
         }
-    }
-
-    /* Watchdog */
-
-    public static void startWatchdog(final SqueakImageContext image, final int timeoutMinutes) {
-        final Thread watchdog = new Thread(() -> {
-            try {
-                final long sleepMillis = timeoutMinutes * 60L * 1000L;
-                Thread.sleep(sleepMillis);
-
-                println("\n\n==========================================================");
-                println("[!!!] WATCHDOG TIMEOUT TRIGGERED: " + timeoutMinutes + " MINUTES REACHED [!!!]");
-                println("==========================================================\n");
-
-                try {
-                    println("Attempting state dump (JVM + Squeak)...");
-
-                    Object prevTruffleContext = null;
-                    try {
-                        prevTruffleContext = image.env.getContext().enter(null);
-                    } catch (Throwable t) {
-                        println("-> Warning: Could not bind Truffle Context.");
-                    }
-
-                    try {
-                        // This handles both the JVM thread dump AND the Squeak process dump
-                        DebugUtils.dumpState(image);
-                    } finally {
-                        if (prevTruffleContext != null) {
-                            image.env.getContext().leave(null, prevTruffleContext);
-                        }
-                    }
-
-                } catch (Throwable t) {
-                    println("-> Primary state dump failed: " + t.toString());
-                    t.printStackTrace();
-
-                    println("\n=======================================================");
-                    println("FALLBACK: FORCING RAW JVM THREAD DUMP...");
-                    println("=======================================================\n");
-
-                    // Fallback: Only dump raw JVM threads if DebugUtils crashed
-                    final ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
-                    final ThreadInfo[] threadInfos = threadMXBean.dumpAllThreads(true, true);
-
-                    for (ThreadInfo info : threadInfos) {
-                        print(info.toString());
-                    }
-                }
-
-                println("\n=======================================================");
-                println("END OF DUMP. KILLING PROCESS.");
-                println("=======================================================\n");
-
-                // Hard exit to fail the CI step immediately
-                System.exit(1);
-
-            } catch (InterruptedException e) {
-                // The VM is shutting down cleanly before the timeout, let the watchdog die
-            }
-        }, WATCHDOG_THREAD_NAME);
-
-        // Daemon ensures it won't keep the JVM alive if tests finish early
-        watchdog.setDaemon(true);
-        watchdog.start();
-    }
-
-    private static void print(final String message) {
-        // Checkstyle: stop
-        System.out.print(message);
-        // Checkstyle: resume
     }
 
     private static void println(final Object object) {

--- a/src/image-tests/runCuisTests.st
+++ b/src/image-tests/runCuisTests.st
@@ -18,7 +18,6 @@ CompiledMethod preferredBytecodeSetEncoderClass == EncoderForSistaV1
 
 nonTerminatingTestCases := OrderedCollection new.
 {
-    #TestValueWithinFix -> TestValueWithinFix allTestSelectors.
 } collect: [:assoc | | testCase |
     testCase := Smalltalk at: assoc key.
     assoc value do: [:sel | nonTerminatingTestCases add: (testCase selector: sel) ]].

--- a/src/image-tests/runSqueakTests.st
+++ b/src/image-tests/runSqueakTests.st
@@ -208,6 +208,7 @@
         SequenceableCollectionTest -> #(#testCollectWithIndexDeprecation).
         SetInspectorTest -> #(#testExpressions).
         SHParserST80Test -> #(#testNumbers).
+        StringTest ->#(#testFindSelector).
         TestValueWithinFix -> #(#testValueWithinTimingBasic #testValueWithinTimingNestedInner #testValueWithinTimingNestedOuter #testValueWithinTimingRepeat).
         WeakIdentityDictionaryTest -> #(#testIsEmpty).
         WeakKeyDictionaryTest -> #(#testIsEmpty).


### PR DESCRIPTION
Fixes 30-minute test hangs on macOS ARM64 CI runners. Also fixes the Cuis `TestValueWithinFix` tests since they were failing due to `shouldTrigger` being hoisted out of the loop. Ran `Test TruffleSqueak` 27 times without failure.

Changes include:

- `shouldTrigger` as a simple boolean can be hoisted outside the interpreter loop preventing interrupt checks. Convert to opaque accesses to guarantee it is always checked.
- `semaphoresToSignal` is accessed by multiple threads. Converted to `ConcurrentLinkedQueue`.
- Simplified the interrupt poll thread since all interrupt sources except the timer immediately set `shouldTrigger`.
- Added a `catch` block to the `CheckForInterruptsThread` polling thread to print error cause and terminate rather than silently exiting.
- Added a watchdog, settable from the command line, to dump the interpreter state and exit if execution continues beyond the given time in minutes. Use `--watchdog-timeout=timeInMinutes`
- Added a 25 minute watchdog to GitHub CI tests.
- Modified `PlatformEventLoop` to use 16 ms timeout when running in CI, guaranteeing progress even when GitHub macOS servers aggressively sleep UI threads. The wait event timeout remains infinite for GUI.
- Regenerated SDL3 bindings to replace `SDL_WaitEvent` with `SDL_WaitEventTimeout`. Used @timfel README as a guide to re-apply the Windows compatibility fix. `jextract` reordered `SDL_DestroyCursor` adding noise to the diff.

Replaces PR #262 