### PR TITLE
ephemeronsQueue is now accessed by more than one thread

### DIFF
--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
@@ -209,6 +209,7 @@ public final class SqueakImageContext {
 
     /* Ephemeron support */
     public boolean containsEphemerons;
+    public final ConcurrentLinkedDeque<EphemeronObject> pendingEphemeronsQueue = new ConcurrentLinkedDeque<>();
     public final ConcurrentLinkedDeque<EphemeronObject> ephemeronsQueue = new ConcurrentLinkedDeque<>();
 
     /* Context stack depth */
@@ -929,9 +930,35 @@ public final class SqueakImageContext {
         }
     }
 
-    public void checkForPendingFinalizations() {
-        if (weakPointersQueue.poll() != null /* has pending finalizations? */ ||
-                        (containsEphemerons && !ephemeronsQueue.isEmpty()) /* has pending ephemerons? */) {
+    /**
+     * Drains pending finalization queues and signals the VM if necessary.
+     * <p>
+     * This method is synchronized because it is called concurrently by two different threads:
+     * 1. The background CheckForInterruptsThread (polling continuously).
+     * 2. The main interpreter thread (via GCHelper.doGC() after manual GC primitives).
+     * <p>
+     * Synchronization prevents race conditions when transferring elements between the
+     * lock-free queues and ensuring the interrupt trigger is only fired once per batch.
+     */
+    public synchronized void checkForPendingFinalizations() {
+        boolean triggerInterrupt = false;
+
+        // Drain pending ephemerons into the main queue
+        if (containsEphemerons) {
+            EphemeronObject ephemeron;
+            while ((ephemeron = pendingEphemeronsQueue.pollFirst()) != null) {
+                ephemeronsQueue.addLast(ephemeron);
+                triggerInterrupt = true;
+            }
+        }
+
+        // ToDo: This assumes image.flags.enqueueWeakArrays() is false
+        // Drop weak pointers and trigger if any existed
+        if (weakPointersQueue.poll() != null) {
+            triggerInterrupt = true;
+        }
+
+        if (triggerInterrupt) {
             interrupt.setPendingFinalizations();
         }
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
@@ -8,9 +8,9 @@ package de.hpi.swa.trufflesqueak.image;
 
 import java.lang.foreign.SymbolLookup;
 import java.lang.ref.ReferenceQueue;
-import java.util.ArrayDeque;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.logging.Level;
 
 import org.graalvm.collections.UnmodifiableEconomicMap;
@@ -209,7 +209,7 @@ public final class SqueakImageContext {
 
     /* Ephemeron support */
     public boolean containsEphemerons;
-    public final ArrayDeque<EphemeronObject> ephemeronsQueue = new ArrayDeque<>();
+    public final ConcurrentLinkedDeque<EphemeronObject> ephemeronsQueue = new ConcurrentLinkedDeque<>();
 
     /* Context stack depth */
     @CompilationFinal private final int maxContextStackDepth;

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageFlags.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageFlags.java
@@ -32,6 +32,7 @@ import com.oracle.truffle.api.dsl.Idempotent;
 public final class SqueakImageFlags {
 
     private static final int PREEMPTION_DOES_NOT_YIELD = 0x010;
+    private static final int ENQUEUE_WEAKARRAYS_ON_FINALIZATION = 0x040;
     private static final int NUMERIC_PRIMS_MIX_ARITHMETIC = 0x100;
     private static final int NUMERIC_PRIMS_MIX_COMPARISON = 0x800;
     private static final int UPSCALE_DISPLAY_IF_HIGH_DPI = 0x400;
@@ -46,6 +47,7 @@ public final class SqueakImageFlags {
     @CompilationFinal private boolean numericPrimsMixArithmetic;
     @CompilationFinal private boolean numericPrimsMixComparison;
     @CompilationFinal private boolean preemptionYields;
+    @CompilationFinal private boolean enqueueWeakArrays;
 
     public void initialize(final long oldBaseAddressValue, final long flags, final long snapshotScreenSize, final int lastMaxExternalSemaphoreTableSize) {
         CompilerAsserts.neverPartOfCompilation();
@@ -90,6 +92,7 @@ public final class SqueakImageFlags {
             numericPrimsUpdateNewBehavior();
         }
         preemptionYields = (headerFlags & PREEMPTION_DOES_NOT_YIELD) == 0;
+        enqueueWeakArrays = (headerFlags & ENQUEUE_WEAKARRAYS_ON_FINALIZATION) != 0;
     }
 
     // For some reason, header flags appear to be shifted by 2 (see #getImageHeaderFlagsParameter).
@@ -154,6 +157,15 @@ public final class SqueakImageFlags {
             CompilerDirectives.transferToInterpreterAndInvalidate();
         }
         return preemptionYields;
+    }
+
+    @Idempotent
+    public boolean enqueueWeakArrays() {
+        // When true, a terminated entry in a WeakArray causes the WeakArray to be enqueued.
+        if (!headerFlagsAssumption.isValid()) {
+            CompilerDirectives.transferToInterpreterAndInvalidate();
+        }
+        return enqueueWeakArrays;
     }
 
     @Idempotent

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageReader.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageReader.java
@@ -78,6 +78,7 @@ public final class SqueakImageReader {
             throw SqueakException.create("Failed to read Smalltalk image:", e.getMessage());
         }
         initObjects();
+        assert !image.flags.enqueueWeakArrays() : "WeakArray enqueuing into finalization queue not yet supported";
         LogUtils.IMAGE.fine(() -> "Image loaded in " + (MiscUtils.currentTimeMillis() - start) + "ms.");
         LogUtils.IMAGE.fine(() -> "Image screen size is " + image.flags.getScreenWidth() + "x" + image.flags.getScreenHeight() + ", HighDPI is " + (image.flags.upscaleDisplayIfHighDPI() ? "enabled"
                         : "disabled"));

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interrupts/CheckForInterruptsState.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interrupts/CheckForInterruptsState.java
@@ -9,6 +9,7 @@ package de.hpi.swa.trufflesqueak.nodes.interrupts;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.LockSupport;
 
 import com.oracle.truffle.api.CompilerAsserts;
@@ -54,6 +55,7 @@ public final class CheckForInterruptsState {
     private volatile long nextWakeupTick;
     private volatile boolean interruptPending;
     private volatile boolean hasPendingFinalizations;
+    private final AtomicBoolean pendingFinalizationsLatch = new AtomicBoolean(false);
     @SuppressWarnings("unused") private boolean shouldTrigger;
 
     private Thread thread;
@@ -229,10 +231,17 @@ public final class CheckForInterruptsState {
         }
     }
 
+    public void resetPendingFinalizationsLatch() {
+        pendingFinalizationsLatch.set(false);
+    }
+
     public void setPendingFinalizations() {
-        hasPendingFinalizations = true;
-        SHOULD_TRIGGER.setOpaque(this, true);
-        wakeupVM();
+        // Only trigger the VM interrupt if the latch wasn't already set
+        if (pendingFinalizationsLatch.compareAndSet(false, true)) {
+            hasPendingFinalizations = true;
+            SHOULD_TRIGGER.setOpaque(this, true);
+            wakeupVM();
+        }
     }
 
     /* Semaphore interrupts */
@@ -269,6 +278,7 @@ public final class CheckForInterruptsState {
         nextWakeupTick = 0;
         interruptPending = false;
         hasPendingFinalizations = false;
+        pendingFinalizationsLatch.set(false);
         clearWeakPointersQueue();
         semaphoresToSignal.clear();
         clearShouldTrigger();

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interrupts/CheckForInterruptsState.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interrupts/CheckForInterruptsState.java
@@ -55,7 +55,6 @@ public final class CheckForInterruptsState {
     private volatile long nextWakeupTick;
     private volatile boolean interruptPending;
     private volatile boolean hasPendingFinalizations;
-    private final AtomicBoolean pendingFinalizationsLatch = new AtomicBoolean(false);
     @SuppressWarnings("unused") private boolean shouldTrigger;
 
     private Thread thread;
@@ -231,17 +230,13 @@ public final class CheckForInterruptsState {
         }
     }
 
-    public void resetPendingFinalizationsLatch() {
-        pendingFinalizationsLatch.set(false);
-    }
-
     public void setPendingFinalizations() {
-        // Only trigger the VM interrupt if the latch wasn't already set
-        if (pendingFinalizationsLatch.compareAndSet(false, true)) {
-            hasPendingFinalizations = true;
-            SHOULD_TRIGGER.setOpaque(this, true);
-            wakeupVM();
-        }
+        // ToDo: This assumes image.flags.enqueueWeakArrays() is false
+        // We need to signal only once for all pending WeakPointers finalizations.
+        clearWeakPointersQueue();
+        hasPendingFinalizations = true;
+        SHOULD_TRIGGER.setOpaque(this, true);
+        wakeupVM();
     }
 
     /* Semaphore interrupts */
@@ -278,7 +273,6 @@ public final class CheckForInterruptsState {
         nextWakeupTick = 0;
         interruptPending = false;
         hasPendingFinalizations = false;
-        pendingFinalizationsLatch.set(false);
         clearWeakPointersQueue();
         semaphoresToSignal.clear();
         clearShouldTrigger();

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/MiscellaneousPrimitives.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/MiscellaneousPrimitives.java
@@ -600,7 +600,10 @@ public final class MiscellaneousPrimitives extends AbstractPrimitiveFactoryHolde
     protected static final class PrimFetchMournerNode extends AbstractSingletonPrimitiveNode implements Primitive0 {
         @Override
         public Object execute(final VirtualFrame frame, final Object receiver) {
-            return NilObject.nullToNil(getContext().ephemeronsQueue.pollFirst());
+            // Reset the latch because the Smalltalk image is actively processing the queue
+            final SqueakImageContext image = getContext();
+            image.interrupt.resetPendingFinalizationsLatch();
+            return NilObject.nullToNil(image.ephemeronsQueue.pollFirst());
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/MiscellaneousPrimitives.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/MiscellaneousPrimitives.java
@@ -600,9 +600,12 @@ public final class MiscellaneousPrimitives extends AbstractPrimitiveFactoryHolde
     protected static final class PrimFetchMournerNode extends AbstractSingletonPrimitiveNode implements Primitive0 {
         @Override
         public Object execute(final VirtualFrame frame, final Object receiver) {
-            // Reset the latch because the Smalltalk image is actively processing the queue
+            /* OSVM: "Answer the top mourner (ephemeron or weak array) from the queue or
+	         * nil if the queue is empty. We don't care about order; ephemerons are
+	         * fired in an arbitrary order based on where they are in the heap."
+             */
+            // ToDo: This assumes image.flags.enqueueWeakArrays() is false
             final SqueakImageContext image = getContext();
-            image.interrupt.resetPendingFinalizationsLatch();
             return NilObject.nullToNil(image.ephemeronsQueue.pollFirst());
         }
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/ObjectGraphUtils.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/ObjectGraphUtils.java
@@ -417,10 +417,10 @@ public final class ObjectGraphUtils {
         traceRemainingEphemerons(ephemeronsToBeTraced, roots);
 
         // Make sure that they do not signal more than once.
-        image.ephemeronsQueue.addAll(ephemeronsToBeTraced);
         for (EphemeronObject ephemeronObject : ephemeronsToBeTraced) {
             ephemeronObject.setHasBeenSignaled();
         }
+        image.pendingEphemeronsQueue.addAll(ephemeronsToBeTraced);
         if (trackOperations) {
             ObjectGraphOperations.CHECK_EPHEMERONS.addNanos(System.nanoTime() - startTime);
         }
@@ -526,6 +526,9 @@ public final class ObjectGraphUtils {
              * disk, but by tracing them we avoid an expensive reachability test in the
              * fetch-next-mourner primitive.
              */
+            for (final AbstractSqueakObjectWithHash object : image.pendingEphemeronsQueue) {
+                addIfUnmarked(object);
+            }
             for (final AbstractSqueakObjectWithHash object : image.ephemeronsQueue) {
                 addIfUnmarked(object);
             }


### PR DESCRIPTION
The first commit is definitely needed; the second may be too stringent. What I was seeing is that the tests were timing out and the semaphore had ~50000 excess signals.

I am still seeing the too many open files errors locally.

Later: I realize now that the test that prevents the signaling of the semaphore should be moved to the test in `image`, prior to the poll of the weak references queue. I can do this tomorrow if you haven't already finished your PR before then.