### PR TITLE
optionally log screen dimensions and HighDPI flag from image header

### DIFF
--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageReader.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageReader.java
@@ -79,6 +79,8 @@ public final class SqueakImageReader {
         }
         initObjects();
         LogUtils.IMAGE.fine(() -> "Image loaded in " + (MiscUtils.currentTimeMillis() - start) + "ms.");
+        LogUtils.IMAGE.fine(() -> "Image screen size is " + image.flags.getScreenWidth() + "x" + image.flags.getScreenHeight() + ", HighDPI is " + (image.flags.upscaleDisplayIfHighDPI() ? "enabled"
+                        : "disabled"));
         image.setHiddenRoots((ArrayObject) hiddenRootsChunk.asObject());
         image.getSqueakImage();
     }


### PR DESCRIPTION
Added IMAGE FINE logging of the image header's screen dimensions and whether it is asking for a high DPI window.