### PR TITLE
ensure thread-safe data sync when registering/deregistering vmThread

### DIFF
--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interrupts/CheckForInterruptsState.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interrupts/CheckForInterruptsState.java
@@ -117,8 +117,10 @@ public final class CheckForInterruptsState {
     }
 
     private void wakeupVM() {
+        // If vmThread is null, this is a no-op. If vmThread is parked, this will unpark it.
+        // If vmThread is not parked, this simply sets a bit in vmThread for examination.
+        // All execution overhead is paid by the caller and not vmThread.
         LockSupport.unpark(vmThread);
-        vmThread = null; // Only ever unpark once.
     }
 
     /* Interrupt check interval */

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ControlPrimitives.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ControlPrimitives.java
@@ -1308,21 +1308,24 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
                         @Bind final SqueakImageContext image,
                         @Cached final CheckForInterruptsFullNode interruptNode,
                         @Cached final PushToStackNode pushNode) {
-            // Check for interrupts enqueued before primitive send.
             try {
-                interruptNode.execute(frame);
-            } catch (final ProcessSwitch ps) {
-                pushNode.execute(frame, receiver);
-                throw ps;
+                // Register this thread to be notified if an interrupt occurs.
+                image.interrupt.setVMThread(Thread.currentThread());
+
+                // Check for interrupts enqueued before primitive send.
+                try {
+                    interruptNode.execute(frame);
+                } catch (final ProcessSwitch ps) {
+                    pushNode.execute(frame, receiver);
+                    throw ps;
+                }
+
+                // Sleep for duration or until interrupt, whichever comes first.
+                MiscUtils.parkNanos(timeMicroseconds * 1000);
+            } finally {
+                // Unregister this thread.
+                image.interrupt.setVMThread(null);
             }
-
-            // Register this thread to be notified if an interrupt occurs.
-            image.interrupt.setVMThread(Thread.currentThread());
-            // Sleep for duration or until interrupt, whichever comes first.
-            MiscUtils.parkNanos(timeMicroseconds * 1000);
-            // Unregister this thread.
-            image.interrupt.setVMThread(null);
-
             // If an interrupt terminates the park, it will be handled on the next idle loop.
             return receiver;
         }


### PR DESCRIPTION
Refines interrupt registration timing: Moves the VM thread registration to just before the interrupt check. This covers a tiny timing edge case, ensuring that if an interrupt arrives at the exact moment the thread is preparing to park, the unpark signal is guaranteed to be caught.

Streamlines thread deregistration: Centralizes the vmThread = null cleanup by deferring it entirely to the finally block of the executing thread. Prevents a scenario where the interrupt thread could clear the vmThread variable concurrently with the VM thread setting it.