### PR TITLE
prevent context depth count from signaling when interrupts are disabled

### DIFF
--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
@@ -89,9 +89,14 @@ import de.hpi.swa.trufflesqueak.util.ObjectGraphUtils;
 @DefaultExpression("get($node)")
 public final class SqueakImageContext {
     private static final ContextReference<SqueakImageContext> REFERENCE = ContextReference.create(SqueakLanguage.class);
+    private static final int SUSPENDED_CONTEXT_STACK_DEPTH = Integer.MIN_VALUE / 2;
 
     /* Encapsulates the state needed to safely execute without interrupts and stack limits */
-    public record SavedExecutionState(boolean insterruptsWereActive, int savedContextDepth) {
+    public record SavedExecutionState(SqueakImageContext context, boolean interruptsWereActive, int savedContextDepth) implements AutoCloseable {
+        @Override
+        public void close() {
+            context.resumeNormalExecution(this);
+        }
     }
 
     /* Special objects */
@@ -305,20 +310,20 @@ public final class SqueakImageContext {
      * (such as process switching or flushing the Truffle execution stack) must be suppressed
      * to prevent disrupting the host execution flow.
      *
-     * @return a {@link SavedExecutionState} record containing the original environment state.
-     * This MUST be passed to {@link #resumeNormalExecution(SavedExecutionState)}
-     * inside a {@code finally} block to restore normal VM operations.
+     * @return a {@link SavedExecutionState} that must be managed within a
+     *         {@code try-with-resources} block. This ensures the original
+     *         environment state is automatically and safely restored upon exit.
      */
     public SavedExecutionState suspendNormalExecution() {
         final boolean wasActive = interrupt.deactivate();
         final int savedDepth = currentContextStackDepth;
-        currentContextStackDepth = -100_000;
-        return new SavedExecutionState(wasActive, savedDepth);
+        currentContextStackDepth = SUSPENDED_CONTEXT_STACK_DEPTH;
+        return new SavedExecutionState(this, wasActive, savedDepth);
     }
 
-    public void resumeNormalExecution(final SavedExecutionState state) {
+    private void resumeNormalExecution(final SavedExecutionState state) {
         currentContextStackDepth = state.savedContextDepth();
-        interrupt.reactivate(state.insterruptsWereActive());
+        interrupt.reactivate(state.interruptsWereActive());
     }
 
     @TruffleBoundary
@@ -328,11 +333,8 @@ public final class SqueakImageContext {
 
     @TruffleBoundary
     public Object evaluateUninterruptably(final String sourceCode) {
-        final SavedExecutionState state = suspendNormalExecution();
-        try {
+        try (var _ = suspendNormalExecution()) {
             return evaluate(sourceCode);
-        } finally {
-            resumeNormalExecution(state);
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
@@ -90,6 +90,10 @@ import de.hpi.swa.trufflesqueak.util.ObjectGraphUtils;
 public final class SqueakImageContext {
     private static final ContextReference<SqueakImageContext> REFERENCE = ContextReference.create(SqueakLanguage.class);
 
+    /* Encapsulates the state needed to safely execute without interrupts and stack limits */
+    public record SavedExecutionState(boolean insterruptsWereActive, int savedContextDepth) {
+    }
+
     /* Special objects */
     public final ClassObject falseClass = new ClassObject(this);
     public final ClassObject trueClass = new ClassObject(this);
@@ -292,6 +296,31 @@ public final class SqueakImageContext {
         return squeakImage;
     }
 
+    /**
+     * Suspends normal execution constraints by deactivating the interrupt handler
+     * and bypassing context stack depth limits.
+     *
+     * This method prepares the environment for safe execution of internal VM routines
+     * or external Interop calls. In these scenarios, normal Smalltalk semantics
+     * (such as process switching or flushing the Truffle execution stack) must be suppressed
+     * to prevent disrupting the host execution flow.
+     *
+     * @return a {@link SavedExecutionState} record containing the original environment state.
+     * This MUST be passed to {@link #resumeNormalExecution(SavedExecutionState)}
+     * inside a {@code finally} block to restore normal VM operations.
+     */
+    public SavedExecutionState suspendNormalExecution() {
+        final boolean wasActive = interrupt.deactivate();
+        final int savedDepth = currentContextStackDepth;
+        currentContextStackDepth = -100_000;
+        return new SavedExecutionState(wasActive, savedDepth);
+    }
+
+    public void resumeNormalExecution(final SavedExecutionState state) {
+        currentContextStackDepth = state.savedContextDepth();
+        interrupt.reactivate(state.insterruptsWereActive());
+    }
+
     @TruffleBoundary
     public Object evaluate(final String sourceCode) {
         return getDoItContextNode(sourceCode).getCallTarget().call();
@@ -299,11 +328,11 @@ public final class SqueakImageContext {
 
     @TruffleBoundary
     public Object evaluateUninterruptably(final String sourceCode) {
-        final boolean wasActive = interrupt.deactivate();
+        final SavedExecutionState state = suspendNormalExecution();
         try {
             return evaluate(sourceCode);
         } finally {
-            interrupt.reactivate(wasActive);
+            resumeNormalExecution(state);
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
@@ -91,7 +91,11 @@ public final class SqueakImageContext {
     private static final ContextReference<SqueakImageContext> REFERENCE = ContextReference.create(SqueakLanguage.class);
     private static final int SUSPENDED_CONTEXT_STACK_DEPTH = Integer.MIN_VALUE / 2;
 
-    /* Encapsulates the state needed to safely execute without interrupts and stack limits */
+    /*
+     * Encapsulates the state needed to safely execute without interrupts and stack limits.
+     * Note: Use a standard try/finally block in partially evaluated Truffle code to avoid
+     * AOT compilation failures caused by try-with-resources desugaring.
+     */
     public record SavedExecutionState(SqueakImageContext context, boolean interruptsWereActive, int savedContextDepth) implements AutoCloseable {
         @Override
         public void close() {
@@ -310,9 +314,14 @@ public final class SqueakImageContext {
      * (such as process switching or flushing the Truffle execution stack) must be suppressed
      * to prevent disrupting the host execution flow.
      *
-     * @return a {@link SavedExecutionState} that must be managed within a
-     *         {@code try-with-resources} block. This ensures the original
-     *         environment state is automatically and safely restored upon exit.
+     * @return a {@link SavedExecutionState} that must be closed to restore the original state.
+     * <p>
+     * <b>Usage Note:</b> While this implements {@link AutoCloseable}, it must be used
+     * with a traditional {@code try/finally} block inside Truffle compiled code paths.
+     * Using {@code try-with-resources} generates {@code Throwable.addSuppressed()}
+     * bytecode, which violates GraalVM Native Image compilation blocklists during
+     * partial evaluation. In standard Java code or behind a {@code @TruffleBoundary},
+     * {@code try-with-resources} is safe to use.
      */
     public SavedExecutionState suspendNormalExecution() {
         final boolean wasActive = interrupt.deactivate();
@@ -333,8 +342,11 @@ public final class SqueakImageContext {
 
     @TruffleBoundary
     public Object evaluateUninterruptably(final String sourceCode) {
-        try (var _ = suspendNormalExecution()) {
+        final var state = suspendNormalExecution();
+        try {
             return evaluate(sourceCode);
+        } finally {
+            state.close();
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/AbstractSqueakObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/AbstractSqueakObject.java
@@ -69,7 +69,8 @@ public abstract class AbstractSqueakObject implements TruffleObject {
                     @SuppressWarnings("unused") @Bind final Node node,
                     @Cached final PerformInteropSendNode performInteropSendNode) throws Exception {
         final SqueakImageContext image = SqueakImageContext.get(node);
-        try (var _ = image.suspendNormalExecution()) {
+        final var state = image.suspendNormalExecution();
+        try {
             return performInteropSendNode.execute(node, receiver, message, arguments);
         } catch (final ProcessSwitch ps) {
             CompilerDirectives.transferToInterpreter();
@@ -79,6 +80,8 @@ public abstract class AbstractSqueakObject implements TruffleObject {
             } else {
                 throw ps; // open debugger in interactive mode
             }
+        } finally {
+            state.close();
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/AbstractSqueakObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/AbstractSqueakObject.java
@@ -34,6 +34,7 @@ import com.oracle.truffle.api.nodes.Node;
 
 import de.hpi.swa.trufflesqueak.exceptions.ProcessSwitch;
 import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
+import de.hpi.swa.trufflesqueak.image.SqueakImageContext.SavedExecutionState;
 import de.hpi.swa.trufflesqueak.interop.WrapToSqueakNode;
 import de.hpi.swa.trufflesqueak.nodes.AbstractNode;
 import de.hpi.swa.trufflesqueak.nodes.LookupMethodNode;
@@ -69,7 +70,7 @@ public abstract class AbstractSqueakObject implements TruffleObject {
                     @SuppressWarnings("unused") @Bind final Node node,
                     @Cached final PerformInteropSendNode performInteropSendNode) throws Exception {
         final SqueakImageContext image = SqueakImageContext.get(node);
-        final boolean wasActive = image.interrupt.deactivate();
+        final SavedExecutionState state = image.suspendNormalExecution();
         try {
             return performInteropSendNode.execute(node, receiver, message, arguments);
         } catch (final ProcessSwitch ps) {
@@ -81,7 +82,7 @@ public abstract class AbstractSqueakObject implements TruffleObject {
                 throw ps; // open debugger in interactive mode
             }
         } finally {
-            image.interrupt.reactivate(wasActive);
+            image.resumeNormalExecution(state);
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/AbstractSqueakObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/AbstractSqueakObject.java
@@ -34,7 +34,6 @@ import com.oracle.truffle.api.nodes.Node;
 
 import de.hpi.swa.trufflesqueak.exceptions.ProcessSwitch;
 import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
-import de.hpi.swa.trufflesqueak.image.SqueakImageContext.SavedExecutionState;
 import de.hpi.swa.trufflesqueak.interop.WrapToSqueakNode;
 import de.hpi.swa.trufflesqueak.nodes.AbstractNode;
 import de.hpi.swa.trufflesqueak.nodes.LookupMethodNode;
@@ -70,8 +69,7 @@ public abstract class AbstractSqueakObject implements TruffleObject {
                     @SuppressWarnings("unused") @Bind final Node node,
                     @Cached final PerformInteropSendNode performInteropSendNode) throws Exception {
         final SqueakImageContext image = SqueakImageContext.get(node);
-        final SavedExecutionState state = image.suspendNormalExecution();
-        try {
+        try (var _ = image.suspendNormalExecution()) {
             return performInteropSendNode.execute(node, receiver, message, arguments);
         } catch (final ProcessSwitch ps) {
             CompilerDirectives.transferToInterpreter();
@@ -81,8 +79,6 @@ public abstract class AbstractSqueakObject implements TruffleObject {
             } else {
                 throw ps; // open debugger in interactive mode
             }
-        } finally {
-            image.resumeNormalExecution(state);
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/AbstractSqueakObjectWithHash.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/AbstractSqueakObjectWithHash.java
@@ -22,6 +22,7 @@ import de.hpi.swa.trufflesqueak.exceptions.SqueakExceptions;
 import de.hpi.swa.trufflesqueak.image.SqueakImageChunk;
 import de.hpi.swa.trufflesqueak.image.SqueakImageConstants;
 import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
+import de.hpi.swa.trufflesqueak.image.SqueakImageContext.SavedExecutionState;
 import de.hpi.swa.trufflesqueak.image.SqueakImageWriter;
 import de.hpi.swa.trufflesqueak.interop.LookupMethodByStringNode;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNode.DispatchIndirectNaryNode.TryPrimitiveNaryNode;
@@ -280,7 +281,7 @@ public abstract class AbstractSqueakObjectWithHash extends AbstractSqueakObject 
     public final Object send(final SqueakImageContext image, final String selector, final Object... arguments) {
         final Object methodObject = LookupMethodByStringNode.executeUncached(getSqueakClass(), selector);
         if (methodObject instanceof final CompiledCodeObject method) {
-            final boolean wasActive = image.interrupt.deactivate();
+            final SavedExecutionState state = image.suspendNormalExecution();
             try {
                 final Object result = TryPrimitiveNaryNode.executeUncached(image.externalSenderFrame, method, this, arguments);
                 if (result != null) {
@@ -289,7 +290,7 @@ public abstract class AbstractSqueakObjectWithHash extends AbstractSqueakObject 
                     return IndirectCallNode.getUncached().call(method.getCallTarget(), FrameAccess.newWith(NilObject.SINGLETON, null, this, arguments));
                 }
             } finally {
-                image.interrupt.reactivate(wasActive);
+                image.resumeNormalExecution(state);
             }
         } else {
             throw SqueakExceptions.SqueakException.create("CompiledMethodObject expected, got: " + methodObject);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/AbstractSqueakObjectWithHash.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/AbstractSqueakObjectWithHash.java
@@ -22,7 +22,6 @@ import de.hpi.swa.trufflesqueak.exceptions.SqueakExceptions;
 import de.hpi.swa.trufflesqueak.image.SqueakImageChunk;
 import de.hpi.swa.trufflesqueak.image.SqueakImageConstants;
 import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
-import de.hpi.swa.trufflesqueak.image.SqueakImageContext.SavedExecutionState;
 import de.hpi.swa.trufflesqueak.image.SqueakImageWriter;
 import de.hpi.swa.trufflesqueak.interop.LookupMethodByStringNode;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNode.DispatchIndirectNaryNode.TryPrimitiveNaryNode;
@@ -281,16 +280,13 @@ public abstract class AbstractSqueakObjectWithHash extends AbstractSqueakObject 
     public final Object send(final SqueakImageContext image, final String selector, final Object... arguments) {
         final Object methodObject = LookupMethodByStringNode.executeUncached(getSqueakClass(), selector);
         if (methodObject instanceof final CompiledCodeObject method) {
-            final SavedExecutionState state = image.suspendNormalExecution();
-            try {
+            try (var _ = image.suspendNormalExecution()) {
                 final Object result = TryPrimitiveNaryNode.executeUncached(image.externalSenderFrame, method, this, arguments);
                 if (result != null) {
                     return result;
                 } else {
                     return IndirectCallNode.getUncached().call(method.getCallTarget(), FrameAccess.newWith(NilObject.SINGLETON, null, this, arguments));
                 }
-            } finally {
-                image.resumeNormalExecution(state);
             }
         } else {
             throw SqueakExceptions.SqueakException.create("CompiledMethodObject expected, got: " + methodObject);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/AbstractSqueakObjectWithHash.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/AbstractSqueakObjectWithHash.java
@@ -280,13 +280,16 @@ public abstract class AbstractSqueakObjectWithHash extends AbstractSqueakObject 
     public final Object send(final SqueakImageContext image, final String selector, final Object... arguments) {
         final Object methodObject = LookupMethodByStringNode.executeUncached(getSqueakClass(), selector);
         if (methodObject instanceof final CompiledCodeObject method) {
-            try (var _ = image.suspendNormalExecution()) {
+            final var state = image.suspendNormalExecution();
+            try {
                 final Object result = TryPrimitiveNaryNode.executeUncached(image.externalSenderFrame, method, this, arguments);
                 if (result != null) {
                     return result;
                 } else {
                     return IndirectCallNode.getUncached().call(method.getCallTarget(), FrameAccess.newWith(NilObject.SINGLETON, null, this, arguments));
                 }
+            } finally {
+                state.close();
             }
         } else {
             throw SqueakExceptions.SqueakException.create("CompiledMethodObject expected, got: " + methodObject);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/DoItRootNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/DoItRootNode.java
@@ -16,6 +16,7 @@ import com.oracle.truffle.api.nodes.RootNode;
 
 import de.hpi.swa.trufflesqueak.SqueakLanguage;
 import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
+import de.hpi.swa.trufflesqueak.image.SqueakImageContext.SavedExecutionState;
 import de.hpi.swa.trufflesqueak.interop.WrapToSqueakNode;
 import de.hpi.swa.trufflesqueak.model.BlockClosureObject;
 import de.hpi.swa.trufflesqueak.model.NilObject;
@@ -44,11 +45,11 @@ public abstract class DoItRootNode extends RootNode {
         if (blockClosure.getNumArgs() != frame.getArguments().length) {
             return NilObject.SINGLETON;
         }
-        final boolean wasActive = image.interrupt.deactivate();
+        final SavedExecutionState state = image.suspendNormalExecution();
         try {
             return primitiveNode.execute(image.externalSenderFrame, blockClosure, wrapNode.executeWrap(node, frame.getArguments()));
         } finally {
-            image.interrupt.reactivate(wasActive);
+            image.resumeNormalExecution(state);
         }
     }
 }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/DoItRootNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/DoItRootNode.java
@@ -16,7 +16,6 @@ import com.oracle.truffle.api.nodes.RootNode;
 
 import de.hpi.swa.trufflesqueak.SqueakLanguage;
 import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
-import de.hpi.swa.trufflesqueak.image.SqueakImageContext.SavedExecutionState;
 import de.hpi.swa.trufflesqueak.interop.WrapToSqueakNode;
 import de.hpi.swa.trufflesqueak.model.BlockClosureObject;
 import de.hpi.swa.trufflesqueak.model.NilObject;
@@ -45,11 +44,8 @@ public abstract class DoItRootNode extends RootNode {
         if (blockClosure.getNumArgs() != frame.getArguments().length) {
             return NilObject.SINGLETON;
         }
-        final SavedExecutionState state = image.suspendNormalExecution();
-        try {
+        try (var _ = image.suspendNormalExecution()) {
             return primitiveNode.execute(image.externalSenderFrame, blockClosure, wrapNode.executeWrap(node, frame.getArguments()));
-        } finally {
-            image.resumeNormalExecution(state);
         }
     }
 }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/DoItRootNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/DoItRootNode.java
@@ -44,8 +44,11 @@ public abstract class DoItRootNode extends RootNode {
         if (blockClosure.getNumArgs() != frame.getArguments().length) {
             return NilObject.SINGLETON;
         }
-        try (var _ = image.suspendNormalExecution()) {
+        final var state = image.suspendNormalExecution();
+        try {
             return primitiveNode.execute(image.externalSenderFrame, blockClosure, wrapNode.executeWrap(node, frame.getArguments()));
+        } finally {
+            state.close();
         }
     }
 }


### PR DESCRIPTION
Disable context stack depth overflow detection when disabling interrupts during polyglot, uninterruptible, and internal evaluations. This prevents evaluation failure when the context stack depth is close to the limit and one of these special evaluations is required.

This PR, when used with PR #290, allows Squeak to start up and function normally with a minimum context stack depth of 1.