### PR TITLE
Display scaling and default language

### DIFF
--- a/src/TruffleSqueak-Utilities.package/TruffleLauncherButton.class/instance/displayScaleChangedBy..st
+++ b/src/TruffleSqueak-Utilities.package/TruffleLauncherButton.class/instance/displayScaleChangedBy..st
@@ -1,0 +1,22 @@
+display scale
+displayScaleChangedBy: factor
+	"The system's scale factor has changed. Try to scale the receiver so that it looks nice on the display. See DisplayScreen >> #uiScaleFactor:."
+	
+	"Font pointSizes do not scale linearly so we need to keep track of the exact pointSizes that are encountered."
+	(self findA: StringMorph) ifNotNil: [ :label | | fonts oldFont oldPointSize newPointSize newFont unscaledPointSize |
+		
+		fonts := self valueOfProperty: #fontSizeTable ifAbsentPut: [ Dictionary new ].
+		
+		oldFont := label font.
+		oldPointSize := oldFont pointSize.
+		
+		newPointSize := oldPointSize * factor.
+		newFont := fonts at: newPointSize ifAbsentPut: [ oldFont asPointSize: newPointSize ].
+		
+		unscaledPointSize := newFont pointSize / factor.
+		(fonts includesKey: unscaledPointSize) ifFalse: [ fonts at: unscaledPointSize put: oldFont ].
+		
+		label font: newFont.
+	].
+
+	super displayScaleChangedBy: factor.

--- a/src/TruffleSqueak-Utilities.package/TruffleLauncherButton.class/instance/handlesDisplayScaleChangedBy..st
+++ b/src/TruffleSqueak-Utilities.package/TruffleLauncherButton.class/instance/handlesDisplayScaleChangedBy..st
@@ -1,0 +1,4 @@
+display scale
+handlesDisplayScaleChangedBy: factor
+	"Buttons placed on the desktop should automatically resize on display scale changes."
+	^ true

--- a/src/TruffleSqueak-Utilities.package/TruffleLauncherButton.class/methodProperties.json
+++ b/src/TruffleSqueak-Utilities.package/TruffleLauncherButton.class/methodProperties.json
@@ -1,0 +1,6 @@
+{
+	"class" : {
+		 },
+	"instance" : {
+		"displayScaleChangedBy:" : "sss 7/14/2026 18:23",
+		"handlesDisplayScaleChangedBy:" : "sss 7/14/2026 18:25" } }

--- a/src/TruffleSqueak-Utilities.package/TruffleLauncherButton.class/properties.json
+++ b/src/TruffleSqueak-Utilities.package/TruffleLauncherButton.class/properties.json
@@ -1,0 +1,14 @@
+{
+	"category" : "TruffleSqueak-Utilities",
+	"classinstvars" : [
+		 ],
+	"classvars" : [
+		 ],
+	"commentStamp" : "",
+	"instvars" : [
+		 ],
+	"name" : "TruffleLauncherButton",
+	"pools" : [
+		 ],
+	"super" : "SimpleButtonMorph",
+	"type" : "normal" }

--- a/src/TruffleSqueak-Utilities.package/TruffleSqueakUtilities.class/class/openButton.at..st
+++ b/src/TruffleSqueak-Utilities.package/TruffleSqueakUtilities.class/class/openButton.at..st
@@ -1,10 +1,19 @@
 helpers
 openButton: anExpression at: aPosition
-	| textMorph ws editor |
+	| ws textMorph editor |
+	
 	ws := Workspace open.
 	ws contents: anExpression.
+	
 	textMorph := ws codeTextMorph.
-	editor := (textMorph findDeepSubmorphThat: [:m | m respondsTo: #editor ] ifAbsent: nil) editor.
+	
+	editor := (textMorph findDeepSubmorphThat: [ :m | m respondsTo: #editor ] ifAbsent: nil) editor.
 	editor selectAll.
-	editor doItButtonFromSelection ifNotNil: [:e | e openInWorld. e position: aPosition].
+	editor doItButtonFromSelection ifNotNil: [ :e |
+		e
+			changeClassTo: TruffleLauncherButton;
+			openInWorld;
+			position: aPosition
+	].
+
 	textMorph owner delete

--- a/src/TruffleSqueak-Utilities.package/TruffleSqueakUtilities.class/class/setUpImage.st
+++ b/src/TruffleSqueak-Utilities.package/TruffleSqueakUtilities.class/class/setUpImage.st
@@ -6,6 +6,9 @@ setUpImage
 	PolyglotToolSet register.
 	ToolSet default: PolyglotToolSet.
 	
+	"Set a default language."
+	Polyglot askForDefaultLanguageInfo.
+	
 	"Ensure FullBlockClosure is in special objects array"
 	(Smalltalk specialObjectsArray at: 38) ifNil:
 		[ Smalltalk specialObjectsArray at: 38 put: FullBlockClosure ].

--- a/src/TruffleSqueak-Utilities.package/TruffleSqueakUtilities.class/class/setUpImage.st
+++ b/src/TruffleSqueak-Utilities.package/TruffleSqueakUtilities.class/class/setUpImage.st
@@ -1,6 +1,8 @@
 image creation
 setUpImage
 	"Install polyglot tools"
+	| currentScale |
+	
 	PolyglotToolSet register.
 	ToolSet default: PolyglotToolSet.
 	
@@ -36,19 +38,21 @@ setUpImage
 	
 	self closeAllWindowsAndMorphs.
 
-	self openButton: PolyglotWorkspace asString, ' open' at: 20@28.
-	self openButton: PolyglotNotebook asString, ' open' at: 190@28.
+	currentScale := Display platformScaleFactor.	
+
+	self openButton: PolyglotWorkspace asString, ' open' at: 20@28 * currentScale.
+	self openButton: PolyglotNotebook asString, ' open' at: 190@28 * currentScale.
 
 	self logo asMorph
-		position: 650@28;
+		position: 650@28 * currentScale;
 		borderWidth: 10;
 		setToAdhereToEdge: #bottomRight;
 		beSticky;
 		openInWorld.
 
 	PolyglotWorkspace open
-		position: 20@60;
-		extent: 600@300.
+		position: 20@60 * currentScale;
+		extent: 600@300 * currentScale.
 
 	"Clean up image"
 	Smalltalk garbageCollect.

--- a/src/TruffleSqueak-Utilities.package/TruffleSqueakUtilities.class/methodProperties.json
+++ b/src/TruffleSqueak-Utilities.package/TruffleSqueakUtilities.class/methodProperties.json
@@ -10,7 +10,7 @@
 		"logo" : "fn 5/6/2020 19:01",
 		"openArraySizeHistogram" : "fn 3/23/2020 18:27",
 		"openBouncingAtomsMorph" : "fn 3/29/2021 22:02",
-		"openButton:at:" : "fn 1/27/2020 11:41",
+		"openButton:at:" : "sss 7/14/2026 15:43",
 		"openFrameRateMorph" : "fn 3/29/2021 22:02",
 		"openLocationSizeHistogram" : "fn 3/23/2020 10:59",
 		"openLocationsHistogram:" : "fn 2/1/2021 14:59",
@@ -23,7 +23,7 @@
 		"primitiveVMObjectToHostObject:" : "fn 10/21/2021 09:06",
 		"registerInWorldMenu" : "fn 3/30/2021 10:31",
 		"setUpAfterLoadingPackages" : "fn 7/20/2021 12:38",
-		"setUpImage" : "fn 7/16/2021 10:15",
+		"setUpImage" : "sss 7/14/2026 15:46",
 		"setUpTestImage" : "fn 3/30/2021 09:45",
 		"setUpUIBenchmark" : "fn 7/16/2021 10:32" },
 	"instance" : {

--- a/src/TruffleSqueak-Utilities.package/TruffleSqueakUtilities.class/methodProperties.json
+++ b/src/TruffleSqueak-Utilities.package/TruffleSqueakUtilities.class/methodProperties.json
@@ -23,7 +23,7 @@
 		"primitiveVMObjectToHostObject:" : "fn 10/21/2021 09:06",
 		"registerInWorldMenu" : "fn 3/30/2021 10:31",
 		"setUpAfterLoadingPackages" : "fn 7/20/2021 12:38",
-		"setUpImage" : "sss 7/14/2026 15:46",
+		"setUpImage" : "sss 7/15/2026 19:57",
 		"setUpTestImage" : "fn 3/30/2021 09:45",
 		"setUpUIBenchmark" : "fn 7/16/2021 10:32" },
 	"instance" : {


### PR DESCRIPTION
This PR changes the `Polyglot` desktop buttons so that they resize properly when opened on a high-DPI screen. It also prompts for the default `Polyglot` language so that the displayed workspace (and subsequent workspaces opened by the desktop button) have a language selected.

**Recommended:** If the TruffleSqueak image is created on a `displayScale = 1.0` screen it will look good when opened on any DPI screen.

If the `displayScale = 2.0` when the image is created, the text in the desktop buttons will be small when displayed on a `displayScale = 1.0` screen. (The font sizing complication is due to `StrikeFont` having a small set of fixed font sizes to choose from.)