### PR TITLE
protect AOT JavaTest#testJavaAddToHostClassPath from crashing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,7 +324,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     steps:
-    - *checkout_repo
+    - *checkout_repo # for analyze_benchmarks.py
     - name: Download TruffleSqueak (${{ matrix.type }}-${{ matrix.os }})
       uses: *download_artifact_action
       with:
@@ -380,12 +380,16 @@ jobs:
         ${{ env.EXEC }} trufflesqueak ${{ env.COMMON_VM_ARGS }} ${{ matrix.vm-args }} -- --evaluate "AWFYHarness run: #('Towers' ${{ matrix.iterations }} 1500)" 2>&1 | tee Towers.log
     - name: Analyze benchmark results
       run: |
-        jq -n --arg body "$(python mx.trufflesqueak/analyze_benchmarks.py ${{ matrix.kind }})" '{ body: $body }' |\
-        curl -sL -X POST -d @- \
-          -H "Content-Type: application/json" \
-          -H "Accept: application/vnd.github.v3+json" \
-          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-          "https://api.github.com/repos/${{ github.repository }}/commits/${{ github.sha }}/comments"
+        body="$(python mx.trufflesqueak/analyze_benchmarks.py ${{ matrix.kind }})"
+        echo "$body" >> $GITHUB_STEP_SUMMARY
+        if [[ "${{ github.event_name }}" == "push" ]]; then
+          jq -cn --arg body "$body" '{ body: $body }' > comment.json
+          curl --fail-with-body -sSL -X POST --data-binary @comment.json \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/commits/${{ github.sha }}/comments"
+        fi
     - name: Upload Graal compiler dumps
       uses: *upload_artifact_action
       with:

--- a/mx.trufflesqueak/pre-commit/eclipseformat.sh
+++ b/mx.trufflesqueak/pre-commit/eclipseformat.sh
@@ -6,4 +6,4 @@
 # Licensed under the MIT License.
 #
 
-mx eclipseformat --no-backup --primary --filelist <(echo "${@}" | tr ' ' '\n')
+mx eclipseformat --eclipse-exe builtin --no-backup --primary --filelist <(echo "${@}" | tr ' ' '\n')

--- a/src/de.hpi.swa.trufflesqueak/src/META-INF/native-image/de.hpi.swa.trufflesqueak/trufflesqueak/native-image.properties
+++ b/src/de.hpi.swa.trufflesqueak/src/META-INF/native-image/de.hpi.swa.trufflesqueak/trufflesqueak/native-image.properties
@@ -5,6 +5,7 @@ Requires = language:nfi
 
 Args = --initialize-at-build-time=de.hpi.swa.trufflesqueak \
        --initialize-at-run-time=de.hpi.swa.trufflesqueak.shared.PlatformEventLoop,de.hpi.swa.trufflesqueak.sdl3.bindings \
+       --features=de.hpi.swa.trufflesqueak.util.HostInteropFeature \
        --add-exports=java.base/jdk.internal.module=de.hpi.swa.trufflesqueak \
        -H:MaxRuntimeCompileMethods=5000 \
        --link-at-build-time \

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/interop/JavaObjectWrapper.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/interop/JavaObjectWrapper.java
@@ -12,10 +12,8 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.math.BigInteger;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.TreeSet;
 import java.util.WeakHashMap;
 
 import com.oracle.truffle.api.CompilerDirectives;
@@ -41,26 +39,11 @@ import com.oracle.truffle.api.interop.UnsupportedTypeException;
 import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
-import com.oracle.truffle.api.nodes.LanguageInfo;
 import com.oracle.truffle.api.nodes.Node;
-import com.oracle.truffle.api.source.SourceSection;
 
 import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
-import de.hpi.swa.trufflesqueak.model.ArrayObject;
-import de.hpi.swa.trufflesqueak.model.BlockClosureObject;
 import de.hpi.swa.trufflesqueak.model.BooleanObject;
-import de.hpi.swa.trufflesqueak.model.CharacterObject;
-import de.hpi.swa.trufflesqueak.model.ClassObject;
-import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
-import de.hpi.swa.trufflesqueak.model.ContextObject;
-import de.hpi.swa.trufflesqueak.model.EmptyObject;
-import de.hpi.swa.trufflesqueak.model.FloatObject;
-import de.hpi.swa.trufflesqueak.model.NativeObject;
 import de.hpi.swa.trufflesqueak.model.NilObject;
-import de.hpi.swa.trufflesqueak.model.PointersObject;
-import de.hpi.swa.trufflesqueak.model.VariablePointersObject;
-import de.hpi.swa.trufflesqueak.model.WeakVariablePointersObject;
-import de.hpi.swa.trufflesqueak.model.layout.ObjectLayout;
 import de.hpi.swa.trufflesqueak.nodes.SqueakGuards;
 import de.hpi.swa.trufflesqueak.util.ArrayUtils;
 import de.hpi.swa.trufflesqueak.util.LogUtils;
@@ -180,43 +163,15 @@ public final class JavaObjectWrapper implements TruffleObject {
         }
     };
 
-    static {
-        /*
-         * Pre-initialize CLASSES_TO_MEMBERS, CLASSES_TO_METHODS, and CLASSES_TO_FIELDS for certain
-         * classes to provide access when TruffleSqueak is compiled with native-image.
-         */
-        if (TruffleOptions.AOT) {
-            for (final Class<?> cls : new Class<?>[]{
-                            // General types
-                            boolean.class, byte.class, char.class, short.class, int.class, long.class, float.class, double.class,
-                            Boolean.class, Byte.class, Character.class, Short.class, Integer.class, Long.class, Float.class, Double.class,
-                            Class.class, Object.class, String.class,
-                            // Common data structures
-                            ArrayList.class, HashMap.class, HashSet.class, TreeSet.class,
-                            // Truffle types exposed by PolyglotPlugin
-                            LanguageInfo.class, SourceSection.class,
-                            // Non-abstract classes of TruffleSqueak model
-                            ArrayObject.class, BlockClosureObject.class, BooleanObject.class, CharacterObject.class, ClassObject.class, CompiledCodeObject.class, ContextObject.class,
-                            EmptyObject.class, FloatObject.class, NativeObject.class, NilObject.class, PointersObject.class, VariablePointersObject.class,
-                            WeakVariablePointersObject.class,
-                            // TruffleSqueak's object layout
-                            ObjectLayout.class,
-                            // Java types used by interop
-                            java.time.Duration.class, java.time.LocalDate.class, java.time.LocalTime.class, java.time.Instant.class, java.time.ZoneId.class, java.time.format.TextStyle.class,
-                            java.util.Locale.class,
-
-            }) {
-                CLASSES_TO_MEMBERS.get(cls);
-                CLASSES_TO_MEMBERS.get(Array.newInstance(cls, 0).getClass()); // Add array classes
-            }
-        }
-    }
-
     @CompilationFinal private static String hostLanguageId;
     private final Object wrappedObject;
 
     private JavaObjectWrapper(final Object object) {
         wrappedObject = object;
+    }
+
+    public static void populateAOT(final Class<?> type) {
+        CLASSES_TO_MEMBERS.get(type);
     }
 
     @TruffleBoundary

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/PolyglotPlugin.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/PolyglotPlugin.java
@@ -2086,7 +2086,7 @@ public final class PolyglotPlugin extends AbstractPrimitiveFactoryHolder {
             try {
                 env.addToHostClassPath(env.getPublicTruffleFile(path));
                 return receiver;
-            } catch (final SecurityException e) {
+            } catch (final RuntimeException e) {
                 throw primitiveFailedInInterpreterCapturing(e);
             }
         }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/HostInteropFeature.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/HostInteropFeature.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 Software Architecture Group, Hasso Plattner Institute
+ * Copyright (c) 2026 Oracle and/or its affiliates
+ *
+ * Licensed under the MIT License.
+ */
+package de.hpi.swa.trufflesqueak.util;
+
+import org.graalvm.nativeimage.dynamicaccess.AccessCondition;
+import org.graalvm.nativeimage.dynamicaccess.ReflectiveAccess;
+import org.graalvm.nativeimage.hosted.Feature;
+
+import com.oracle.truffle.api.TruffleOptions;
+import com.oracle.truffle.api.nodes.LanguageInfo;
+import com.oracle.truffle.api.source.SourceSection;
+
+import de.hpi.swa.trufflesqueak.interop.JavaObjectWrapper;
+import de.hpi.swa.trufflesqueak.model.ArrayObject;
+import de.hpi.swa.trufflesqueak.model.BlockClosureObject;
+import de.hpi.swa.trufflesqueak.model.BooleanObject;
+import de.hpi.swa.trufflesqueak.model.CharacterObject;
+import de.hpi.swa.trufflesqueak.model.ClassObject;
+import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
+import de.hpi.swa.trufflesqueak.model.ContextObject;
+import de.hpi.swa.trufflesqueak.model.EmptyObject;
+import de.hpi.swa.trufflesqueak.model.FloatObject;
+import de.hpi.swa.trufflesqueak.model.NativeObject;
+import de.hpi.swa.trufflesqueak.model.NilObject;
+import de.hpi.swa.trufflesqueak.model.PointersObject;
+import de.hpi.swa.trufflesqueak.model.VariablePointersObject;
+import de.hpi.swa.trufflesqueak.model.WeakVariablePointersObject;
+import de.hpi.swa.trufflesqueak.model.layout.ObjectLayout;
+import de.hpi.swa.trufflesqueak.model.layout.SlotLocation;
+
+/** Registers Java types for reflection which is required for host interop. */
+public class HostInteropFeature implements Feature {
+    @Override
+    public void afterRegistration(final AfterRegistrationAccess access) {
+        final ReflectiveAccess reflection = access.getReflectiveAccess();
+        for (final Class<?> cls : new Class<?>[]{
+                        // General types
+                        boolean.class, byte.class, char.class, short.class, int.class, long.class, float.class, double.class,
+                        Boolean.class, Byte.class, Character.class, Short.class, Integer.class, Long.class, Float.class, Double.class,
+                        Class.class, Object.class, String.class, RuntimeException.class,
+                        // Common data structures
+                        java.util.ArrayList.class, java.util.HashMap.class, java.util.HashSet.class, java.util.TreeSet.class, java.util.Arrays.class,
+                        // Truffle types exposed by PolyglotPlugin
+                        LanguageInfo.class, SourceSection.class,
+                        // Truffle types
+                        TruffleOptions.class,
+                        // Non-abstract classes of TruffleSqueak model
+                        ArrayObject.class, BlockClosureObject.class, BooleanObject.class, CharacterObject.class, ClassObject.class, CompiledCodeObject.class, ContextObject.class,
+                        EmptyObject.class, FloatObject.class, NativeObject.class, NilObject.class, PointersObject.class, VariablePointersObject.class,
+                        WeakVariablePointersObject.class,
+                        // TruffleSqueak's object layout
+                        ObjectLayout.class, SlotLocation.class,
+                        // TruffleSqueak utils
+                        MiscUtils.class,
+                        // Java types used by interop
+                        java.net.InetAddress.class,
+                        java.nio.ByteBuffer.class,
+                        java.time.Duration.class, java.time.LocalDate.class, java.time.LocalTime.class, java.time.Instant.class, java.time.ZoneId.class, java.time.ZoneOffset.class,
+                        java.time.format.TextStyle.class, java.time.zone.ZoneRules.class,
+                        java.util.Locale.class,
+        }) {
+            JavaObjectWrapper.populateAOT(cls);
+            reflection.register(AccessCondition.unconditional(), cls);
+            reflection.register(AccessCondition.unconditional(), cls.getConstructors());
+            reflection.register(AccessCondition.unconditional(), cls.getMethods());
+            reflection.register(AccessCondition.unconditional(), cls.getFields());
+        }
+        /*
+         * System class needs special handling. In particular, its fields hold user-specific data
+         * that should never be in the image heap.
+         */
+        reflection.register(AccessCondition.unconditional(), java.lang.System.class.getMethods());
+    }
+}

--- a/src/image-tests/runSqueakTests.st
+++ b/src/image-tests/runSqueakTests.st
@@ -138,7 +138,6 @@
         SocketTest -> #(#testSocketReuse #testTCPSocketReuse #testUDP).
         StackInterpreterTests -> #(#testImmediateFloats #testPointerTaggingDetagging). "broken"
         SystemChangeFileTest -> #(#testClassRenamed). "flaky and can hang the system"
-        TruffleSqueakTest -> #(#testTestMapConsistency).
     } collect: [:assoc | | testCase |
         testCase := assoc key.
         assoc value do: [:sel | ignoredTests add: (testCase selector: sel) ]].
@@ -148,10 +147,6 @@
             FFIPluginConstructedTests -> FFIPluginConstructedTests allTestSelectors.
             FFIPluginLibraryTests -> FFIPluginLibraryTests allTestSelectors.
             FFIPluginTests -> FFIPluginTests allTestSelectors.
-            InteropTest -> InteropTest allTestSelectors.
-            JavaTest -> JavaTest allTestSelectors.
-            PolyglotTest -> #(#testInstallLanguage).
-            TruffleSqueakTest -> #(#testLayoutStatistics #testCallTarget).
         } collect: [:assoc | | testCase |
             testCase := assoc key.
             assoc value do: [:sel | ignoredTests add: (testCase selector: sel) ]].


### PR DESCRIPTION
Download and run the Action artifact `trufflesqueak-native-ubuntu-22.04-arm`, choose the recommended Squeak image, open the Test Runner, then run all the tests results in: 

```
[trufflesqueak] Running TruffleSqueak-25.0.1.image on Oracle GraalVM (latency mode)...
org.graalvm.polyglot.PolyglotException: Cannot add classpath entry some.jar in native mode.
	at <smalltalk> JavaTest#testJavaAddToHostClassPath(Unknown)
	at <smalltalk> TestCase#performTest(TestCase#performTest:1-6:0-104)
	at <smalltalk> [] in [] in TestCase#runCase([] in [] in TestCase#runCase:1-4:0-74)
	at <smalltalk> BlockClosure#on:do:(BlockClosure#on:do::1-8:0-175)
	at <smalltalk> [] in TestCase#timeout:after:([] in TestCase#timeout:after::1-10:0-302)
	at <smalltalk> BlockClosure#ensure:(BlockClosure#ensure::1-15:0-317)
	at <smalltalk> CTX TestCase#timeout:after: @47dbbd40(TestCase#timeout:after::1-32:0-961)
	at org.graalvm.polyglot.Value.execute(Value.java:1096)
	at de.hpi.swa.trufflesqueak.launcher.TruffleSqueakLauncher.execute(TruffleSqueakLauncher.java:167)
	at de.hpi.swa.trufflesqueak.launcher.TruffleSqueakLauncher.lambda$executeInVMThread$0(TruffleSqueakLauncher.java:196)
	at java.lang.Thread.runWith(Thread.java:1487)
	at java.lang.Thread.run(Thread.java:1474)
	at com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:930)
	at com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:906)
```

This PR snags the exception and causes the primitive to fail rather than the crash.
