### PR TITLE
Fix Cuis window sizing on startup and resource leaks

### DIFF
--- a/src/de.hpi.swa.trufflesqueak.sdl3/jextract.args
+++ b/src/de.hpi.swa.trufflesqueak.sdl3/jextract.args
@@ -94,6 +94,7 @@ src/SDL-release-3.4.2/include/SDL3/SDL.h
 --include-function SDL_GetPrimaryDisplay
 --include-function SDL_GetWindowDisplayScale
 --include-function SDL_RaiseWindow
+--include-function SDL_ShowWindow
 --include-function SDL_SetWindowFullscreen
 --include-function SDL_SetWindowIcon
 --include-function SDL_SetWindowSize

--- a/src/de.hpi.swa.trufflesqueak.sdl3/src/de/hpi/swa/trufflesqueak/sdl3/SDL3Constants.java
+++ b/src/de.hpi.swa.trufflesqueak.sdl3/src/de/hpi/swa/trufflesqueak/sdl3/SDL3Constants.java
@@ -113,6 +113,7 @@ public final class SDL3Constants {
     public static final int SDL_SCALEMODE_NEAREST = 0;
 
     // SDL_video.h
+    public static final long SDL_WINDOW_HIDDEN = 0x0000000000000008L;
     public static final long SDL_WINDOW_RESIZABLE = 0x0000000000000020L;
     public static final long SDL_WINDOW_HIGH_PIXEL_DENSITY = 0x0000000000002000L;
 

--- a/src/de.hpi.swa.trufflesqueak.sdl3/src/de/hpi/swa/trufflesqueak/sdl3/bindings/SDL_h.java
+++ b/src/de.hpi.swa.trufflesqueak.sdl3/src/de/hpi/swa/trufflesqueak/sdl3/bindings/SDL_h.java
@@ -1109,6 +1109,66 @@ public class SDL_h extends SDL_h$shared {
         }
     }
 
+    private static class SDL_ShowWindow {
+        public static final FunctionDescriptor DESC = FunctionDescriptor.of(
+            SDL_h.C_BOOL,
+            SDL_h.C_POINTER
+        );
+
+        public static final MemorySegment ADDR = SYMBOL_LOOKUP.findOrThrow("SDL_ShowWindow");
+
+        public static final MethodHandle HANDLE = Linker.nativeLinker().downcallHandle(ADDR, DESC);
+    }
+
+    /**
+     * Function descriptor for:
+     * {@snippet lang=c :
+     * extern bool SDL_ShowWindow(SDL_Window *window)
+     * }
+     */
+    public static FunctionDescriptor SDL_ShowWindow$descriptor() {
+        return SDL_ShowWindow.DESC;
+    }
+
+    /**
+     * Downcall method handle for:
+     * {@snippet lang=c :
+     * extern bool SDL_ShowWindow(SDL_Window *window)
+     * }
+     */
+    public static MethodHandle SDL_ShowWindow$handle() {
+        return SDL_ShowWindow.HANDLE;
+    }
+
+    /**
+     * Address for:
+     * {@snippet lang=c :
+     * extern bool SDL_ShowWindow(SDL_Window *window)
+     * }
+     */
+    public static MemorySegment SDL_ShowWindow$address() {
+        return SDL_ShowWindow.ADDR;
+    }
+
+    /**
+     * {@snippet lang=c :
+     * extern bool SDL_ShowWindow(SDL_Window *window)
+     * }
+     */
+    public static boolean SDL_ShowWindow(MemorySegment window) {
+        var mh$ = SDL_ShowWindow.HANDLE;
+        try {
+            if (TRACE_DOWNCALLS) {
+                traceDowncall("SDL_ShowWindow", window);
+            }
+            return (boolean)mh$.invokeExact(window);
+        } catch (Error | RuntimeException ex) {
+           throw ex;
+        } catch (Throwable ex$) {
+           throw new AssertionError("should not reach here", ex$);
+        }
+    }
+
     private static class SDL_RaiseWindow {
         public static final FunctionDescriptor DESC = FunctionDescriptor.of(
             SDL_h.C_BOOL,

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/io/SqueakDisplay.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/io/SqueakDisplay.java
@@ -83,6 +83,7 @@ import static de.hpi.swa.trufflesqueak.sdl3.SDL3Constants.SDL_PIXELFORMAT_ARGB88
 import static de.hpi.swa.trufflesqueak.sdl3.SDL3Constants.SDL_SCALEMODE_NEAREST;
 import static de.hpi.swa.trufflesqueak.sdl3.SDL3Constants.SDL_TEXTUREACCESS_STREAMING;
 import static de.hpi.swa.trufflesqueak.sdl3.SDL3Constants.SDL_WINDOW_HIGH_PIXEL_DENSITY;
+import static de.hpi.swa.trufflesqueak.sdl3.SDL3Constants.SDL_WINDOW_HIDDEN;
 import static de.hpi.swa.trufflesqueak.sdl3.SDL3Constants.SDL_WINDOW_RESIZABLE;
 import static de.hpi.swa.trufflesqueak.sdl3.SDL3Utils.checkSdlError;
 import static de.hpi.swa.trufflesqueak.sdl3.SDL3Utils.getSDLError;
@@ -119,6 +120,7 @@ import static de.hpi.swa.trufflesqueak.sdl3.bindings.SDL_h.SDL_SetWindowIcon;
 import static de.hpi.swa.trufflesqueak.sdl3.bindings.SDL_h.SDL_SetWindowSize;
 import static de.hpi.swa.trufflesqueak.sdl3.bindings.SDL_h.SDL_SetWindowTitle;
 import static de.hpi.swa.trufflesqueak.sdl3.bindings.SDL_h.SDL_ShowCursor;
+import static de.hpi.swa.trufflesqueak.sdl3.bindings.SDL_h.SDL_ShowWindow;
 import static de.hpi.swa.trufflesqueak.sdl3.bindings.SDL_h.SDL_StartTextInput;
 import static de.hpi.swa.trufflesqueak.sdl3.bindings.SDL_h.SDL_UnlockSurface;
 import static de.hpi.swa.trufflesqueak.sdl3.bindings.SDL_h.SDL_UpdateTexture;
@@ -175,6 +177,8 @@ public final class SqueakDisplay {
     private MemorySegment cursor = MemorySegment.NULL;
     private MemorySegment renderer = MemorySegment.NULL;
     private MemorySegment texture = MemorySegment.NULL;
+
+    private boolean isWindowHidden = false;
 
     // Squeak bitmap (physical pixels)
     private int width;
@@ -379,6 +383,16 @@ public final class SqueakDisplay {
     private SqueakDisplay(final SqueakImageContext image) {
         this.image = image;
         PlatformEventLoop.start(this::processEvent, this::performRenderIfNeeded);
+
+        // Initial window size is obtained from the image header.
+        logicalWindowWidth = image.flags.getScreenWidth();
+        logicalWindowHeight = image.flags.getScreenHeight();
+
+        // If window size was not saved, use default as in OSVM.
+        if (logicalWindowWidth == 0 || logicalWindowHeight == 0) {
+            logicalWindowWidth = 640;
+            logicalWindowHeight = 480;
+        }
     }
 
     public static SqueakDisplay create(final SqueakImageContext image) {
@@ -494,6 +508,17 @@ public final class SqueakDisplay {
         checkSdlError(SDL_RenderClear(renderer));
         checkSdlError(SDL_RenderTexture(renderer, texture, MemorySegment.NULL, MemorySegment.NULL));
         checkSdlError(SDL_RenderPresent(renderer));
+
+        // Show the window and move it to the front, if needed.
+        if (isWindowHidden) {
+            final int currentLogicalWidth = (int) Math.ceil(width / getDisplayScale());
+            final int currentLogicalHeight = (int) Math.ceil(height / getDisplayScale());
+            if (currentLogicalWidth == getLogicalWindowWidth() && currentLogicalHeight == getLogicalWindowHeight()) {
+                isWindowHidden = false;
+                checkSdlError(SDL_ShowWindow(window));
+                checkSdlError(SDL_RaiseWindow(window));
+            }
+        }
     }
 
     private void requestRender() {
@@ -665,33 +690,28 @@ public final class SqueakDisplay {
                             : imageFileName + " running on " + SqueakLanguageConfig.IMPLEMENTATION_NAME;
             try (Arena arena = Arena.ofConfined()) {
                 /*
-                 * When Smalltalk opens the Display the first time, we do not yet know the
-                 * scaleFactor. We assume that Smalltalk uses the values stored in the image header
-                 * together with the current scaleFactor (1.0 initially) to create the initial
-                 * Display. Therefore, we can request an initial window with logical pixel
-                 * dimensions equal to the bitmap dimensions. After we create the window, we will
-                 * know the scaleFactor and Smalltalk can use that scaleFactor to resize Display.
+                 * Creating the window: We create it hidden so the user doesn't see
+                 * a black screen during image start up. We use the saved dimensions from
+                 * the image header for the size. The window will be explicitly unhidden
+                 * later in the render loop once the Smalltalk UI is fully drawn.
                  */
                 SDL_RunOnMainThread(SDL_MainThreadCallback.allocate((_) -> {
-                    long windowFlags = SDL_WINDOW_RESIZABLE;
+                    // The window is initially hidden. It will be shown when rendered at full size.
+                    isWindowHidden = true;
+                    long windowFlags = SDL_WINDOW_RESIZABLE | SDL_WINDOW_HIDDEN;
                     if (image.flags.upscaleDisplayIfHighDPI()) {
                         windowFlags |= SDL_WINDOW_HIGH_PIXEL_DENSITY;
                     }
 
                     try (Arena windowTitleArena = Arena.ofConfined()) {
-                        window = checkSdlError(SDL_CreateWindow(windowTitleArena.allocateFrom(title), width, height, windowFlags));
+                        window = checkSdlError(SDL_CreateWindow(windowTitleArena.allocateFrom(title), logicalWindowWidth, logicalWindowHeight, windowFlags));
                     }
 
                     renderer = checkSdlError(SDL_CreateRenderer(window, MemorySegment.NULL));
 
                     setWindowIcon(window);
-                    checkSdlError(SDL_RaiseWindow(window));
 
                     scaleFactor = checkSdlError(SDL_GetWindowDisplayScale(window));
-
-                    // Store the logical dimensions exactly as Smalltalk requested them
-                    logicalWindowWidth = width;
-                    logicalWindowHeight = height;
 
                     checkSdlError(SDL_StartTextInput(window));
                     fullDamage();
@@ -703,23 +723,7 @@ public final class SqueakDisplay {
                     }
                 }, arena), MemorySegment.NULL, true);
             }
-        } else {
-            /*
-             * On subsequent calls to open() (via DisplayScreen>>beDisplay), we assume that
-             * Smalltalk knows the scaleFactor and the dimensions are in physical pixels. Therefore,
-             * we request the window to resize to the logical pixel dimensions.
-             */
-            final int targetLogicalWidth = (int) Math.ceil(width / getDisplayScale());
-            final int targetLogicalHeight = (int) Math.ceil(height / getDisplayScale());
-            if (targetLogicalWidth != logicalWindowWidth || targetLogicalHeight != logicalWindowHeight) {
-                logicalWindowWidth = targetLogicalWidth;
-                logicalWindowHeight = targetLogicalHeight;
-                SDL_RunOnMainThread(resizeTask, MemorySegment.NULL, true);
-            }
         }
-
-        // Save current logical window size in flags for later writing to disk image
-        image.flags.setScreenSize(getLogicalWindowWidth(), getLogicalWindowHeight());
     }
 
     private static void setWindowIcon(final MemorySegment window) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/io/SqueakDisplay.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/io/SqueakDisplay.java
@@ -201,10 +201,10 @@ public final class SqueakDisplay {
     // UI thread tracking
     private int textureWidth = -1;
     private int textureHeight = -1;
+
     private volatile int logicalWindowWidth;
     private volatile int logicalWindowHeight;
-
-    private float scaleFactor;
+    private volatile float scaleFactor;
 
     private final ConcurrentLinkedDeque<long[]> deferredEvents = new ConcurrentLinkedDeque<>();
 
@@ -218,7 +218,7 @@ public final class SqueakDisplay {
     private double pendingScrollX = 0.0;
     private double pendingScrollY = 0.0;
 
-    private String clipboardText;
+    private volatile String clipboardText;
     private final List<String> dropFilesAccumulator = new ArrayList<>();
     private final int[] primaryDisplayDimensions = {0, 0};
 
@@ -297,64 +297,64 @@ public final class SqueakDisplay {
         }
 
         // Use SDL_LockSurface to ensure we have CPU access to the pixel buffer
-        checkSdlError(SDL_LockSurface(surface));
         try {
-            final MemorySegment pixels = SDL_Surface.pixels(surface);
-            final int pitch = SDL_Surface.pitch(surface);
-            final int[] sqPixels = data.cursorWords;
-            final int[] sqMask = data.maskWords;
+            checkSdlError(SDL_LockSurface(surface));
+            try {
+                final MemorySegment pixels = SDL_Surface.pixels(surface);
+                final int pitch = SDL_Surface.pitch(surface);
+                final int[] sqPixels = data.cursorWords;
+                final int[] sqMask = data.maskWords;
 
-            if (data.depth == 32) {
-                /* Case 1: 32-bit ARGB (Direct Copy) */
-                for (int y = 0; y < h; y++) {
-                    final long srcOffset = (long) y * w * Integer.BYTES;
-                    final long dstOffset = (long) y * pitch;
-                    MemorySegment.copy(MemorySegment.ofArray(sqPixels), srcOffset, pixels, dstOffset, (long) w * Integer.BYTES);
-                }
-            } else if (sqMask != null && w == SqueakIOConstants.CURSOR_WIDTH && h == SqueakIOConstants.CURSOR_HEIGHT) {
-                /* Case 2: Legacy 16x16 Masked Cursor */
-                for (int y = 0; y < h; y++) {
-                    final int cWord = sqPixels[y];
-                    final int mWord = sqMask[y];
-                    for (int x = 0; x < w; x++) {
-                        final int bit = 0x80000000 >>> x;
-                        final boolean c = (cWord & bit) != 0;
-                        final boolean m = (mWord & bit) != 0;
+                if (data.depth == 32) {
+                    /* Case 1: 32-bit ARGB (Direct Copy) */
+                    for (int y = 0; y < h; y++) {
+                        final long srcOffset = (long) y * w * Integer.BYTES;
+                        final long dstOffset = (long) y * pitch;
+                        MemorySegment.copy(MemorySegment.ofArray(sqPixels), srcOffset, pixels, dstOffset, (long) w * Integer.BYTES);
+                    }
+                } else if (sqMask != null && w == SqueakIOConstants.CURSOR_WIDTH && h == SqueakIOConstants.CURSOR_HEIGHT) {
+                    /* Case 2: Legacy 16x16 Masked Cursor */
+                    for (int y = 0; y < h; y++) {
+                        final int cWord = sqPixels[y];
+                        final int mWord = sqMask[y];
+                        for (int x = 0; x < w; x++) {
+                            final int bit = 0x80000000 >>> x;
+                            final boolean c = (cWord & bit) != 0;
+                            final boolean m = (mWord & bit) != 0;
 
-                        int argb = 0; // Transparent (0,0)
-                        if (m && c) {
-                            argb = 0xFF000000;      // Black (1,1)
-                        } else if (m) {
-                            argb = 0xFFFFFFFF;      // White (1,0)
-                        } else if (c) {
-                            // True XOR/Invert is not supported by SDL3 ARGB cursors.
-                            // Fallback to opaque Black so XOR crosshairs remain visible.
-                            argb = 0xFF000000;      // Fallback Black (0,1)
+                            int argb = 0; // Transparent (0,0)
+                            if (m && c) {
+                                argb = 0xFF000000;      // Black (1,1)
+                            } else if (m) {
+                                argb = 0xFFFFFFFF;      // White (1,0)
+                            } else if (c) {
+                                // True XOR/Invert is not supported by SDL3 ARGB cursors.
+                                // Fallback to opaque Black so XOR crosshairs remain visible.
+                                argb = 0xFF000000;      // Fallback Black (0,1)
+                            }
+
+                            pixels.set(ValueLayout.JAVA_INT, (long) y * pitch + (long) x * 4, argb);
                         }
+                    }
+                } else {
+                    /* Case 3: Arbitrary Sized Monochrome (1-bit) */
+                    // Squeak bit-padding: rows are padded to 32-bit boundaries
+                    final int wordsPerRow = (w + 31) / 32;
+                    for (int y = 0; y < h; y++) {
+                        for (int x = 0; x < w; x++) {
+                            final int wordIdx = y * wordsPerRow + (x / 32);
+                            final int bitIdx = x % 32;
+                            final boolean isSet = (sqPixels[wordIdx] & (0x80000000 >>> bitIdx)) != 0;
 
-                        pixels.set(ValueLayout.JAVA_INT, (long) y * pitch + (long) x * 4, argb);
+                            // Map 1 to Black, 0 to Transparent
+                            pixels.set(ValueLayout.JAVA_INT, (long) y * pitch + (long) x * 4, isSet ? 0xFF000000 : 0x00000000);
+                        }
                     }
                 }
-            } else {
-                /* Case 3: Arbitrary Sized Monochrome (1-bit) */
-                // Squeak bit-padding: rows are padded to 32-bit boundaries
-                final int wordsPerRow = (w + 31) / 32;
-                for (int y = 0; y < h; y++) {
-                    for (int x = 0; x < w; x++) {
-                        final int wordIdx = y * wordsPerRow + (x / 32);
-                        final int bitIdx = x % 32;
-                        final boolean isSet = (sqPixels[wordIdx] & (0x80000000 >>> bitIdx)) != 0;
-
-                        // Map 1 to Black, 0 to Transparent
-                        pixels.set(ValueLayout.JAVA_INT, (long) y * pitch + (long) x * 4, isSet ? 0xFF000000 : 0x00000000);
-                    }
-                }
+            } finally {
+                SDL_UnlockSurface(surface);
             }
-        } finally {
-            SDL_UnlockSurface(surface);
-        }
 
-        try {
             cursor = checkSdlError(SDL_CreateColorCursor(surface, data.offsetX, data.offsetY));
             if (cursor != MemorySegment.NULL) {
                 checkSdlError(SDL_SetCursor(cursor));
@@ -429,7 +429,9 @@ public final class SqueakDisplay {
     // Called by the main thread at the end of the event loop
     private void performRenderIfNeeded() {
         if (renderer == MemorySegment.NULL || stagingBuffer == MemorySegment.NULL) {
-            frameRequested = false;
+            synchronized (this) {
+                frameRequested = false;
+            }
             return;
         }
 


### PR DESCRIPTION
Before saving the image, Cuis replaces Display with a tiny bitmap to reduce the image size on disk. Previously, we were saving the window dimensions when the window was resized or when the bitmap was resized. Because of this, when starting up the saved Cuis image, the Display would be tiny. Cuis 7.3 would crash with this small size; Cuis 7.5 would start and you could resize the window manually.

Changed SqueakDisplay to:

- save the window dimensions only when the window is resized
- create the window hidden, showing it when the image finally sets Display dimensions to agree with the image header dimensions

Also, made a couple of thread-safe data synchronization fixes and fixed a potential leak if creating a Cursor failed.