### PR TITLE
Guard for forwarded class in super-send dispatch

### DIFF
--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/AbstractSqueakObjectWithHash.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/AbstractSqueakObjectWithHash.java
@@ -9,7 +9,6 @@ package de.hpi.swa.trufflesqueak.model;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 
-import com.oracle.truffle.api.dsl.Idempotent;
 import org.graalvm.collections.UnmodifiableEconomicMap;
 
 import com.oracle.truffle.api.CompilerAsserts;
@@ -196,7 +195,6 @@ public abstract class AbstractSqueakObjectWithHash extends AbstractSqueakObject 
         squeakHashAndBits |= FORWARDED_BIT;
     }
 
-    @Idempotent
     public final boolean isNotForwarded() {
         return (squeakHashAndBits & FORWARDED_BIT) == 0;
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/AbstractSqueakObjectWithHash.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/AbstractSqueakObjectWithHash.java
@@ -9,6 +9,7 @@ package de.hpi.swa.trufflesqueak.model;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 
+import com.oracle.truffle.api.dsl.Idempotent;
 import org.graalvm.collections.UnmodifiableEconomicMap;
 
 import com.oracle.truffle.api.CompilerAsserts;
@@ -195,6 +196,7 @@ public abstract class AbstractSqueakObjectWithHash extends AbstractSqueakObject 
         squeakHashAndBits |= FORWARDED_BIT;
     }
 
+    @Idempotent
     public final boolean isNotForwarded() {
         return (squeakHashAndBits & FORWARDED_BIT) == 0;
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ClassObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ClassObject.java
@@ -313,6 +313,10 @@ public final class ClassObject extends AbstractSqueakObjectWithClassAndHash {
         return superclass;
     }
 
+    public ClassObject resolveAndGetResolvedSuperclass() {
+        return ((ClassObject) resolveForwardingPointer()).getResolvedSuperclass();
+    }
+
     public ClassObject getResolvedSuperclass() {
         assert assertNotForwarded();
         if (!superclass.isNotForwarded()) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ClassObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ClassObject.java
@@ -313,10 +313,6 @@ public final class ClassObject extends AbstractSqueakObjectWithClassAndHash {
         return superclass;
     }
 
-    public ClassObject resolveAndGetResolvedSuperclass() {
-        return ((ClassObject) resolveForwardingPointer()).getResolvedSuperclass();
-    }
-
     public ClassObject getResolvedSuperclass() {
         assert assertNotForwarded();
         if (!superclass.isNotForwarded()) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/CompiledCodeObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/CompiledCodeObject.java
@@ -20,6 +20,7 @@ import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.dsl.Idempotent;
+import com.oracle.truffle.api.dsl.NeverDefault;
 import com.oracle.truffle.api.dsl.NonIdempotent;
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.source.Source;
@@ -563,7 +564,7 @@ public final class CompiledCodeObject extends AbstractSqueakObjectWithClassAndHa
         } else {
             String className = "UnknownClass";
             String selector = "unknownSelector";
-            final ClassObject methodClass = getMethodClassSlow();
+            final ClassObject methodClass = getMethodClassOrNullSlow();
             if (methodClass != null) {
                 className = methodClass.getClassName();
             }
@@ -699,7 +700,17 @@ public final class CompiledCodeObject extends AbstractSqueakObjectWithClassAndHa
         }
     }
 
+    @NeverDefault
     public ClassObject getMethodClassSlow() {
+        final ClassObject methodClass = getMethodClassOrNullSlow();
+        if (methodClass != null) {
+            return methodClass;
+        } else {
+            throw CompilerDirectives.shouldNotReachHere();
+        }
+    }
+
+    public ClassObject getMethodClassOrNullSlow() {
         CompilerAsserts.neverPartOfCompilation();
         final AbstractPointersObjectReadNode readNode = AbstractPointersObjectReadNode.getUncached();
         if (hasMethodClass(readNode)) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/CompiledCodeObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/CompiledCodeObject.java
@@ -21,7 +21,6 @@ import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.dsl.Idempotent;
 import com.oracle.truffle.api.dsl.NeverDefault;
-import com.oracle.truffle.api.dsl.NonIdempotent;
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.utilities.CyclicAssumption;
@@ -678,7 +677,7 @@ public final class CompiledCodeObject extends AbstractSqueakObjectWithClassAndHa
     }
 
     /** CompiledMethod>>#methodClassAssociation. */
-    private Object getMethodClassAssociation() {
+    private AbstractPointersObject getMethodClassAssociation() {
         /*
          * From the CompiledMethod class description:
          *
@@ -688,7 +687,7 @@ public final class CompiledCodeObject extends AbstractSqueakObjectWithClassAndHa
          * may be nil (as would be the case for example of methods providing a pool of inst var
          * accessors).
          */
-        return literals[getNumLiterals() - 1];
+        return (AbstractPointersObject) literals[getNumLiterals() - 1];
     }
 
     public boolean hasMethodClass(final AbstractPointersObjectReadNode readNode) {
@@ -719,7 +718,7 @@ public final class CompiledCodeObject extends AbstractSqueakObjectWithClassAndHa
                 return methodClass;
             } else {
                 final ClassObject forwardedMethodClass = (ClassObject) methodClass.getForwardingPointer();
-                AbstractPointersObjectWriteNode.executeUncached((AbstractPointersObject) getMethodClassAssociation(), CLASS_BINDING.VALUE, forwardedMethodClass);
+                AbstractPointersObjectWriteNode.executeUncached(getMethodClassAssociation(), CLASS_BINDING.VALUE, forwardedMethodClass);
                 return forwardedMethodClass;
             }
         }
@@ -727,9 +726,8 @@ public final class CompiledCodeObject extends AbstractSqueakObjectWithClassAndHa
     }
 
     /** CompiledMethod>>#methodClass. */
-    @NonIdempotent
-    public ClassObject getMethodClass(final AbstractPointersObjectReadNode readNode) {
-        return (ClassObject) readNode.execute((AbstractPointersObject) getMethodClassAssociation(), CLASS_BINDING.VALUE);
+    private ClassObject getMethodClass(final AbstractPointersObjectReadNode readNode) {
+        return (ClassObject) readNode.execute(getMethodClassAssociation(), CLASS_BINDING.VALUE);
     }
 
     public long getHeader() {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
@@ -92,16 +92,17 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
     }
 
     public abstract static class DispatchSuperNaryNode extends AbstractDispatchNaryNode {
-        protected final ClassObject methodClass;
+        protected final CompiledCodeObject method;
 
-        DispatchSuperNaryNode(final ClassObject methodClass, final NativeObject selector) {
+        DispatchSuperNaryNode(final CompiledCodeObject codeObject, final NativeObject selector) {
             super(selector);
-            this.methodClass = methodClass;
+            this.method = codeObject.getMethod();
         }
 
-        @Specialization(assumptions = {"methodClass.getClassHierarchyAndMethodDictStable()", "dispatchDirectNode.getAssumptions()"})
+        @Specialization(assumptions = {"cachedMethodClass.getClassHierarchyAndMethodDictStable()", "dispatchDirectNode.getAssumptions()"})
         protected static final Object doCached(final VirtualFrame frame, final Object receiver, final Object[] arguments,
-                        @Cached("create(selector, methodClass.resolveAndGetResolvedSuperclass())") final DispatchDirectNaryNode dispatchDirectNode) {
+                        @SuppressWarnings("unused") @Cached("method.getMethodClassSlow()") final ClassObject cachedMethodClass,
+                        @Cached("create(selector, cachedMethodClass.getResolvedSuperclass())") final DispatchDirectNaryNode dispatchDirectNode) {
             return dispatchDirectNode.execute(frame, receiver, arguments);
         }
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
@@ -41,7 +41,6 @@ import de.hpi.swa.trufflesqueak.nodes.LookupMethodNode;
 import de.hpi.swa.trufflesqueak.nodes.accessing.AbstractPointersObjectNodes.AbstractPointersObjectWriteNode;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectClassNode;
 import de.hpi.swa.trufflesqueak.nodes.context.GetOrCreateContextWithoutFrameNode;
-import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNodeFactory.DispatchSuperNaryNodeGen;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNodeFactory.DispatchDirectPrimitiveFallbackNaryNodeGen;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNodeFactory.DispatchIndirectNaryNodeGen.TryPrimitiveNaryNodeGen;
 import de.hpi.swa.trufflesqueak.nodes.primitives.AbstractPrimitiveNode;
@@ -100,22 +99,11 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
             this.methodClass = methodClass;
         }
 
-        @Specialization(guards = "methodClass.isNotForwarded()", assumptions = {"methodClass.getClassHierarchyAndMethodDictStable()",
-                        "dispatchDirectNode.getAssumptions()"})
+        @Specialization(assumptions = {"methodClass.getClassHierarchyAndMethodDictStable()", "dispatchDirectNode.getAssumptions()"})
         protected static final Object doCached(final VirtualFrame frame, final Object receiver, final Object[] arguments,
-                        @Cached("create(selector, methodClass.getResolvedSuperclass())") final DispatchDirectNaryNode dispatchDirectNode) {
+                        @Cached("create(selector, methodClass.resolveAndGetResolvedSuperclass())") final DispatchDirectNaryNode dispatchDirectNode) {
             return dispatchDirectNode.execute(frame, receiver, arguments);
         }
-
-        @Specialization(guards = "!methodClass.isNotForwarded()")
-        protected final Object doForwarded(final VirtualFrame frame, final Object receiver, final Object[] arguments) {
-            CompilerDirectives.transferToInterpreterAndInvalidate();
-            final ClassObject newMethodClass = (ClassObject) methodClass.resolveForwardingPointer();
-            final DispatchSuperNaryNode newNode = DispatchSuperNaryNodeGen.create(newMethodClass, selector);
-            return this.replace(newNode).execute(frame, receiver, arguments);
-        }
-
-        public abstract Object execute(VirtualFrame frame, Object receiver, Object[] arguments);
     }
 
     public abstract static class DispatchDirectedSuperNaryNode extends AbstractDispatchNode {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
@@ -96,7 +96,7 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
 
         DispatchSuperNaryNode(final CompiledCodeObject codeObject, final NativeObject selector) {
             super(selector);
-            this.method = codeObject.getMethod();
+            method = codeObject.getMethod();
         }
 
         @Specialization(assumptions = {"cachedMethodClass.getClassHierarchyAndMethodDictStable()", "dispatchDirectNode.getAssumptions()"})

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
@@ -41,6 +41,7 @@ import de.hpi.swa.trufflesqueak.nodes.LookupMethodNode;
 import de.hpi.swa.trufflesqueak.nodes.accessing.AbstractPointersObjectNodes.AbstractPointersObjectWriteNode;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectClassNode;
 import de.hpi.swa.trufflesqueak.nodes.context.GetOrCreateContextWithoutFrameNode;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNodeFactory.DispatchSuperNaryNodeGen;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNodeFactory.DispatchDirectPrimitiveFallbackNaryNodeGen;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNodeFactory.DispatchIndirectNaryNodeGen.TryPrimitiveNaryNodeGen;
 import de.hpi.swa.trufflesqueak.nodes.primitives.AbstractPrimitiveNode;
@@ -99,11 +100,22 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
             this.methodClass = methodClass;
         }
 
-        @Specialization(assumptions = {"methodClass.getClassHierarchyAndMethodDictStable()", "dispatchDirectNode.getAssumptions()"})
+        @Specialization(guards = "methodClass.isNotForwarded()", assumptions = {"methodClass.getClassHierarchyAndMethodDictStable()",
+                        "dispatchDirectNode.getAssumptions()"})
         protected static final Object doCached(final VirtualFrame frame, final Object receiver, final Object[] arguments,
                         @Cached("create(selector, methodClass.getResolvedSuperclass())") final DispatchDirectNaryNode dispatchDirectNode) {
             return dispatchDirectNode.execute(frame, receiver, arguments);
         }
+
+        @Specialization(guards = "!methodClass.isNotForwarded()")
+        protected final Object doForwarded(final VirtualFrame frame, final Object receiver, final Object[] arguments) {
+            CompilerDirectives.transferToInterpreterAndInvalidate();
+            final ClassObject newMethodClass = (ClassObject) methodClass.resolveForwardingPointer();
+            final DispatchSuperNaryNode newNode = DispatchSuperNaryNodeGen.create(newMethodClass, selector);
+            return this.replace(newNode).execute(frame, receiver, arguments);
+        }
+
+        public abstract Object execute(VirtualFrame frame, Object receiver, Object[] arguments);
     }
 
     public abstract static class DispatchDirectedSuperNaryNode extends AbstractDispatchNode {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterSistaV1Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterSistaV1Node.java
@@ -340,8 +340,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                     if (isDirected) {
                         node = DispatchDirectedSuperNaryNodeGen.create(selector);
                     } else {
-                        final ClassObject methodClass = code.getMethod().getMethodClassSlow();
-                        node = DispatchSuperNaryNodeGen.create(methodClass, selector);
+                        node = DispatchSuperNaryNodeGen.create(code, selector);
                     }
                     setData(currentPC, insert(node));
                     vstate.resetExtAB();

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterV3PlusClosuresNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterV3PlusClosuresNode.java
@@ -23,7 +23,6 @@ import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
 import de.hpi.swa.trufflesqueak.model.AbstractSqueakObjectWithClassAndHash;
 import de.hpi.swa.trufflesqueak.model.ArrayObject;
 import de.hpi.swa.trufflesqueak.model.BooleanObject;
-import de.hpi.swa.trufflesqueak.model.ClassObject;
 import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
 import de.hpi.swa.trufflesqueak.model.NativeObject;
 import de.hpi.swa.trufflesqueak.model.NilObject;
@@ -162,8 +161,7 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                         }
                         case 1: {
                             final NativeObject selector = (NativeObject) code.getLiteral(byte3);
-                            final ClassObject methodClass = code.getMethod().getMethodClassSlow();
-                            setData(currentPC, insert(DispatchSuperNaryNodeGen.create(methodClass, selector)));
+                            setData(currentPC, insert(DispatchSuperNaryNodeGen.create(code, selector)));
                             break;
                         }
                         case 2: {
@@ -189,8 +187,7 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                 }
                 case BC.SINGLE_EXTENDED_SUPER: {
                     final NativeObject selector = (NativeObject) code.getLiteral(getByte(bc, pc++) & 0x1F);
-                    final ClassObject methodClass = code.getMethod().getMethodClassSlow();
-                    setData(currentPC, insert(DispatchSuperNaryNodeGen.create(methodClass, selector)));
+                    setData(currentPC, insert(DispatchSuperNaryNodeGen.create(code, selector)));
                     break;
                 }
                 case BC.SECOND_EXTENDED_SEND: {


### PR DESCRIPTION
During `processBytecode()`, `InterpreterSistaV1Node` and `InterpreterV3PlusClosuresNode` cache the method's class in a `DispatchSuperNaryNode` when processing an `EXT_SEND_SUPER` byte code.

If that cached class is mutated during execution, the class will be forwarded to its replacement but the `DispatchSuperNaryNode` will continue to dispatch to the pre-mutation superclass.

This PR adds a guard to ensure that the cached class has not been forwarded. If the class is forwarded, the node is replaced with a new node that caches the forwarded class.

The following code snippet demonstrates the problem and fails on `main` and works correctly with the changes in this PR.

```
| superA superB subClass instance result |

"1. Create the Old Superclass (returns 1)"
superA := Object subclass: #SuperSendTestA 
    instanceVariableNames: '' 
    classVariableNames: '' 
    poolDictionaries: '' 
    category: 'TruffleSqueak-Tests'.
superA compile: 'dummy: a with: b with: c ^ 1'.

"2. Create the New Superclass (returns 2)"
superB := Object subclass: #SuperSendTestB
    instanceVariableNames: '' 
    classVariableNames: '' 
    poolDictionaries: '' 
    category: 'TruffleSqueak-Tests'.
superB compile: 'dummy: a with: b with: c ^ 2'.

"3. Create our Target Class, initially inheriting from SuperA"
subClass := superA subclass: #SuperSendTestSub 
    instanceVariableNames: '' 
    classVariableNames: '' 
    poolDictionaries: '' 
    category: 'TruffleSqueak-Tests'.

"4. The Time Bomb: A method that changes its own superclass mid-execution"
subClass compile: 'doMutatingSuperSend
    "Redefine the class to inherit from SuperB. This triggers a becomeForward:"
    SuperSendTestB subclass: #SuperSendTestSub 
        instanceVariableNames: '''' 
        classVariableNames: '''' 
        poolDictionaries: '''' 
        category: ''TruffleSqueak-Tests''.
        
    "Execute extended super send. 
     - Unpatched AST will use the stale class and call SuperA >> dummy (returns 1).
     - Patched AST will heal itself, follow the forwarding pointer to the new class, 
       and call SuperB >> dummy (returns 2)."
    ^ super dummy: 1 with: 2 with: 3'.

"5. Execute the test"
instance := subClass new.
result := instance doMutatingSuperSend.

"6. Cleanup"
subClass removeFromSystem.
superA removeFromSystem.
superB removeFromSystem.

"7. Assert the fix"
self assert: result = 2.
^ 'Success: The AST healed and returned ', result printString
```
