### PR TITLE
add download progress output to console

### DIFF
--- a/src/de.hpi.swa.trufflesqueak.shared/src/de/hpi/swa/trufflesqueak/shared/ImageDownloadSupport.java
+++ b/src/de.hpi.swa.trufflesqueak.shared/src/de/hpi/swa/trufflesqueak/shared/ImageDownloadSupport.java
@@ -46,14 +46,17 @@ public final class ImageDownloadSupport {
     public record ProxyConfiguration(ProxyMode mode, String host, int port, String username, String password) {
     }
 
+    public record DownloadStream(BufferedInputStream stream, long contentLength) {
+    }
+
     private ImageDownloadSupport() {
     }
 
-    public static BufferedInputStream openStream(final URI uri) throws IOException {
+    public static DownloadStream openStream(final URI uri) throws IOException {
         return openStream(uri, System.getenv());
     }
 
-    static BufferedInputStream openStream(final URI uri, final Map<String, String> environment) throws IOException {
+    static DownloadStream openStream(final URI uri, final Map<String, String> environment) throws IOException {
         final HttpClient.Builder builder = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL);
         final ProxyConfiguration proxyConfiguration = proxyConfigurationFor(uri, environment);
         switch (proxyConfiguration.mode()) {
@@ -85,7 +88,11 @@ public final class ImageDownloadSupport {
                 response.body().close();
                 throw new IOException("Failed to download " + uri + " (HTTP " + response.statusCode() + ")");
             }
-            return new BufferedInputStream(response.body());
+
+            // Extract the content length (defaults to -1 if the server uses chunked encoding)
+            final long contentLength = response.headers().firstValueAsLong("Content-Length").orElse(-1L);
+
+            return new DownloadStream(new BufferedInputStream(response.body()), contentLength);
         } catch (final InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new IOException("Interrupted while downloading " + uri, e);

--- a/src/de.hpi.swa.trufflesqueak.shared/src/de/hpi/swa/trufflesqueak/shared/SqueakImageLocator.java
+++ b/src/de.hpi.swa.trufflesqueak.shared/src/de/hpi/swa/trufflesqueak/shared/SqueakImageLocator.java
@@ -8,7 +8,9 @@ package de.hpi.swa.trufflesqueak.shared;
 
 import java.io.BufferedInputStream;
 import java.io.File;
+import java.io.FilterInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.net.URI;
@@ -65,7 +67,7 @@ public final class SqueakImageLocator {
                     if (!isQuiet) {
                         out.printf("Downloading %s...%n", selectedEntry.name());
                     }
-                    final Path downloadedImage = downloadAndUnzip(downloadUrl, resourcesDirectory);
+                    final Path downloadedImage = downloadAndUnzip(downloadUrl, resourcesDirectory, isQuiet, out);
                     Files.writeString(cachePath, resourcesDirectory.toPath().relativize(downloadedImage).toString(), StandardCharsets.UTF_8);
                     return downloadedImage.toString();
                 }
@@ -147,15 +149,35 @@ public final class SqueakImageLocator {
         return languageHome.resolve("resources").toFile();
     }
 
-    private static Path downloadAndUnzip(final String url, final File destDirectory) {
-        try (BufferedInputStream bis = ImageDownloadSupport.openStream(URI.create(url))) {
-            return unzip(bis, destDirectory);
+    private static Path downloadAndUnzip(final String url, final File destDirectory, final boolean isQuiet, final PrintStream out) {
+        try {
+            final ImageDownloadSupport.DownloadStream download = ImageDownloadSupport.openStream(URI.create(url));
+
+            // Suppress the progress bar if the user requested quiet mode or if there is no console.
+            final boolean isInteractive = System.console() != null;
+            final boolean disableProgressBar = isQuiet || !isInteractive;
+
+            try (BufferedInputStream bis = download.stream();
+                            ProgressTrackingInputStream ptis = new ProgressTrackingInputStream(bis, download.contentLength(), disableProgressBar, out)) {
+
+                final Path extracted = unzip(ptis, destDirectory);
+
+                if (!isQuiet) {
+                    if (isInteractive) {
+                        out.println("\rDownload and extraction complete!          ");
+                    } else {
+                        out.println("Download and extraction complete!");
+                    }
+                }
+
+                return extracted;
+            }
         } catch (final IOException e) {
             throw new RuntimeException(e);
         }
     }
 
-    private static Path unzip(final BufferedInputStream bis, final File destDirectory) throws IOException {
+    private static Path unzip(final InputStream bis, final File destDirectory) throws IOException {
         final ZipInputStream zis = new ZipInputStream(bis);
         ZipEntry zipEntry = zis.getNextEntry();
         Path extractedImage = null;
@@ -186,6 +208,64 @@ public final class SqueakImageLocator {
     private static void ensureDirectory(final File directory) throws IOException {
         if (!directory.isDirectory() && !directory.mkdirs()) {
             throw new IOException("Failed to create directory " + directory);
+        }
+    }
+
+    private static class ProgressTrackingInputStream extends FilterInputStream {
+        private long totalBytesRead;
+        private final long contentLength;
+        private final boolean isQuiet;
+        private final PrintStream out;
+
+        private int lastPercent = -1;
+        private long lastPrintedMegabytes;
+
+        protected ProgressTrackingInputStream(final InputStream in, final long contentLength, final boolean isQuiet, final PrintStream out) {
+            super(in);
+            this.contentLength = contentLength;
+            this.isQuiet = isQuiet;
+            this.out = out;
+        }
+
+        @Override
+        public int read(final byte[] b, final int off, final int len) throws IOException {
+            final int bytesRead = super.read(b, off, len);
+            if (bytesRead != -1) {
+                trackProgress(bytesRead);
+            }
+            return bytesRead;
+        }
+
+        @Override
+        public int read() throws IOException {
+            final int byteRead = super.read();
+            if (byteRead != -1) {
+                trackProgress(1);
+            }
+            return byteRead;
+        }
+
+        private void trackProgress(final int bytesRead) {
+            if (isQuiet) {
+                return;
+            }
+
+            totalBytesRead += bytesRead;
+
+            if (contentLength > 0) {
+                final int percent = (int) ((totalBytesRead * 100) / contentLength);
+                if (percent > lastPercent) {
+                    lastPercent = percent;
+                    out.print("\rDownloading: [" + percent + "%]...");
+                }
+            } else {
+                // Fallback if the server uses chunked transfer encoding without a Content-Length
+                final long currentMegabytes = totalBytesRead / (1024 * 1024);
+                if (currentMegabytes > lastPrintedMegabytes) {
+                    lastPrintedMegabytes = currentMegabytes;
+                    out.print("\rDownloaded: " + currentMegabytes + " MB...");
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Display progress while downloading an image. The output is suppressed completely when the `--quiet` option is supplied. If there is no console, only download completion is output.