### PR TITLE
change PrimRelinquishProcessorNode to match OSVM behavior

### DIFF
--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interrupts/CheckForInterruptsState.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interrupts/CheckForInterruptsState.java
@@ -58,6 +58,7 @@ public final class CheckForInterruptsState {
     @SuppressWarnings("unused") private boolean shouldTrigger;
 
     private Thread thread;
+    private volatile Thread vmThread;
 
     public CheckForInterruptsState(final SqueakImageContext image) {
         this.image = image;
@@ -90,6 +91,7 @@ public final class CheckForInterruptsState {
                      */
                     if (nextWakeUpTickTrigger()) {
                         SHOULD_TRIGGER.setOpaque(CheckForInterruptsState.this, true);
+                        wakeupVM();
                     }
                     LockSupport.parkNanos(interruptCheckNanos);
                 }
@@ -105,6 +107,19 @@ public final class CheckForInterruptsState {
         if (thread != null) {
             thread.interrupt();
             thread = null;
+        }
+    }
+
+    /* Relinquish Processor Primitive Helper */
+
+    public void setVMThread(final Thread thread) {
+        this.vmThread = thread;
+    }
+
+    private void wakeupVM() {
+        final Thread theThread = vmThread;
+        if (theThread != null) {
+            LockSupport.unpark(theThread);
         }
     }
 
@@ -164,6 +179,7 @@ public final class CheckForInterruptsState {
     public void setInterruptPending() {
         interruptPending = true;
         SHOULD_TRIGGER.setOpaque(this, true);
+        wakeupVM();
     }
 
     /* Timer interrupt */
@@ -215,6 +231,7 @@ public final class CheckForInterruptsState {
     public void setPendingFinalizations() {
         hasPendingFinalizations = true;
         SHOULD_TRIGGER.setOpaque(this, true);
+        wakeupVM();
     }
 
     /* Semaphore interrupts */
@@ -240,6 +257,7 @@ public final class CheckForInterruptsState {
     public void signalSemaphoreWithIndex(final int index) {
         semaphoresToSignal.addLast(index);
         SHOULD_TRIGGER.setOpaque(this, true);
+        wakeupVM();
     }
 
     /*

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interrupts/CheckForInterruptsState.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interrupts/CheckForInterruptsState.java
@@ -117,10 +117,7 @@ public final class CheckForInterruptsState {
     }
 
     private void wakeupVM() {
-        final Thread theThread = vmThread;
-        if (theThread != null) {
-            LockSupport.unpark(theThread);
-        }
+        LockSupport.unpark(vmThread);
     }
 
     /* Interrupt check interval */

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interrupts/CheckForInterruptsState.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interrupts/CheckForInterruptsState.java
@@ -118,6 +118,7 @@ public final class CheckForInterruptsState {
 
     private void wakeupVM() {
         LockSupport.unpark(vmThread);
+        vmThread = null; // Only ever unpark once.
     }
 
     /* Interrupt check interval */

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ControlPrimitives.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ControlPrimitives.java
@@ -1305,29 +1305,31 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
              * the time left on the current Delay. If it does wait, the wait terminates
              * early when an interrupt event is received.
              *
-             * Here, we emulate this behavior by checking and handling interrupts before and
-             * after the park. By registering the current thread, newly arriving interrupts
-             * will force the park to exit early.
+             * Here, we emulate this behavior by checking for interrupts before the park.
+             * By registering the current thread, newly arriving interrupts will force the
+             * park to exit early, allowing the next iteration of the Smalltalk idle loop to
+             * catch them.
              */
 
-            // Register the current VM thread.
-            image.interrupt.setVMThread(Thread.currentThread());
-
             try {
-                interruptNode.execute(frame);
-            } catch (final ProcessSwitch ps) {
-                pushNode.execute(frame, receiver);
-                throw ps;
+                // Register this thread to be notified if an interrupt occurs.
+                image.interrupt.setVMThread(Thread.currentThread());
+
+                // Check for interrupts enqueued before primitive send.
+                try {
+                    interruptNode.execute(frame);
+                } catch (final ProcessSwitch ps) {
+                    pushNode.execute(frame, receiver);
+                    throw ps;
+                }
+
+                // Sleep for duration or until interrupt, whichever comes first.
+                MiscUtils.park(timeMicroseconds * 1000);
+            } finally {
+                image.interrupt.setVMThread(null);
             }
 
-            MiscUtils.park(timeMicroseconds * 1000);
-
-            try {
-                interruptNode.execute(frame);
-            } catch (final ProcessSwitch ps) {
-                pushNode.execute(frame, receiver);
-                throw ps;
-            }
+            // If an interrupt terminates the park, it will be handled on the next idle loop.
             return receiver;
         }
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ControlPrimitives.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ControlPrimitives.java
@@ -1287,6 +1287,19 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
         }
     }
 
+    /**
+     * Because this primitive is called within a loop that contains a message send, interrupts are
+     * not checked on the backwards jump to the loop head. Here, we perform the check to make sure
+     * that interrupts are processed.
+     * <p>
+     * In OSVM, this primitive returns immediately if there are pending interrupts. Also, it waits
+     * until the minimum of the duration given by the argument and the time left on the current
+     * Delay. If it does wait, the wait terminates early when an interrupt event is received.
+     * <p>
+     * Here, we emulate this behavior by checking for interrupts before the park. By registering the
+     * current thread, newly arriving interrupts will force the park to exit early, allowing the
+     * next iteration of the Smalltalk idle loop to catch them.
+     */
     @GenerateNodeFactory
     @SqueakPrimitive(indices = 230)
     protected abstract static class PrimRelinquishProcessorNode extends AbstractPrimitiveWithFrameNode implements Primitive1WithFallback {
@@ -1295,39 +1308,20 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
                         @Bind final SqueakImageContext image,
                         @Cached final CheckForInterruptsFullNode interruptNode,
                         @Cached final PushToStackNode pushNode) {
-            /*
-             * Because this primitive is called within a loop that contains a message send,
-             * interrupts are not checked on the backwards jump to the loop head. Here, we
-             * perform the check to make sure that interrupts are processed.
-             *
-             * In OSVM, this primitive returns immediately if there are pending interrupts.
-             * Also, it waits until the minimum of the duration given by the argument and
-             * the time left on the current Delay. If it does wait, the wait terminates
-             * early when an interrupt event is received.
-             *
-             * Here, we emulate this behavior by checking for interrupts before the park.
-             * By registering the current thread, newly arriving interrupts will force the
-             * park to exit early, allowing the next iteration of the Smalltalk idle loop to
-             * catch them.
-             */
-
+            // Check for interrupts enqueued before primitive send.
             try {
-                // Register this thread to be notified if an interrupt occurs.
-                image.interrupt.setVMThread(Thread.currentThread());
-
-                // Check for interrupts enqueued before primitive send.
-                try {
-                    interruptNode.execute(frame);
-                } catch (final ProcessSwitch ps) {
-                    pushNode.execute(frame, receiver);
-                    throw ps;
-                }
-
-                // Sleep for duration or until interrupt, whichever comes first.
-                MiscUtils.park(timeMicroseconds * 1000);
-            } finally {
-                image.interrupt.setVMThread(null);
+                interruptNode.execute(frame);
+            } catch (final ProcessSwitch ps) {
+                pushNode.execute(frame, receiver);
+                throw ps;
             }
+
+            // Register this thread to be notified if an interrupt occurs.
+            image.interrupt.setVMThread(Thread.currentThread());
+            // Sleep for duration or until interrupt, whichever comes first.
+            MiscUtils.parkNanos(timeMicroseconds * 1000);
+            // Unregister this thread.
+            image.interrupt.setVMThread(null);
 
             // If an interrupt terminates the park, it will be handled on the next idle loop.
             return receiver;

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ControlPrimitives.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ControlPrimitives.java
@@ -1292,13 +1292,36 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
     protected abstract static class PrimRelinquishProcessorNode extends AbstractPrimitiveWithFrameNode implements Primitive1WithFallback {
         @Specialization
         protected static final Object doRelinquish(final VirtualFrame frame, final Object receiver, final long timeMicroseconds,
+                        @Bind final SqueakImageContext image,
                         @Cached final CheckForInterruptsFullNode interruptNode,
                         @Cached final PushToStackNode pushNode) {
-            MiscUtils.park(timeMicroseconds * 1000);
             /*
-             * Perform interrupt check (even if interrupt handler is not active), otherwise
-             * idleProcess gets stuck.
+             * Because this primitive is called within a loop that contains a message send,
+             * interrupts are not checked on the backwards jump to the loop head. Here, we
+             * perform the check to make sure that interrupts are processed.
+             *
+             * In OSVM, this primitive returns immediately if there are pending interrupts.
+             * Also, it waits until the minimum of the duration given by the argument and
+             * the time left on the current Delay. If it does wait, the wait terminates
+             * early when an interrupt event is received.
+             *
+             * Here, we emulate this behavior by checking and handling interrupts before and
+             * after the park. By registering the current thread, newly arriving interrupts
+             * will force the park to exit early.
              */
+
+            // Register the current VM thread.
+            image.interrupt.setVMThread(Thread.currentThread());
+
+            try {
+                interruptNode.execute(frame);
+            } catch (final ProcessSwitch ps) {
+                pushNode.execute(frame, receiver);
+                throw ps;
+            }
+
+            MiscUtils.park(timeMicroseconds * 1000);
+
             try {
                 interruptNode.execute(frame);
             } catch (final ProcessSwitch ps) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/MiscUtils.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/MiscUtils.java
@@ -274,7 +274,7 @@ public final class MiscUtils {
     }
 
     @TruffleBoundary
-    public static void park(final long nanos) {
+    public static void parkNanos(final long nanos) {
         LockSupport.parkNanos(nanos);
     }
 

--- a/src/image-tests/runSqueakTests.st
+++ b/src/image-tests/runSqueakTests.st
@@ -184,39 +184,19 @@
 
     flakyTests := OrderedCollection new.
     {
-        BasicInspectorTest -> #(#testExpressions).
         BitBltSimulationTest -> #(#testAlphaCompositing2Simulated #testAlphaCompositingSimulated).
-        ClassInspectorTest -> #(#testExpressions).
-        CollectionInspectorTest -> #(#testExpressions).
-        CompiledCodeInspectorTest -> #(#testExpressions).
-        ContextInspectorTest -> #(#testExpressions).
-        ContextVariablesInspectorTest -> #(#testExpressions).
         DebuggerTests -> #(#test02UnhandledException #test19Abandon).
-        DictionaryInspectorTest -> #(#testExpressions).
-        FileList2ModalDialogsTest -> #(#testModalFolderSelector #testModalFolderSelectorForProjectLoad).
-        FSFileHandleTest -> #(#testCloseWhenGarbageCollected).
-        InspectorTest -> #(#testExpressions).
-        IntegerTest -> #(#testReciprocalModulo).
-        MCDictionaryRepositoryTest -> #(#testIncludesName #testStoreAndLoad).
         MCSnapshotTest -> #(#testInstanceReuse).
-        MethodHighlightingTests -> #(#testMethodHighlighting).
         MorphicToolBuilderTests -> #(#testGetButtonColor).
-        PCCByCompilationTest -> #(#testSwitchPrimCallOffOn).
         PCCByLiteralsTest -> #(#testSwitchPrimCallOffOn).
-        SequenceableCollectionTest -> #(#testCollectWithIndexDeprecation).
-        SetInspectorTest -> #(#testExpressions).
         SHParserST80Test -> #(#testNumbers).
         StringTest ->#(#testFindSelector).
-        TestValueWithinFix -> #(#testValueWithinTimingBasic #testValueWithinTimingNestedInner #testValueWithinTimingNestedOuter #testValueWithinTimingRepeat).
-        WeakIdentityDictionaryTest -> #(#testIsEmpty).
-        WeakKeyDictionaryTest -> #(#testIsEmpty).
+        TestValueWithinFix -> #(#testValueWithinTimingRepeat).
         WeakSetInspectorTest -> #(#testSymbolTableM6812 #testUninitialized).
-        WeakSetTest -> #(#testIsEmpty).
         WideStringTest -> #(#testAsIntegerSignedUsingRandomNumbers). "sometimes hitting timeout due to slow becomeForward:"
 
         "failing on some platforms"
         GIFReadWriterTest -> #(#testAnimatedColorsOutIn).
-        MCPackageTest -> #(#testUnload).
     } collect: [:assoc | | testCase |
         testCase := assoc key.
         assoc value do: [:sel | flakyTests add: (testCase selector: sel) ]].
@@ -224,8 +204,6 @@
     isWin ifTrue: [
         {
             DurationTest -> #(#testBusyWait #testBusyWaitMicro). "Fails on Windows native"
-            FSFileHandleTest -> #("May fail with 'FileDoesNotExist: plonk' on Windows" #testAt #testAtPut #testAtPutBinaryAscii #testAtWriteBinaryAscii #testClose #testCreatedOpen #testIO #testReadBufferTooLarge #testReadOnly #testReference #testSizeAfterGrow #testSizeNoGrow #testTruncate #testTruncateEmpty #testWriteStream).
-            PNGReadWriterTest -> #("May fail with FileDoesNotExistException on Windows" #testBlue16 #testBlue32 #testBlue8).
         } collect: [:assoc | | testCase |
             testCase := assoc key.
             assoc value do: [:sel | flakyTests add: (testCase selector: sel) ]].


### PR DESCRIPTION
OSVM cuts short the sleep within the relinquish processor primitive when an event arrives or when a Delay expires.