### PR TITLE
Use context stack depth to set the Java stack size

### DIFF
--- a/src/de.hpi.swa.trufflesqueak.launcher/src/de/hpi/swa/trufflesqueak/launcher/TruffleSqueakLauncher.java
+++ b/src/de.hpi.swa.trufflesqueak.launcher/src/de/hpi/swa/trufflesqueak/launcher/TruffleSqueakLauncher.java
@@ -95,19 +95,8 @@ public final class TruffleSqueakLauncher extends AbstractLanguageLauncher {
                 i = handleIntOption(arguments, i, arg, SqueakLanguageOptions.WATCHDOG_TIMEOUT_FLAG, val -> watchdogTimeoutMinutes = val, unrecognized);
             } else if (arg.startsWith(SqueakLanguageOptions.SDL_POLL_TIMEOUT_FLAG)) {
                 i = handleIntOption(arguments, i, arg, SqueakLanguageOptions.SDL_POLL_TIMEOUT_FLAG, val -> sdlPollTimeoutMilliseconds = val, unrecognized);
-            } else if (arg.startsWith(SqueakLanguageOptions.CONTEXT_STACK_DEPTH_FLAG) ||
-                            arg.startsWith("--" + SqueakLanguageConfig.ID + "." + SqueakLanguageOptions.CONTEXT_STACK_DEPTH)) {
-
-                final String matchedPrefix = arg.startsWith(SqueakLanguageOptions.CONTEXT_STACK_DEPTH_FLAG)
-                                ? SqueakLanguageOptions.CONTEXT_STACK_DEPTH_FLAG
-                                : "--" + SqueakLanguageConfig.ID + "." + SqueakLanguageOptions.CONTEXT_STACK_DEPTH;
-
-                i = handleIntOption(arguments, i, arg, matchedPrefix, val -> {
-                    contextStackDepth = Math.max(SqueakLanguageConfig.MIN_CONTEXT_STACK_DEPTH, val);
-                }, unrecognized);
-
-                // Push the fully-qualified flag back into unrecognized.
-                unrecognized.add("--" + SqueakLanguageConfig.ID + "." + SqueakLanguageOptions.CONTEXT_STACK_DEPTH + "=" + contextStackDepth);
+            } else if (arg.startsWith(SqueakLanguageOptions.CONTEXT_STACK_DEPTH_FLAG)) {
+                i = handleIntOption(arguments, i, arg, SqueakLanguageOptions.CONTEXT_STACK_DEPTH_FLAG, val -> contextStackDepth = Math.max(MIN_CONTEXT_STACK_DEPTH, val), unrecognized);
             } else if (SqueakLanguageOptions.DOWNLOAD_IMAGE_FLAG.equals(arg)) {
                 downloadImageKey = getRequiredDownloadImageKey(arguments, ++i);
             } else {
@@ -126,7 +115,7 @@ public final class TruffleSqueakLauncher extends AbstractLanguageLauncher {
     /**
      * Handles parsing a non-negative integer option, routing it to 'unrecognized' if it is a false
      * prefix match.
-     *
+     * 
      * @return the updated argument index 'i'
      */
     private int handleIntOption(final List<String> arguments, final int i, final String arg, final String flagName, final IntConsumer setter, final List<String> unrecognized) {
@@ -224,6 +213,7 @@ public final class TruffleSqueakLauncher extends AbstractLanguageLauncher {
         contextBuilder.option(SqueakLanguageConfig.ID + "." + SqueakLanguageOptions.IMAGE_PATH, imagePath);
         contextBuilder.option(SqueakLanguageConfig.ID + "." + SqueakLanguageOptions.HEADLESS, Boolean.toString(headless));
         contextBuilder.option(SqueakLanguageConfig.ID + "." + SqueakLanguageOptions.QUIET, Boolean.toString(quiet));
+        contextBuilder.option(SqueakLanguageConfig.ID + "." + SqueakLanguageOptions.CONTEXT_STACK_DEPTH, Integer.toString(contextStackDepth));
         contextBuilder.arguments(getLanguageId(), imageArguments);
         final String runtimeName = getRuntimeName();
         final boolean hasGraalCompiler = runtimeName.contains("Graal");

--- a/src/de.hpi.swa.trufflesqueak.launcher/src/de/hpi/swa/trufflesqueak/launcher/TruffleSqueakLauncher.java
+++ b/src/de.hpi.swa.trufflesqueak.launcher/src/de/hpi/swa/trufflesqueak/launcher/TruffleSqueakLauncher.java
@@ -7,7 +7,6 @@
 package de.hpi.swa.trufflesqueak.launcher;
 
 import static de.hpi.swa.trufflesqueak.shared.SqueakLanguageConfig.DEFAULT_CONTEXT_STACK_DEPTH;
-import static de.hpi.swa.trufflesqueak.shared.SqueakLanguageConfig.MIN_CONTEXT_STACK_DEPTH;
 
 import java.io.File;
 import java.io.IOException;
@@ -96,7 +95,7 @@ public final class TruffleSqueakLauncher extends AbstractLanguageLauncher {
             } else if (arg.startsWith(SqueakLanguageOptions.SDL_POLL_TIMEOUT_FLAG)) {
                 i = handleIntOption(arguments, i, arg, SqueakLanguageOptions.SDL_POLL_TIMEOUT_FLAG, val -> sdlPollTimeoutMilliseconds = val, unrecognized);
             } else if (arg.startsWith(SqueakLanguageOptions.CONTEXT_STACK_DEPTH_FLAG)) {
-                i = handleIntOption(arguments, i, arg, SqueakLanguageOptions.CONTEXT_STACK_DEPTH_FLAG, val -> contextStackDepth = Math.max(MIN_CONTEXT_STACK_DEPTH, val), unrecognized);
+                i = handleIntOption(arguments, i, arg, SqueakLanguageOptions.CONTEXT_STACK_DEPTH_FLAG, val -> contextStackDepth = Math.max(1, val), unrecognized);
             } else if (SqueakLanguageOptions.DOWNLOAD_IMAGE_FLAG.equals(arg)) {
                 downloadImageKey = getRequiredDownloadImageKey(arguments, ++i);
             } else {

--- a/src/de.hpi.swa.trufflesqueak.launcher/src/de/hpi/swa/trufflesqueak/launcher/TruffleSqueakLauncher.java
+++ b/src/de.hpi.swa.trufflesqueak.launcher/src/de/hpi/swa/trufflesqueak/launcher/TruffleSqueakLauncher.java
@@ -6,6 +6,9 @@
  */
 package de.hpi.swa.trufflesqueak.launcher;
 
+import static de.hpi.swa.trufflesqueak.shared.SqueakLanguageConfig.DEFAULT_CONTEXT_STACK_DEPTH;
+import static de.hpi.swa.trufflesqueak.shared.SqueakLanguageConfig.MIN_CONTEXT_STACK_DEPTH;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -50,6 +53,7 @@ public final class TruffleSqueakLauncher extends AbstractLanguageLauncher {
     private boolean addDisableDynamicCompilationThresholds = true;
     private int sdlPollTimeoutMilliseconds;
     private int watchdogTimeoutMinutes;
+    private int contextStackDepth = DEFAULT_CONTEXT_STACK_DEPTH;
 
     public static void main(final String[] arguments) throws RuntimeException {
         new TruffleSqueakLauncher().launch(arguments);
@@ -91,6 +95,8 @@ public final class TruffleSqueakLauncher extends AbstractLanguageLauncher {
                 i = handleIntOption(arguments, i, arg, SqueakLanguageOptions.WATCHDOG_TIMEOUT_FLAG, val -> watchdogTimeoutMinutes = val, unrecognized);
             } else if (arg.startsWith(SqueakLanguageOptions.SDL_POLL_TIMEOUT_FLAG)) {
                 i = handleIntOption(arguments, i, arg, SqueakLanguageOptions.SDL_POLL_TIMEOUT_FLAG, val -> sdlPollTimeoutMilliseconds = val, unrecognized);
+            } else if (arg.startsWith(SqueakLanguageOptions.CONTEXT_STACK_DEPTH_FLAG)) {
+                i = handleIntOption(arguments, i, arg, SqueakLanguageOptions.CONTEXT_STACK_DEPTH_FLAG, val -> contextStackDepth = Math.max(MIN_CONTEXT_STACK_DEPTH, val), unrecognized);
             } else if (SqueakLanguageOptions.DOWNLOAD_IMAGE_FLAG.equals(arg)) {
                 downloadImageKey = getRequiredDownloadImageKey(arguments, ++i);
             } else {
@@ -161,11 +167,41 @@ public final class TruffleSqueakLauncher extends AbstractLanguageLauncher {
 
     @Override
     protected void launch(final Context.Builder contextBuilder) {
+        final int[] vmExitCode = {-1};
+
+        final Runnable vmRunnable = () -> {
+            try {
+                vmExitCode[0] = execute(contextBuilder);
+            } catch (Throwable t) {
+                throw abort(t);
+            } finally {
+                // Only stop the event loop if we actually started it
+                if (!headless) {
+                    PlatformEventLoop.stop();
+                }
+            }
+        };
+
+        // Calculate thread stack size based on context depth
+        final long threadStackSizeBytes = (contextStackDepth + 512L) * 1024L;
+
+        final Thread vmThread = new Thread(null, vmRunnable, "TruffleSqueakVM-Thread", threadStackSizeBytes);
+        vmThread.start();
+
         if (headless) {
-            System.exit(execute(contextBuilder));
+            // Headless mode: Main thread just waits for the VM thread to finish
+            try {
+                vmThread.join();
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw abort(e);
+            }
         } else {
-            executeInVMThread(contextBuilder);
+            // UI mode: Main thread runs the SDL event loop
+            PlatformEventLoop.run(sdlPollTimeoutMilliseconds);
         }
+
+        System.exit(vmExitCode[0]);
     }
 
     private int execute(final Context.Builder contextBuilder) {
@@ -177,6 +213,7 @@ public final class TruffleSqueakLauncher extends AbstractLanguageLauncher {
         contextBuilder.option(SqueakLanguageConfig.ID + "." + SqueakLanguageOptions.IMAGE_PATH, imagePath);
         contextBuilder.option(SqueakLanguageConfig.ID + "." + SqueakLanguageOptions.HEADLESS, Boolean.toString(headless));
         contextBuilder.option(SqueakLanguageConfig.ID + "." + SqueakLanguageOptions.QUIET, Boolean.toString(quiet));
+        contextBuilder.option(SqueakLanguageConfig.ID + "." + SqueakLanguageOptions.CONTEXT_STACK_DEPTH, Integer.toString(contextStackDepth));
         contextBuilder.arguments(getLanguageId(), imageArguments);
         final String runtimeName = getRuntimeName();
         final boolean hasGraalCompiler = runtimeName.contains("Graal");
@@ -253,22 +290,6 @@ public final class TruffleSqueakLauncher extends AbstractLanguageLauncher {
         }
     }
 
-    private void executeInVMThread(final Context.Builder contextBuilder) {
-        final int[] vmExitCode = {-1};
-        final Thread vmThread = new Thread(() -> {
-            try {
-                vmExitCode[0] = execute(contextBuilder);
-            } catch (Throwable t) {
-                throw abort(t);
-            } finally {
-                PlatformEventLoop.stop();
-            }
-        }, "TruffleSqueakVM-Thread");
-        vmThread.start();
-        PlatformEventLoop.run(sdlPollTimeoutMilliseconds);
-        System.exit(vmExitCode[0]);
-    }
-
     @Override
     protected String getLanguageId() {
         return SqueakLanguageConfig.ID;
@@ -291,13 +312,14 @@ public final class TruffleSqueakLauncher extends AbstractLanguageLauncher {
         launcherOption(SqueakLanguageOptions.QUIET_FLAG, SqueakLanguageOptions.QUIET_HELP);
         launcherOption(SqueakLanguageOptions.SDL_POLL_TIMEOUT_FLAG + " <milliseconds>", SqueakLanguageOptions.SDL_POLL_TIMEOUT_HELP);
         launcherOption(SqueakLanguageOptions.WATCHDOG_TIMEOUT_FLAG + " <minutes>", SqueakLanguageOptions.WATCHDOG_TIMEOUT_HELP);
+        launcherOption(SqueakLanguageOptions.CONTEXT_STACK_DEPTH_FLAG + " <number>", SqueakLanguageOptions.CONTEXT_STACK_DEPTH_HELP);
     }
 
     @Override
     protected void collectArguments(final Set<String> options) {
         options.addAll(List.of(SqueakLanguageOptions.WATCHDOG_TIMEOUT_FLAG, SqueakLanguageOptions.CODE_FLAG, SqueakLanguageOptions.CODE_FLAG_SHORT, SqueakLanguageOptions.HEADLESS_FLAG,
                         SqueakLanguageOptions.QUIET_FLAG, SqueakLanguageOptions.PRINT_IMAGE_PATH_FLAG, SqueakLanguageOptions.DOWNLOAD_IMAGE_FLAG, SqueakLanguageOptions.RESOURCE_SUMMARY_FLAG,
-                        SqueakLanguageOptions.TRANSCRIPT_FORWARDING_FLAG));
+                        SqueakLanguageOptions.TRANSCRIPT_FORWARDING_FLAG, SqueakLanguageOptions.CONTEXT_STACK_DEPTH_FLAG));
     }
 
     private static boolean isExistingImageFile(final String fileName) {

--- a/src/de.hpi.swa.trufflesqueak.launcher/src/de/hpi/swa/trufflesqueak/launcher/TruffleSqueakLauncher.java
+++ b/src/de.hpi.swa.trufflesqueak.launcher/src/de/hpi/swa/trufflesqueak/launcher/TruffleSqueakLauncher.java
@@ -95,8 +95,19 @@ public final class TruffleSqueakLauncher extends AbstractLanguageLauncher {
                 i = handleIntOption(arguments, i, arg, SqueakLanguageOptions.WATCHDOG_TIMEOUT_FLAG, val -> watchdogTimeoutMinutes = val, unrecognized);
             } else if (arg.startsWith(SqueakLanguageOptions.SDL_POLL_TIMEOUT_FLAG)) {
                 i = handleIntOption(arguments, i, arg, SqueakLanguageOptions.SDL_POLL_TIMEOUT_FLAG, val -> sdlPollTimeoutMilliseconds = val, unrecognized);
-            } else if (arg.startsWith(SqueakLanguageOptions.CONTEXT_STACK_DEPTH_FLAG)) {
-                i = handleIntOption(arguments, i, arg, SqueakLanguageOptions.CONTEXT_STACK_DEPTH_FLAG, val -> contextStackDepth = Math.max(MIN_CONTEXT_STACK_DEPTH, val), unrecognized);
+            } else if (arg.startsWith(SqueakLanguageOptions.CONTEXT_STACK_DEPTH_FLAG) ||
+                            arg.startsWith("--" + SqueakLanguageConfig.ID + "." + SqueakLanguageOptions.CONTEXT_STACK_DEPTH)) {
+
+                final String matchedPrefix = arg.startsWith(SqueakLanguageOptions.CONTEXT_STACK_DEPTH_FLAG)
+                                ? SqueakLanguageOptions.CONTEXT_STACK_DEPTH_FLAG
+                                : "--" + SqueakLanguageConfig.ID + "." + SqueakLanguageOptions.CONTEXT_STACK_DEPTH;
+
+                i = handleIntOption(arguments, i, arg, matchedPrefix, val -> {
+                    contextStackDepth = Math.max(SqueakLanguageConfig.MIN_CONTEXT_STACK_DEPTH, val);
+                }, unrecognized);
+
+                // Push the fully-qualified flag back into unrecognized.
+                unrecognized.add("--" + SqueakLanguageConfig.ID + "." + SqueakLanguageOptions.CONTEXT_STACK_DEPTH + "=" + contextStackDepth);
             } else if (SqueakLanguageOptions.DOWNLOAD_IMAGE_FLAG.equals(arg)) {
                 downloadImageKey = getRequiredDownloadImageKey(arguments, ++i);
             } else {
@@ -115,7 +126,7 @@ public final class TruffleSqueakLauncher extends AbstractLanguageLauncher {
     /**
      * Handles parsing a non-negative integer option, routing it to 'unrecognized' if it is a false
      * prefix match.
-     * 
+     *
      * @return the updated argument index 'i'
      */
     private int handleIntOption(final List<String> arguments, final int i, final String arg, final String flagName, final IntConsumer setter, final List<String> unrecognized) {
@@ -213,7 +224,6 @@ public final class TruffleSqueakLauncher extends AbstractLanguageLauncher {
         contextBuilder.option(SqueakLanguageConfig.ID + "." + SqueakLanguageOptions.IMAGE_PATH, imagePath);
         contextBuilder.option(SqueakLanguageConfig.ID + "." + SqueakLanguageOptions.HEADLESS, Boolean.toString(headless));
         contextBuilder.option(SqueakLanguageConfig.ID + "." + SqueakLanguageOptions.QUIET, Boolean.toString(quiet));
-        contextBuilder.option(SqueakLanguageConfig.ID + "." + SqueakLanguageOptions.CONTEXT_STACK_DEPTH, Integer.toString(contextStackDepth));
         contextBuilder.arguments(getLanguageId(), imageArguments);
         final String runtimeName = getRuntimeName();
         final boolean hasGraalCompiler = runtimeName.contains("Graal");

--- a/src/de.hpi.swa.trufflesqueak.shared/src/de/hpi/swa/trufflesqueak/shared/SqueakLanguageConfig.java
+++ b/src/de.hpi.swa.trufflesqueak.shared/src/de/hpi/swa/trufflesqueak/shared/SqueakLanguageConfig.java
@@ -20,7 +20,6 @@ public final class SqueakLanguageConfig {
     private static final String IMAGE_VERSION = "25.0.1"; // on release: `VERSION;`
 
     public static final int DEFAULT_CONTEXT_STACK_DEPTH = 2 << 12;
-    public static final int MIN_CONTEXT_STACK_DEPTH = 128;
 
     public record SupportedImage(String id, String name, String url) {
         public static SupportedImage url(final String url) {

--- a/src/de.hpi.swa.trufflesqueak.shared/src/de/hpi/swa/trufflesqueak/shared/SqueakLanguageConfig.java
+++ b/src/de.hpi.swa.trufflesqueak.shared/src/de/hpi/swa/trufflesqueak/shared/SqueakLanguageConfig.java
@@ -19,6 +19,9 @@ public final class SqueakLanguageConfig {
     public static final String WEBSITE = "https://github.com/hpi-swa/trufflesqueak";
     private static final String IMAGE_VERSION = "25.0.1"; // on release: `VERSION;`
 
+    public static final int DEFAULT_CONTEXT_STACK_DEPTH = 2 << 12;
+    public static final int MIN_CONTEXT_STACK_DEPTH = 128;
+
     public record SupportedImage(String id, String name, String url) {
         public static SupportedImage url(final String url) {
             final String name = extractName(url);

--- a/src/de.hpi.swa.trufflesqueak.shared/src/de/hpi/swa/trufflesqueak/shared/SqueakLanguageOptions.java
+++ b/src/de.hpi.swa.trufflesqueak.shared/src/de/hpi/swa/trufflesqueak/shared/SqueakLanguageOptions.java
@@ -12,7 +12,7 @@ public final class SqueakLanguageOptions {
     public static final String CODE_HELP = "Smalltalk code to be executed without display";
     public static final String CONTEXT_STACK_DEPTH = "context-stack-depth";
     public static final String CONTEXT_STACK_DEPTH_FLAG = "--" + CONTEXT_STACK_DEPTH;
-    public static final String CONTEXT_STACK_DEPTH_HELP = "Flush context stack when it reaches this depth (0 = disabled)";
+    public static final String CONTEXT_STACK_DEPTH_HELP = "Flush context stack when it reaches this depth";
     public static final String HEADLESS = "headless";
     public static final String HEADLESS_FLAG = "--" + HEADLESS;
     public static final String HEADLESS_HELP = "Run without a display";

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/SqueakOptions.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/SqueakOptions.java
@@ -7,7 +7,6 @@
 package de.hpi.swa.trufflesqueak;
 
 import static de.hpi.swa.trufflesqueak.shared.SqueakLanguageConfig.DEFAULT_CONTEXT_STACK_DEPTH;
-import static de.hpi.swa.trufflesqueak.shared.SqueakLanguageConfig.MIN_CONTEXT_STACK_DEPTH;
 
 import org.graalvm.options.OptionCategory;
 import org.graalvm.options.OptionDescriptors;
@@ -74,7 +73,7 @@ public final class SqueakOptions {
                             options.get(ResourceSummary),
                             options.get(Headless),
                             options.get(Interrupts),
-                            Math.max(MIN_CONTEXT_STACK_DEPTH, options.get(ContextStackDepth)),
+                            Math.max(1, options.get(ContextStackDepth)),
                             options.get(Startup),
                             options.get(Testing),
                             options.get(SignalInputSemaphore));

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/SqueakOptions.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/SqueakOptions.java
@@ -6,6 +6,9 @@
  */
 package de.hpi.swa.trufflesqueak;
 
+import static de.hpi.swa.trufflesqueak.shared.SqueakLanguageConfig.DEFAULT_CONTEXT_STACK_DEPTH;
+import static de.hpi.swa.trufflesqueak.shared.SqueakLanguageConfig.MIN_CONTEXT_STACK_DEPTH;
+
 import org.graalvm.options.OptionCategory;
 import org.graalvm.options.OptionDescriptors;
 import org.graalvm.options.OptionKey;
@@ -44,7 +47,7 @@ public final class SqueakOptions {
     public static final OptionKey<Boolean> ResourceSummary = new OptionKey<>(false);
 
     @Option(name = SqueakLanguageOptions.CONTEXT_STACK_DEPTH, category = OptionCategory.USER, stability = OptionStability.EXPERIMENTAL, help = SqueakLanguageOptions.CONTEXT_STACK_DEPTH_HELP, usageSyntax = "number")//
-    public static final OptionKey<Integer> ContextStackDepth = new OptionKey<>(2 << 12);
+    public static final OptionKey<Integer> ContextStackDepth = new OptionKey<>(DEFAULT_CONTEXT_STACK_DEPTH);
 
     @Option(name = SqueakLanguageOptions.SIGNAL_INPUT_SEMAPHORE, category = OptionCategory.INTERNAL, stability = OptionStability.EXPERIMENTAL, help = SqueakLanguageOptions.SIGNAL_INPUT_SEMAPHORE_HELP, usageSyntax = "false|true")//
     public static final OptionKey<Boolean> SignalInputSemaphore = new OptionKey<>(false);
@@ -71,7 +74,7 @@ public final class SqueakOptions {
                             options.get(ResourceSummary),
                             options.get(Headless),
                             options.get(Interrupts),
-                            Math.max(1, options.get(ContextStackDepth)),
+                            Math.max(MIN_CONTEXT_STACK_DEPTH, options.get(ContextStackDepth)),
                             options.get(Startup),
                             options.get(Testing),
                             options.get(SignalInputSemaphore));


### PR DESCRIPTION
Links the Java thread stack size to the requested `--context-stack-depth` to prevent Java stack overflow, and unifies headless and UI thread execution.

**Changes**

* **Thread Sizing:** Both headless and UI modes now execute inside a dedicated `TruffleSqueakVM-Thread`. The thread's stack size is allocated as `(contextStackDepth + 512) * 1024` bytes.
* **Centralized Constants:** Moves the default context depth (`2 << 12`) and introduces a new minimum depth (`128`) in `SqueakLanguageConfig.java`.
* **Input Clamping:** Clamps the context stack depth to the minimum in both `TruffleSqueakLauncher` and `SqueakOptions`.
* **Deprecation:** Removes `(0 = disabled)` from the help string since that is no longer supported.

**Results**

With this change, it is now possible to `update code from the server` using the default context stack depth of 8192. This was also tested with a variety of context stack depths down to the minimum of 128.

Also tested headless mode:
 
```
trufflesqueak % $TS_JVM_HOME/bin/trufflesqueak --download-image trufflesqueak --context-stack-depth 35000 -c "Time millisecondsToRun: [30000 factorial]"
[trufflesqueak] Running TruffleSqueak-25.0.1.image on Oracle GraalVM (latency mode)...
[trufflesqueak] Evaluating 'Time millisecondsToRun: [30000 factorial]'...
[trufflesqueak] Result: 986
```


_Note that using smaller context stack depths will result in more Truffle frame flushes and slower code execution._