### PR TITLE
Fix scheduler context corruption during multiple simultaneous interrupts

### DIFF
--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/io/SqueakDisplay.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/io/SqueakDisplay.java
@@ -912,20 +912,25 @@ public final class SqueakDisplay {
             return;
         }
 
+        final boolean isCommandOrCtrl = (buttons & (KEYBOARD.CTRL | KEYBOARD.CMD)) != 0;
         final int keyChar = toSqueakKey(sdlKeySym);
 
-        addKeyboardEvent(KEYBOARD_EVENT.DOWN, keyChar);
+        /*
+         * OSVM: Windows signals the interrupt; Linux enqueues the key; macOS does both.
+         * See https://share.gemini.google/IHLpmtSinLV6
+         * Doing both on macOS Cuis 7.3/7.5 can cause an interrupt of the interrupt notifier
+         * on the running process; Squeak & Cuis 7.6 work as expected.
+         */
+        if (isCommandOrCtrl && keyChar == '.') {
+            image.interrupt.setInterruptPending();
+        }
 
-        final boolean isCommandOrCtrl = (buttons & (KEYBOARD.CTRL | KEYBOARD.CMD)) != 0;
+        addKeyboardEvent(KEYBOARD_EVENT.DOWN, keyChar);
 
         if (isControlKey(sdlKeySym) || isCommandOrCtrl) {
             if (keyChar <= 65535) {
                 addKeyboardEvent(KEYBOARD_EVENT.CHAR, keyChar);
             }
-        }
-
-        if (isCommandOrCtrl && keyChar == '.') {
-            image.interrupt.setInterruptPending();
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interrupts/CheckForInterruptsNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interrupts/CheckForInterruptsNode.java
@@ -17,10 +17,15 @@ import de.hpi.swa.trufflesqueak.exceptions.ProcessSwitch;
 import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
 import de.hpi.swa.trufflesqueak.model.ArrayObject;
 import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
+import de.hpi.swa.trufflesqueak.model.PointersObject;
+import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.PROCESS_SCHEDULER;
 import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.SPECIAL_OBJECT;
 import de.hpi.swa.trufflesqueak.nodes.AbstractNode;
-import de.hpi.swa.trufflesqueak.nodes.dispatch.AbstractDispatchNode;
-import de.hpi.swa.trufflesqueak.nodes.process.SignalSemaphoreNode;
+import de.hpi.swa.trufflesqueak.nodes.accessing.AbstractPointersObjectNodes.AbstractPointersObjectReadNode;
+import de.hpi.swa.trufflesqueak.nodes.accessing.AbstractPointersObjectNodesFactory.AbstractPointersObjectReadNodeGen;
+import de.hpi.swa.trufflesqueak.nodes.process.SignalSemaphoreForInterruptNode;
+import de.hpi.swa.trufflesqueak.nodes.process.TransferToNode;
+import de.hpi.swa.trufflesqueak.nodes.process.TransferToNodeGen;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
 public abstract class CheckForInterruptsNode extends AbstractNode {
@@ -28,17 +33,31 @@ public abstract class CheckForInterruptsNode extends AbstractNode {
     /**
      * Shared signaling logic used by all Nodes.
      */
-    protected static boolean signalSemaphoresCached(final VirtualFrame frame, final CheckForInterruptsState istate, final Object[] specialObjects, final SignalSemaphoreNode signalNode) {
-        boolean switchToNewProcess = false;
+    protected static PointersObject signalSemaphoresCached(final CheckForInterruptsState istate, final Object[] specialObjects, final SignalSemaphoreForInterruptNode signalNode,
+                    final PointersObject activeProcess, final boolean activeProcessYields) {
+        PointersObject nextActiveProcess = activeProcess;
+        boolean nextActiveProcessYields = activeProcessYields;
 
         if (istate.tryInterruptPending()) {
-            switchToNewProcess |= signalNode.executeSignal(frame, specialObjects[SPECIAL_OBJECT.THE_INTERRUPT_SEMAPHORE]);
+            final PointersObject result = signalNode.executeSignal(specialObjects[SPECIAL_OBJECT.THE_INTERRUPT_SEMAPHORE], nextActiveProcess, nextActiveProcessYields);
+            if (result != nextActiveProcess) {
+                nextActiveProcessYields = true;
+                nextActiveProcess = result;
+            }
         }
         if (istate.tryWakeUpTickTrigger()) {
-            switchToNewProcess |= signalNode.executeSignal(frame, specialObjects[SPECIAL_OBJECT.THE_TIMER_SEMAPHORE]);
+            final PointersObject result = signalNode.executeSignal(specialObjects[SPECIAL_OBJECT.THE_TIMER_SEMAPHORE], nextActiveProcess, nextActiveProcessYields);
+            if (result != nextActiveProcess) {
+                nextActiveProcessYields = true;
+                nextActiveProcess = result;
+            }
         }
         if (istate.tryPendingFinalizations()) {
-            switchToNewProcess |= signalNode.executeSignal(frame, specialObjects[SPECIAL_OBJECT.THE_FINALIZATION_SEMAPHORE]);
+            final PointersObject result = signalNode.executeSignal(specialObjects[SPECIAL_OBJECT.THE_FINALIZATION_SEMAPHORE], nextActiveProcess, nextActiveProcessYields);
+            if (result != nextActiveProcess) {
+                nextActiveProcessYields = true;
+                nextActiveProcess = result;
+            }
         }
         if (istate.trySemaphoresToSignal()) {
             final ArrayObject externalObjects = (ArrayObject) specialObjects[SPECIAL_OBJECT.EXTERNAL_OBJECTS_ARRAY];
@@ -46,24 +65,42 @@ public abstract class CheckForInterruptsNode extends AbstractNode {
                 final Object[] semaphores = externalObjects.getObjectStorage();
                 Integer semaIndex;
                 while ((semaIndex = istate.nextSemaphoreToSignal()) != null) {
-                    switchToNewProcess |= signalNode.executeSignal(frame, semaphores[semaIndex - 1]);
+                    final PointersObject result = signalNode.executeSignal(semaphores[semaIndex - 1], nextActiveProcess, nextActiveProcessYields);
+                    if (result != nextActiveProcess) {
+                        nextActiveProcessYields = true;
+                        nextActiveProcess = result;
+                    }
                 }
             }
         }
-        return switchToNewProcess;
+        return nextActiveProcess;
     }
 
-    protected static boolean signalSemaphoresUncached(final VirtualFrame frame, final SqueakImageContext image, final CheckForInterruptsState istate, final Object[] specialObjects) {
-        boolean switchToNewProcess = false;
+    protected static PointersObject signalSemaphoresUncached(final SqueakImageContext image, final CheckForInterruptsState istate, final Object[] specialObjects, final PointersObject activeProcess,
+                    final boolean activeProcessYields) {
+        PointersObject nextActiveProcess = activeProcess;
+        boolean nextActiveProcessYields = activeProcessYields;
 
         if (istate.tryInterruptPending()) {
-            switchToNewProcess |= SignalSemaphoreNode.executeUncached(frame, image, specialObjects[SPECIAL_OBJECT.THE_INTERRUPT_SEMAPHORE]);
+            final PointersObject result = SignalSemaphoreForInterruptNode.executeUncached(image, specialObjects[SPECIAL_OBJECT.THE_INTERRUPT_SEMAPHORE], nextActiveProcess, nextActiveProcessYields);
+            if (result != nextActiveProcess) {
+                nextActiveProcessYields = true;
+                nextActiveProcess = result;
+            }
         }
         if (istate.tryWakeUpTickTrigger()) {
-            switchToNewProcess |= SignalSemaphoreNode.executeUncached(frame, image, specialObjects[SPECIAL_OBJECT.THE_TIMER_SEMAPHORE]);
+            final PointersObject result = SignalSemaphoreForInterruptNode.executeUncached(image, specialObjects[SPECIAL_OBJECT.THE_TIMER_SEMAPHORE], nextActiveProcess, nextActiveProcessYields);
+            if (result != nextActiveProcess) {
+                nextActiveProcessYields = true;
+                nextActiveProcess = result;
+            }
         }
         if (istate.tryPendingFinalizations()) {
-            switchToNewProcess |= SignalSemaphoreNode.executeUncached(frame, image, specialObjects[SPECIAL_OBJECT.THE_FINALIZATION_SEMAPHORE]);
+            final PointersObject result = SignalSemaphoreForInterruptNode.executeUncached(image, specialObjects[SPECIAL_OBJECT.THE_FINALIZATION_SEMAPHORE], nextActiveProcess, nextActiveProcessYields);
+            if (result != nextActiveProcess) {
+                nextActiveProcessYields = true;
+                nextActiveProcess = result;
+            }
         }
         if (istate.trySemaphoresToSignal()) {
             final ArrayObject externalObjects = (ArrayObject) specialObjects[SPECIAL_OBJECT.EXTERNAL_OBJECTS_ARRAY];
@@ -71,11 +108,15 @@ public abstract class CheckForInterruptsNode extends AbstractNode {
                 final Object[] semaphores = externalObjects.getObjectStorage();
                 Integer semaIndex;
                 while ((semaIndex = istate.nextSemaphoreToSignal()) != null) {
-                    switchToNewProcess |= SignalSemaphoreNode.executeUncached(frame, image, semaphores[semaIndex - 1]);
+                    final PointersObject result = SignalSemaphoreForInterruptNode.executeUncached(image, semaphores[semaIndex - 1], nextActiveProcess, nextActiveProcessYields);
+                    if (result != nextActiveProcess) {
+                        nextActiveProcessYields = true;
+                        nextActiveProcess = result;
+                    }
                 }
             }
         }
-        return switchToNewProcess;
+        return nextActiveProcess;
     }
 
     @DenyReplace
@@ -102,7 +143,12 @@ public abstract class CheckForInterruptsNode extends AbstractNode {
             CompilerDirectives.transferToInterpreter();
             FrameAccess.externalizePCAndSP(frame, pc, sp);
             final Object[] specialObjects = image.specialObjectsArray.getObjectStorage();
-            if (signalSemaphoresUncached(frame, image, image.interrupt, specialObjects)) {
+
+            final PointersObject originalActiveProcess = image.getActiveProcessSlow();
+            final PointersObject nextActiveProcess = signalSemaphoresUncached(image, image.interrupt, specialObjects, originalActiveProcess, image.flags.preemptionYields());
+
+            if (nextActiveProcess != originalActiveProcess) {
+                TransferToNode.executeUncached(frame, nextActiveProcess);
                 throw ProcessSwitch.SINGLETON;
             }
         }
@@ -191,7 +237,12 @@ public abstract class CheckForInterruptsNode extends AbstractNode {
                 /* Exclude interrupts case from compilation. */
                 CompilerDirectives.transferToInterpreter();
                 final Object[] specialObjects = image.specialObjectsArray.getObjectStorage();
-                if (signalSemaphoresUncached(frame, image, istate, specialObjects)) {
+
+                final PointersObject originalActiveProcess = image.getActiveProcessSlow();
+                final PointersObject nextActiveProcess = signalSemaphoresUncached(image, istate, specialObjects, originalActiveProcess, image.flags.preemptionYields());
+
+                if (nextActiveProcess != originalActiveProcess) {
+                    TransferToNode.executeUncached(frame, nextActiveProcess);
                     throw ProcessSwitch.SINGLETON;
                 }
             }
@@ -214,15 +265,21 @@ public abstract class CheckForInterruptsNode extends AbstractNode {
     }
 
     public static final class CheckForInterruptsFullNode extends Node {
-        @Child private SignalSemaphoreNode signalSemaphoreNode;
+        @Child private SignalSemaphoreForInterruptNode signalSemaphoreNode;
+        @Child private AbstractPointersObjectReadNode readNode;
+        @Child private TransferToNode transferToNode;
 
+        private final SqueakImageContext image;
         private final CheckForInterruptsState istate;
         private final Object[] specialObjects;
 
         private CheckForInterruptsFullNode(final SqueakImageContext image) {
+            this.image = image;
             istate = image.interrupt;
             specialObjects = image.specialObjectsArray.getObjectStorage();
-            signalSemaphoreNode = SignalSemaphoreNode.create();
+            signalSemaphoreNode = SignalSemaphoreForInterruptNode.create();
+            readNode = AbstractPointersObjectReadNodeGen.create();
+            transferToNode = TransferToNodeGen.create();
         }
 
         @NeverDefault
@@ -234,7 +291,11 @@ public abstract class CheckForInterruptsNode extends AbstractNode {
             if (istate.shouldSkip()) {
                 return;
             }
-            if (signalSemaphoresCached(frame, istate, specialObjects, signalSemaphoreNode)) {
+            final PointersObject originalActiveProcess = readNode.executePointers(image.getScheduler(), PROCESS_SCHEDULER.ACTIVE_PROCESS);
+            final PointersObject nextActiveProcess = signalSemaphoresCached(istate, specialObjects, signalSemaphoreNode, originalActiveProcess, image.flags.preemptionYields());
+
+            if (nextActiveProcess != originalActiveProcess) {
+                transferToNode.execute(frame, nextActiveProcess);
                 throw ProcessSwitch.SINGLETON;
             }
         }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/process/ResumeProcessNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/process/ResumeProcessNode.java
@@ -21,7 +21,7 @@ import de.hpi.swa.trufflesqueak.nodes.AbstractNode;
 import de.hpi.swa.trufflesqueak.nodes.accessing.AbstractPointersObjectNodes.AbstractPointersObjectReadNode;
 
 /**
- * Returns the new active Context or null if the current active Context has not been preempted.
+ * Returns true if the current active Context has been preempted.
  */
 @GenerateInline(false)
 @GenerateCached

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/process/SignalSemaphoreForInterruptNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/process/SignalSemaphoreForInterruptNode.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 Software Architecture Group, Hasso Plattner Institute
+ * Copyright (c) 2026 Oracle and/or its affiliates
+ *
+ * Licensed under the MIT License.
+ */
+package de.hpi.swa.trufflesqueak.nodes.process;
+
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Cached.Exclusive;
+import com.oracle.truffle.api.dsl.GenerateCached;
+import com.oracle.truffle.api.dsl.GenerateInline;
+import com.oracle.truffle.api.dsl.NeverDefault;
+import com.oracle.truffle.api.dsl.Specialization;
+
+import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
+import de.hpi.swa.trufflesqueak.model.NilObject;
+import de.hpi.swa.trufflesqueak.model.PointersObject;
+import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.PROCESS;
+import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.SEMAPHORE;
+import de.hpi.swa.trufflesqueak.nodes.AbstractNode;
+import de.hpi.swa.trufflesqueak.nodes.accessing.AbstractPointersObjectNodes.AbstractPointersObjectReadNode;
+import de.hpi.swa.trufflesqueak.nodes.accessing.AbstractPointersObjectNodes.AbstractPointersObjectWriteNode;
+
+/**
+ * Signals the given semaphore and evaluates whether the newly awakened Process preempts
+ * the currently active Process.
+ * <p>
+ * If a waiting Process is awakened and has a strictly higher priority than the provided
+ * nextActiveProcess, the current nextActiveProcess is put to sleep and the new Process
+ * is returned. Otherwise, the awakened Process is put to sleep and the original
+ * nextActiveProcess is returned.
+ */
+@GenerateInline(false)
+@GenerateCached
+public abstract class SignalSemaphoreForInterruptNode extends AbstractNode {
+
+    @NeverDefault
+    public static SignalSemaphoreForInterruptNode create() {
+        return SignalSemaphoreForInterruptNodeGen.create();
+    }
+
+    public static final PointersObject executeUncached(final SqueakImageContext image, final Object semaphoreOrNil, final PointersObject nextActiveProcess, final boolean nextActiveProcessYields) {
+        if (!(semaphoreOrNil instanceof final PointersObject semaphore) || !image.isSemaphoreClass(semaphore.getSqueakClass())) {
+            return nextActiveProcess;
+        }
+        final AbstractPointersObjectReadNode readNode = AbstractPointersObjectReadNode.getUncached();
+        final AbstractPointersObjectWriteNode writeNode = AbstractPointersObjectWriteNode.getUncached();
+
+        if (semaphore.isEmptyList(readNode)) {
+            writeNode.execute(semaphore, SEMAPHORE.EXCESS_SIGNALS, readNode.executeLong(semaphore, SEMAPHORE.EXCESS_SIGNALS) + 1);
+            return nextActiveProcess;
+        } else {
+            final PointersObject newProcess = semaphore.removeFirstLinkOfList(readNode, writeNode);
+            final long newPriority = readNode.executeLong(newProcess, PROCESS.PRIORITY);
+            final long winnerPriority = readNode.executeLong(nextActiveProcess, PROCESS.PRIORITY);
+
+            if (newPriority > winnerPriority) {
+                PutToSleepNode.executeUncached(image, nextActiveProcess, nextActiveProcessYields);
+                return newProcess;
+            } else {
+                PutToSleepNode.executeUncached(image, newProcess, true);
+                return nextActiveProcess;
+            }
+        }
+    }
+
+    public abstract PointersObject executeSignal(Object semaphoreOrNil, PointersObject nextActiveProcess, boolean nextActiveProcessYields);
+
+    @Specialization(guards = {"isSemaphore(semaphore)", "semaphore.isEmptyList(readNode)"}, limit = "1")
+    protected static final PointersObject doSignalEmpty(final PointersObject semaphore, final PointersObject nextActiveProcess, @SuppressWarnings("unused") final boolean nextActiveProcessYields,
+                    @Exclusive @Cached final AbstractPointersObjectReadNode readNode,
+                    @Exclusive @Cached final AbstractPointersObjectWriteNode writeNode) {
+        writeNode.execute(semaphore, SEMAPHORE.EXCESS_SIGNALS, readNode.executeLong(semaphore, SEMAPHORE.EXCESS_SIGNALS) + 1);
+        return nextActiveProcess;
+    }
+
+    @Specialization(guards = {"isSemaphore(semaphore)", "!semaphore.isEmptyList(readNode)"}, limit = "1")
+    protected static final PointersObject doSignal(final PointersObject semaphore, final PointersObject nextActiveProcess, final boolean nextActiveProcessYields,
+                    @Exclusive @Cached final AbstractPointersObjectReadNode readNode,
+                    @Exclusive @Cached final AbstractPointersObjectWriteNode writeNode,
+                    @Cached final PutToSleepNode putToSleepNode) {
+
+        final PointersObject newProcess = semaphore.removeFirstLinkOfList(readNode, writeNode);
+        final long newPriority = readNode.executeLong(newProcess, PROCESS.PRIORITY);
+        final long winnerPriority = readNode.executeLong(nextActiveProcess, PROCESS.PRIORITY);
+
+        if (newPriority > winnerPriority) {
+            putToSleepNode.executePutToSleep(nextActiveProcess, nextActiveProcessYields);
+            return newProcess;
+        } else {
+            putToSleepNode.executePutToSleep(newProcess, true);
+            return nextActiveProcess;
+        }
+    }
+
+    @Specialization
+    protected static final PointersObject doNothing(@SuppressWarnings("unused") final NilObject nil, final PointersObject nextActiveProcess,
+                    @SuppressWarnings("unused") final boolean nextActiveProcessYields) {
+        return nextActiveProcess;
+    }
+}

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/process/SignalSemaphoreNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/process/SignalSemaphoreNode.java
@@ -23,7 +23,7 @@ import de.hpi.swa.trufflesqueak.nodes.accessing.AbstractPointersObjectNodes.Abst
 import de.hpi.swa.trufflesqueak.nodes.accessing.AbstractPointersObjectNodes.AbstractPointersObjectWriteNode;
 
 /**
- * Returns the new active Context or null if the current active Context has not been preempted.
+ * Returns true if the current active Context has been preempted.
  */
 @GenerateInline(false)
 @GenerateCached


### PR DESCRIPTION
**The Bug:**
When multiple semaphores are signaled within a single interrupt check cycle (e.g., a Command+period user interrupt and the same Command+period enqueued as a keyboard event), the interrupt check triggered cascading context switches. Because `TransferToNode` was executed immediately for each awakened process, the `VirtualFrame` of the originally active process was erroneously saved into the `suspendedContext` of several intermediate processes, leading to very odd behavior.

**The Fix:**
This PR introduces a "wake-then-switch" architecture to safely batch interrupt evaluations:

* **Decoupled Waking from Switching:** Introduced `SignalSemaphoreForInterruptNode` to evaluate priority preemptions and mutate semaphore states without touching the Truffle execution frame.
* **State Machine Evaluation:** `CheckForInterruptsNode` now acts as a pure state tracker (`nextActiveProcess` and `nextActiveProcessYields`), folding all pending signals (Interrupt, Timer, Finalization, External) into a single "winning" `Process`.
* **Single Context Switch:** `TransferToNode` is now called exactly once at the end of the interrupt loop, guaranteeing the `VirtualFrame` is safely saved only to the originally interrupted process.
* **Standard Primitives Preserved:** Kept the original `SignalSemaphoreNode` intact so standard bytecode-driven primitives (like `PrimSignal`) retain their required synchronous context-switch behavior.