### PR TITLE
follow forwarding pointer when tracing specialObjectsArray

### DIFF
--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/ObjectGraphUtils.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/ObjectGraphUtils.java
@@ -534,7 +534,7 @@ public final class ObjectGraphUtils {
 
             /* Trace the special objects to give separate roots to the threads. */
             addIfUnmarked(image.specialObjectsArray);
-            tracePointers(image.specialObjectsArray);
+            tracePointers(image.specialObjectsArray.resolveForwardingPointer());
         }
 
         private void addObjectsFromFrames() {


### PR DESCRIPTION
Following the instructions for creating the [TruffleSqueak Test Image](https://github.com/hpi-swa/trufflesqueak/blob/main/docs/images.md#trufflesqueak-test-image-creation) leads to an interpreter crash.

It appears that the `specialObjectsArray` is replaced using `becomeForward:`. This PR ensures that the forwarded `specialObjectsArray` is traced.