### PR TITLE
Refine dispatch fallbacks (DNU/CI) and optimize extended sends

### DIFF
--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
@@ -166,7 +166,8 @@ public final class SqueakImageContext {
     // The maximum message arity that supports DNU shortcuts.
     public static final int MAX_DNU_SHORTCUT_ARITY = 3;
 
-    @CompilationFinal(dimensions = 1) private NativeObject[] dnuShortcutSelectors = new NativeObject[0];
+    @CompilationFinal private Assumption dnuShortcutsAbsent = Truffle.getRuntime().createAssumption("DNU shortcuts");
+    @CompilationFinal(dimensions = 1) private NativeObject[] dnuShortcutSelectors = null;
 
     /* Method Cache */
     private static final int METHOD_CACHE_SIZE = 2 << 12;
@@ -478,16 +479,44 @@ public final class SqueakImageContext {
         return null;
     }
 
+    public boolean hasDNUShortcut(final int arity) {
+        return hasDNUShortcuts() && arity < MAX_DNU_SHORTCUT_ARITY + 1;
+    }
+
+    public boolean hasDNUShortcuts() {
+        assert (dnuShortcutSelectors == null) == dnuShortcutsAbsent.isValid() : "DNU shortcuts assumption out of sync";
+        return dnuShortcutSelectors != null;
+    }
+
+    public Assumption getDnuShortcutsAbsent() {
+        return dnuShortcutsAbsent;
+    }
+
     public void setDNUShortcutSelectors(final NativeObject[] newSelectors) {
         CompilerDirectives.transferToInterpreterAndInvalidate();
+
+        if (newSelectors != null) {
+            // Invalidate the fast-path assumption if it's currently valid.
+            if (dnuShortcutsAbsent.isValid()) {
+                dnuShortcutsAbsent.invalidate("DNU shortcuts set");
+            }
+        } else {
+            // Recreate the assumption so the fast path can recover.
+            if (!dnuShortcutsAbsent.isValid()) {
+                dnuShortcutsAbsent = Truffle.getRuntime().createAssumption("DNU shortcuts");
+            }
+        }
+
         dnuShortcutSelectors = newSelectors;
         flushMethodCache();
     }
 
     private boolean isDNUShortcutSelector(final NativeObject selector) {
-        for (final NativeObject shortcutSelector : dnuShortcutSelectors) {
-            if (selector == shortcutSelector) {
-                return true;
+        if (hasDNUShortcuts()) {
+            for (final NativeObject shortcutSelector : dnuShortcutSelectors) {
+                if (selector == shortcutSelector) {
+                    return true;
+                }
             }
         }
         return false;
@@ -717,7 +746,6 @@ public final class SqueakImageContext {
         }
     }
 
-    @TruffleBoundary
     public Assumption getAbsentSelectorAssumption(final NativeObject selector) {
         CyclicAssumption absentAssumption = absentSelectorAssumptions.get(selector);
         if (absentAssumption == null) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 
+import org.graalvm.collections.EconomicMap;
 import org.graalvm.collections.UnmodifiableEconomicMap;
 
 import com.oracle.truffle.api.Assumption;
@@ -130,7 +131,7 @@ public final class SqueakImageContext {
     @CompilationFinal private ClassObject doubleByteArrayClass;
     @CompilationFinal private ClassObject wordArrayClass;
     @CompilationFinal private ClassObject doubleWordArrayClass;
-    public final NativeObject cannotInterpretSelector = new NativeObject(); // TODO: use selector
+    public final NativeObject cannotInterpretSelector = new NativeObject();
     public final ClassObject blockClosureClass = new ClassObject(this);
     @CompilationFinal private ClassObject fullBlockClosureClass;
     public final ClassObject largeNegativeIntegerClass = new ClassObject(this);
@@ -162,12 +163,18 @@ public final class SqueakImageContext {
                     ArrayUtils.EMPTY_ARRAY, compiledMethodClass);
     public final VirtualFrame externalSenderFrame = Truffle.getRuntime().createVirtualFrame(FrameAccess.newWith(NilObject.SINGLETON, null, NilObject.SINGLETON), dummyMethod.getFrameDescriptor());
 
+    // The maximum message arity that supports DNU shortcuts.
+    public static final int MAX_DNU_SHORTCUT_ARITY = 3;
+
+    @CompilationFinal(dimensions = 1) private NativeObject[] dnuShortcutSelectors = new NativeObject[0];
+
     /* Method Cache */
     private static final int METHOD_CACHE_SIZE = 2 << 12;
     private static final int METHOD_CACHE_MASK = METHOD_CACHE_SIZE - 1;
     private static final int METHOD_CACHE_REPROBES = 4;
     private int methodCacheRandomish;
     @CompilationFinal(dimensions = 1) private final MethodCacheEntry[] methodCache = new MethodCacheEntry[METHOD_CACHE_SIZE];
+    private final EconomicMap<NativeObject, CyclicAssumption> absentSelectorAssumptions = EconomicMap.create();
 
     /* Interpreter state */
     private int primFailCode = 0;
@@ -464,6 +471,28 @@ public final class SqueakImageContext {
         return currentMarkingFlag = !currentMarkingFlag;
     }
 
+    public NativeObject getDNUShortcutSelector(final int arity) {
+        if (0 <= arity && arity < dnuShortcutSelectors.length) {
+            return dnuShortcutSelectors[arity];
+        }
+        return null;
+    }
+
+    public void setDNUShortcutSelectors(final NativeObject[] newSelectors) {
+        CompilerDirectives.transferToInterpreterAndInvalidate();
+        dnuShortcutSelectors = newSelectors;
+        flushMethodCache();
+    }
+
+    private boolean isDNUShortcutSelector(final NativeObject selector) {
+        for (final NativeObject shortcutSelector : dnuShortcutSelectors) {
+            if (selector == shortcutSelector) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /* SpurMemoryManager>>#setHiddenRootsObj: */
     public void setHiddenRoots(final ArrayObject theHiddenRoots) {
         assert hiddenRoots == null && (theHiddenRoots.isObjectType() || isTesting());
@@ -688,9 +717,31 @@ public final class SqueakImageContext {
         }
     }
 
-    public void flushCachesForSelector(final NativeObject selector) {
-        flushCachesForSelectorInClassTable(selector);
-        flushMethodCacheForSelector(selector);
+    @TruffleBoundary
+    public Assumption getAbsentSelectorAssumption(final NativeObject selector) {
+        CyclicAssumption absentAssumption = absentSelectorAssumptions.get(selector);
+        if (absentAssumption == null) {
+            absentAssumption = new CyclicAssumption("Absent selector globally: " + selector.asStringUnsafe());
+            absentSelectorAssumptions.put(selector, absentAssumption);
+        }
+        return absentAssumption.getAssumption();
+    }
+
+    @TruffleBoundary
+    private void invalidateAllAbsentSelectorAssumptions() {
+        for (final CyclicAssumption absentAssumption : absentSelectorAssumptions.getValues()) {
+            absentAssumption.invalidate("Fallback method (DNU/CI) shadowed or modified");
+        }
+        absentSelectorAssumptions.clear();
+    }
+
+    @TruffleBoundary
+    private void invalidateAbsentSelectorAssumption(final NativeObject selector) {
+        final CyclicAssumption absentAssumption = absentSelectorAssumptions.get(selector);
+        if (absentAssumption != null) {
+            absentAssumption.invalidate("Absent selector flushed globally");
+            absentSelectorAssumptions.removeKey(selector);
+        }
     }
 
     public TruffleFile getHomePath() {
@@ -1067,17 +1118,27 @@ public final class SqueakImageContext {
 
     /* Clear all cache entries (prim 89). */
     public void flushMethodCache() {
+        invalidateAllAbsentSelectorAssumptions();
         for (int i = 0; i < METHOD_CACHE_SIZE; i++) {
             methodCache[i].freeAndRelease();
         }
     }
 
     /* Clear cache entries for selector (prim 119). */
-    private void flushMethodCacheForSelector(final NativeObject selector) {
-        if (selector == doesNotUnderstand || selector == cannotInterpretSelector) {
+    public void flushCachesForSelector(final NativeObject selector) {
+        if (selector == doesNotUnderstand || selector == cannotInterpretSelector || isDNUShortcutSelector(selector)) {
+            // A core fallback changed. Invalidate the entire method cache to ensure
+            // no missing selectors are holding onto the stale fallback method.
             flushMethodCache();
-            return;
+            flushCachesForSelectorInClassTable(selector);
+        } else {
+            invalidateAbsentSelectorAssumption(selector);
+            flushCachesForSelectorInClassTable(selector);
+            flushMethodCacheForSelector(selector);
         }
+    }
+
+    private void flushMethodCacheForSelector(final NativeObject selector) {
         for (int i = 0; i < METHOD_CACHE_SIZE; i++) {
             if (methodCache[i].getSelector() == selector) {
                 methodCache[i].freeAndRelease();

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ClassObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ClassObject.java
@@ -6,6 +6,7 @@
  */
 package de.hpi.swa.trufflesqueak.model;
 
+import de.hpi.swa.trufflesqueak.util.LogUtils;
 import org.graalvm.collections.UnmodifiableEconomicMap;
 
 import com.oracle.truffle.api.Assumption;
@@ -36,6 +37,21 @@ import de.hpi.swa.trufflesqueak.util.ObjectGraphUtils.ObjectTracer;
  */
 @SuppressWarnings("static-method")
 public final class ClassObject extends AbstractSqueakObjectWithClassAndHash {
+    public enum FallbackConvention {
+        CANNOT_INTERPRET, // Use #cannotInterpret: and build nested Message objects
+        STANDARD_DNU,     // Use #doesNotUnderstand: and build a Message object
+        SHORTCUT_DNU      // Use #dnu...: and pass arguments and selector directly (no Message
+                          // object)
+    }
+
+    public record DispatchFailureResult(
+                    CompiledCodeObject fallbackMethod,
+                    int fallbackDepth,
+                    FallbackConvention convention,
+                    NativeObject fallbackSelector,
+                    int arity) {
+    }
+
     @CompilationFinal private CyclicAssumption classHierarchyAndMethodDictStable;
     @CompilationFinal private CyclicAssumption classFormatStable;
 
@@ -466,9 +482,10 @@ public final class ClassObject extends AbstractSqueakObjectWithClassAndHash {
      * @throws SqueakException if the fallback method cannot be found (fatal VM error).
      */
     @TruffleBoundary
-    public CompiledCodeObject resolveDispatchFailure(final NativeObject originalSelector) {
+    public DispatchFailureResult resolveDispatchFailure(final NativeObject originalSelector, final int arity) {
         CompilerAsserts.neverPartOfCompilation();
-        // Walk superclass chain to determine if #cannotInterpret:.
+
+        // Walk superclass chain to determine if this is a #cannotInterpret: case.
         ClassObject current = this;
         while (current != null) {
             assert current.assertNotForwarded();
@@ -478,31 +495,52 @@ public final class ClassObject extends AbstractSqueakObjectWithClassAndHash {
             current = current.getSuperclassOrNull();
         }
 
-        // If the walk terminates with null, we have a DNU.
+        // --- DNU Path (No nil method dictionaries) ---
         if (current == null) {
             assert originalSelector != image.doesNotUnderstand : "Fatal dispatch error: Recursive doesNotUnderstand:";
 
+            // Attempt the Shortcut DNU first
+            final NativeObject shortcutSelector = image.getDNUShortcutSelector(arity);
+            if (shortcutSelector != null) {
+                final CompiledCodeObject shortcutMethod = lookupMethodInMethodDictSlow(shortcutSelector);
+                if (shortcutMethod != null) {
+                    if (shortcutMethod.getNumArgs() == arity + 1) {
+                        return new DispatchFailureResult(shortcutMethod, 1, FallbackConvention.SHORTCUT_DNU, shortcutSelector, arity);
+                    } else {
+                        LogUtils.DEBUG.warning(() -> "Ignoring misconfigured DNU shortcut " + shortcutSelector.asStringUnsafe() +
+                                        ": expected " + (arity + 1) + " arguments, but got " + shortcutMethod.getNumArgs());
+                    }
+                }
+            }
+
+            // Fall back to standard #doesNotUnderstand:
             final CompiledCodeObject dnuMethod = lookupMethodInMethodDictSlow(image.doesNotUnderstand);
             if (dnuMethod != null) {
-                return dnuMethod;
+                return new DispatchFailureResult(dnuMethod, 1, FallbackConvention.STANDARD_DNU, image.doesNotUnderstand, arity);
             } else {
                 throw SqueakException.create("Fatal dispatch error: #doesNotUnderstand: not found in", this);
             }
-        } else {
-            // Search for #cannotInterpret: starting in the superclass of the missing method
-            // dictionary class.
-            final ClassObject startingClass = current.getSuperclassOrNull();
-            if (startingClass == null) {
-                throw SqueakException.create("Fatal dispatch error: hit nil method dictionary in class with no superclass while sending", originalSelector);
-            }
-
-            final CompiledCodeObject ciMethod = startingClass.lookupMethodInMethodDictSlow(image.cannotInterpretSelector);
-            if (ciMethod != null) {
-                return ciMethod;
-            } else {
-                throw SqueakException.create("Fatal dispatch error: #cannotInterpret: not found in superclass chain of", current);
-            }
         }
+
+        // --- CannotInterpret Path (Hit a nil dictionary) ---
+        int depth = 1;
+        ClassObject searchClass = current.getSuperclassOrNull();
+        final NativeObject selector = image.cannotInterpretSelector;
+        final int messageSelectorHash = selector.getSqueakHashInt();
+
+        while (searchClass != null) {
+            if (searchClass.methodDict == null) {
+                depth++;
+            } else {
+                final Object result = lookupMethodInDictionary(searchClass.getResolvedMethodDict(), selector, messageSelectorHash);
+                if (result instanceof CompiledCodeObject ciMethod) {
+                    return new DispatchFailureResult(ciMethod, depth, FallbackConvention.CANNOT_INTERPRET, selector, arity);
+                }
+            }
+            searchClass = searchClass.getSuperclassOrNull();
+        }
+
+        throw SqueakException.create("Fatal dispatch error: #cannotInterpret: not found in superclass chain of", this);
     }
 
     /**

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ClassObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ClassObject.java
@@ -6,7 +6,6 @@
  */
 package de.hpi.swa.trufflesqueak.model;
 
-import de.hpi.swa.trufflesqueak.util.LogUtils;
 import org.graalvm.collections.UnmodifiableEconomicMap;
 
 import com.oracle.truffle.api.Assumption;
@@ -30,6 +29,7 @@ import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.METACLASS;
 import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.METHOD_DICT;
 import de.hpi.swa.trufflesqueak.nodes.accessing.AbstractPointersObjectNodes.AbstractPointersObjectReadNode;
 import de.hpi.swa.trufflesqueak.util.ArrayUtils;
+import de.hpi.swa.trufflesqueak.util.LogUtils;
 import de.hpi.swa.trufflesqueak.util.ObjectGraphUtils.ObjectTracer;
 
 /*
@@ -481,7 +481,6 @@ public final class ClassObject extends AbstractSqueakObjectWithClassAndHash {
      * @return The CompiledCodeObject for the fallback method.
      * @throws SqueakException if the fallback method cannot be found (fatal VM error).
      */
-    @TruffleBoundary
     public DispatchFailureResult resolveDispatchFailure(final NativeObject originalSelector, final int arity) {
         CompilerAsserts.neverPartOfCompilation();
 
@@ -500,15 +499,17 @@ public final class ClassObject extends AbstractSqueakObjectWithClassAndHash {
             assert originalSelector != image.doesNotUnderstand : "Fatal dispatch error: Recursive doesNotUnderstand:";
 
             // Attempt the Shortcut DNU first
-            final NativeObject shortcutSelector = image.getDNUShortcutSelector(arity);
-            if (shortcutSelector != null) {
-                final CompiledCodeObject shortcutMethod = lookupMethodInMethodDictSlow(shortcutSelector);
-                if (shortcutMethod != null) {
-                    if (shortcutMethod.getNumArgs() == arity + 1) {
-                        return new DispatchFailureResult(shortcutMethod, 1, FallbackConvention.SHORTCUT_DNU, shortcutSelector, arity);
-                    } else {
-                        LogUtils.DEBUG.warning(() -> "Ignoring misconfigured DNU shortcut " + shortcutSelector.asStringUnsafe() +
-                                        ": expected " + (arity + 1) + " arguments, but got " + shortcutMethod.getNumArgs());
+            if (image.hasDNUShortcut(arity)) {
+                final NativeObject shortcutSelector = image.getDNUShortcutSelector(arity);
+                if (shortcutSelector != null) {
+                    final CompiledCodeObject shortcutMethod = lookupMethodInMethodDictSlow(shortcutSelector);
+                    if (shortcutMethod != null) {
+                        if (shortcutMethod.getNumArgs() == arity + 1) {
+                            return new DispatchFailureResult(shortcutMethod, 1, FallbackConvention.SHORTCUT_DNU, shortcutSelector, arity);
+                        } else {
+                            LogUtils.DEBUG.warning(() -> "Ignoring misconfigured DNU shortcut " + shortcutSelector.asStringUnsafe() +
+                                            ": expected " + (arity + 1) + " arguments, but got " + shortcutMethod.getNumArgs());
+                        }
                     }
                 }
             }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/CompiledCodeObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/CompiledCodeObject.java
@@ -744,7 +744,7 @@ public final class CompiledCodeObject extends AbstractSqueakObjectWithClassAndHa
         final boolean oldHasPrimitive = hasPrimitive();
         internalHeader = CompiledCodeHeaderUtils.fromSmallIntegerValue(value);
         assert getNumLiterals() == oldNumLiterals;
-        if (oldHasPrimitive && !hasPrimitive()) {
+        if (oldHasPrimitive != hasPrimitive()) {
             primitiveNodeOrNull = UNINITIALIZED_PRIMITIVE_NODE;
         }
         invalidateCallTarget();

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/AbstractCreateFrameArgumentsForIndirectCallNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/AbstractCreateFrameArgumentsForIndirectCallNode.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Software Architecture Group, Hasso Plattner Institute
+ * Copyright (c) 2026 Oracle and/or its affiliates
+ *
+ * Licensed under the MIT License.
+ */
+package de.hpi.swa.trufflesqueak.nodes.dispatch;
+
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.profiles.InlinedConditionProfile;
+
+import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
+import de.hpi.swa.trufflesqueak.model.AbstractSqueakObject;
+import de.hpi.swa.trufflesqueak.model.ClassObject;
+import de.hpi.swa.trufflesqueak.model.NativeObject;
+import de.hpi.swa.trufflesqueak.model.PointersObject;
+import de.hpi.swa.trufflesqueak.nodes.AbstractNode;
+import de.hpi.swa.trufflesqueak.nodes.accessing.AbstractPointersObjectNodes.AbstractPointersObjectWriteNode;
+import de.hpi.swa.trufflesqueak.util.FrameAccess;
+
+public abstract class AbstractCreateFrameArgumentsForIndirectCallNode extends AbstractNode {
+    protected static final Object[] newMessage(final Node node,
+                    final AbstractSqueakObject sender, final Object receiver, final Object[] arguments, final ClassObject receiverClass,
+                    final NativeObject selector, final ClassObject.DispatchFailureResult result,
+                    final SqueakImageContext image,
+                    final InlinedConditionProfile isCannotInterpretProfile,
+                    final AbstractPointersObjectWriteNode writeNode,
+                    final CreateMessageNode createMessageNode) {
+        final PointersObject message;
+        if (isCannotInterpretProfile.profile(node, result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET)) {
+            message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
+        } else {
+            message = image.newMessage(writeNode, selector, receiverClass, arguments);
+        }
+        return FrameAccess.newMessageFallbackWith(sender, receiver, message);
+    }
+}

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/AbstractDispatchSelectorNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/AbstractDispatchSelectorNode.java
@@ -7,8 +7,9 @@
 package de.hpi.swa.trufflesqueak.nodes.dispatch;
 
 import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
+import de.hpi.swa.trufflesqueak.nodes.AbstractNode;
 
-public abstract class DispatchSelectorNode {
+public abstract class AbstractDispatchSelectorNode extends AbstractNode {
     protected static final boolean checkArgumentCount(final CompiledCodeObject method, final int expectedNumArgs) {
         assert method.getNumArgs() == expectedNumArgs : "Unexpected number of arguments: " + method.getNumArgs();
         return true;

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/CreateMessageNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/CreateMessageNode.java
@@ -20,7 +20,7 @@ import de.hpi.swa.trufflesqueak.nodes.accessing.AbstractPointersObjectNodes.Abst
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectClassNode;
 
 @GenerateInline(false)
-abstract class CreateMessageNode extends AbstractNode {
+public abstract class CreateMessageNode extends AbstractNode {
     public abstract PointersObject execute(NativeObject selector, Object receiver, Object[] arguments);
 
     @Specialization

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector0Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector0Node.java
@@ -138,9 +138,15 @@ public final class DispatchSelector0Node extends DispatchSelectorNode {
             return new DispatchDirectMethod0Node(assumptions, method);
         }
 
-        private static DispatchDirectMessageFallback0Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
-            final CompiledCodeObject fallbackMethod = receiverClass.resolveDispatchFailure(selector);
-            return new DispatchDirectMessageFallback0Node(assumptions, selector, fallbackMethod);
+        private static DispatchDirect0Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
+            final ClassObject.DispatchFailureResult result = receiverClass.resolveDispatchFailure(selector, 0);
+            final Assumption[] finalAssumptions = DispatchUtils.getAssumptionsForMessageFallback(assumptions, selector, result.fallbackMethod());
+
+            return switch (result.convention()) {
+                case SHORTCUT_DNU -> new DispatchDirectShortcutFallback0Node(finalAssumptions, selector, result.fallbackMethod());
+                case STANDARD_DNU -> new DispatchDirectDNUFallback0Node(finalAssumptions, selector, result.fallbackMethod());
+                case CANNOT_INTERPRET -> new DispatchDirectCannotInterpretFallback0Node(finalAssumptions, selector, result.fallbackMethod(), result.fallbackDepth(), result.fallbackSelector());
+            };
         }
     }
 
@@ -219,21 +225,68 @@ public final class DispatchSelector0Node extends DispatchSelectorNode {
         }
     }
 
-    static final class DispatchDirectMessageFallback0Node extends DispatchDirectWithSender0Node {
-        private final NativeObject selector;
-        @Child private DirectCallNode callNode;
-        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+    abstract static class AbstractDispatchDirectFallback0Node extends DispatchDirectWithSender0Node {
+        protected final NativeObject selector;
+        @Child protected DirectCallNode callNode;
 
-        DispatchDirectMessageFallback0Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+        AbstractDispatchDirectFallback0Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject targetMethod) {
             super(assumptions);
             this.selector = selector;
-            callNode = DirectCallNode.create(dnuMethod.getCallTarget());
+            this.callNode = DirectCallNode.create(targetMethod.getCallTarget());
+        }
+
+        @Override
+        public abstract Object execute(VirtualFrame frame, Object receiver);
+    }
+
+    static final class DispatchDirectDNUFallback0Node extends AbstractDispatchDirectFallback0Node {
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectDNUFallback0Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+            super(assumptions, selector, dnuMethod);
         }
 
         @Override
         public Object execute(final VirtualFrame frame, final Object receiver) {
             final PointersObject message = createMessageNode.execute(selector, receiver, ArrayUtils.EMPTY_ARRAY);
             return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
+        }
+    }
+
+    static final class DispatchDirectCannotInterpretFallback0Node extends AbstractDispatchDirectFallback0Node {
+        private final int fallbackDepth;
+        private final NativeObject ciSelector;
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectCannotInterpretFallback0Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject ciMethod, final int fallbackDepth,
+                        final NativeObject ciSelector) {
+            super(assumptions, selector, ciMethod);
+            this.fallbackDepth = fallbackDepth;
+            this.ciSelector = ciSelector;
+        }
+
+        @Override
+        public Object execute(final VirtualFrame frame, final Object receiver) {
+            final PointersObject message = DispatchUtils.buildNestedMessage(
+                            createMessageNode,
+                            selector,
+                            ciSelector,
+                            receiver,
+                            ArrayUtils.EMPTY_ARRAY,
+                            fallbackDepth);
+            return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
+        }
+    }
+
+    static final class DispatchDirectShortcutFallback0Node extends AbstractDispatchDirectFallback0Node {
+
+        DispatchDirectShortcutFallback0Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject shortcutMethod) {
+            super(assumptions, selector, shortcutMethod);
+        }
+
+        @Override
+        public Object execute(final VirtualFrame frame, final Object receiver) {
+            return callNode.call(FrameAccess.newWith(senderNode.execute(frame), null, receiver, selector));
         }
     }
 
@@ -272,7 +325,14 @@ public final class DispatchSelector0Node extends DispatchSelectorNode {
             final ClassObject receiverClass = classNode.executeLookup(node, receiver);
             final Object lookupResult = getContext(node).lookup(receiverClass, selector);
             final CompiledCodeObject method = methodNode.execute(node, getContext(node), 0, canPrimFail, selector, receiverClass, lookupResult);
-            final Object result = tryPrimitiveNode.execute(frame, method, receiver);
+
+            final Object result;
+            if (lookupResult instanceof CompiledCodeObject) {
+                result = tryPrimitiveNode.execute(frame, method, receiver);
+            } else {
+                result = null;
+            }
+
             if (result != null) {
                 return result;
             } else {
@@ -345,9 +405,21 @@ public final class DispatchSelector0Node extends DispatchSelectorNode {
             @Specialization(guards = "lookupResult == null")
             protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final ClassObject receiverClass,
                             @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
-                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode) {
+                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(0);
+
+                if (result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU) {
+                    return FrameAccess.newWith(sender, null, receiver, selector);
+                }
+
                 final Object[] arguments = ArrayUtils.EMPTY_ARRAY;
-                final PointersObject message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                final PointersObject message;
+                if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
+                    message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
+                } else {
+                    message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                }
                 return FrameAccess.newMessageFallbackWith(sender, receiver, message);
             }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector0Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector0Node.java
@@ -13,6 +13,7 @@ import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.HostCompilerDirectives;
 import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Cached.Exclusive;
 import com.oracle.truffle.api.dsl.GenerateCached;
 import com.oracle.truffle.api.dsl.GenerateInline;
 import com.oracle.truffle.api.dsl.ImportStatic;
@@ -47,10 +48,15 @@ import de.hpi.swa.trufflesqueak.nodes.primitives.PrimitiveNodeFactory;
 import de.hpi.swa.trufflesqueak.util.ArrayUtils;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
-public final class DispatchSelector0Node extends DispatchSelectorNode {
+public final class DispatchSelector0Node extends AbstractDispatchSelectorNode {
     public abstract static class Dispatch0Node extends AbstractDispatchNode {
         Dispatch0Node(final NativeObject selector) {
             super(selector);
+        }
+
+        @NeverDefault
+        public static Dispatch0Node create(final NativeObject selector) {
+            return DispatchSelector0NodeFactory.Dispatch0NodeGen.create(selector);
         }
 
         public abstract Object execute(VirtualFrame frame, Object receiver);
@@ -81,7 +87,7 @@ public final class DispatchSelector0Node extends DispatchSelectorNode {
 
         @NeverDefault
         protected static final DispatchDirect0Node create(final NativeObject selector, final LookupClassGuard guard) {
-            return create(selector, guard, false);
+            return create(selector, guard, true);
         }
 
         @NeverDefault
@@ -392,7 +398,7 @@ public final class DispatchSelector0Node extends DispatchSelectorNode {
 
         @GenerateInline
         @GenerateCached(false)
-        protected abstract static class CreateFrameArgumentsForIndirectCall0Node extends AbstractNode {
+        protected abstract static class CreateFrameArgumentsForIndirectCall0Node extends AbstractCreateFrameArgumentsForIndirectCallNode {
             abstract Object[] execute(Node node, AbstractSqueakObject sender, Object receiver, ClassObject receiverClass, Object lookupResult, NativeObject selector);
 
             @Specialization
@@ -402,25 +408,33 @@ public final class DispatchSelector0Node extends DispatchSelectorNode {
                 return FrameAccess.newWith(sender, null, receiver);
             }
 
-            @Specialization(guards = "lookupResult == null")
+            @Specialization(guards = "lookupResult == null", assumptions = {"image.getDnuShortcutsAbsent()"})
             protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final ClassObject receiverClass,
                             @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
-                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
-                            @Cached(inline = false) final CreateMessageNode createMessageNode) {
-                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(0);
-
-                if (result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU) {
-                    return FrameAccess.newWith(sender, null, receiver, selector);
-                }
-
+                            @Bind final SqueakImageContext image,
+                            @Exclusive @Cached final InlinedConditionProfile isCannotInterpretProfile,
+                            @Exclusive @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Exclusive @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = image.findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(0);
                 final Object[] arguments = ArrayUtils.EMPTY_ARRAY;
-                final PointersObject message;
-                if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
-                    message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
+                return newMessage(node, sender, receiver, arguments, receiverClass, selector, result, image, isCannotInterpretProfile, writeNode, createMessageNode);
+            }
+
+            @Specialization(guards = "lookupResult == null", replaces = "doMessageFallback")
+            protected static final Object[] doMessageFallbackWithShortcuts(final Node node, final AbstractSqueakObject sender, final Object receiver, final ClassObject receiverClass,
+                            @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
+                            @Bind final SqueakImageContext image,
+                            @Exclusive @Cached final InlinedConditionProfile isShortcutProfile,
+                            @Exclusive @Cached final InlinedConditionProfile isCannotInterpretProfile,
+                            @Exclusive @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Exclusive @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = image.findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(0);
+                if (isShortcutProfile.profile(node, result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU)) {
+                    return FrameAccess.newWith(sender, null, receiver, selector);
                 } else {
-                    message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                    final Object[] arguments = ArrayUtils.EMPTY_ARRAY;
+                    return newMessage(node, sender, receiver, arguments, receiverClass, selector, result, image, isCannotInterpretProfile, writeNode, createMessageNode);
                 }
-                return FrameAccess.newMessageFallbackWith(sender, receiver, message);
             }
 
             @Specialization(guards = {"targetObject != null", "!isCompiledCodeObject(targetObject)"})

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector0Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector0Node.java
@@ -50,13 +50,21 @@ import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
 public final class DispatchSelector0Node extends AbstractDispatchSelectorNode {
     public abstract static class Dispatch0Node extends AbstractDispatchNode {
-        Dispatch0Node(final NativeObject selector) {
+        protected final boolean canPrimFail;
+
+        Dispatch0Node(final NativeObject selector, final boolean canPrimFail) {
             super(selector);
+            this.canPrimFail = canPrimFail;
         }
 
         @NeverDefault
         public static Dispatch0Node create(final NativeObject selector) {
-            return DispatchSelector0NodeFactory.Dispatch0NodeGen.create(selector);
+            return DispatchSelector0NodeFactory.Dispatch0NodeGen.create(selector, false);
+        }
+
+        @NeverDefault
+        public static Dispatch0Node create(final NativeObject selector, final boolean canPrimFail) {
+            return DispatchSelector0NodeFactory.Dispatch0NodeGen.create(selector, canPrimFail);
         }
 
         public abstract Object execute(VirtualFrame frame, Object receiver);
@@ -74,7 +82,7 @@ public final class DispatchSelector0Node extends AbstractDispatchSelectorNode {
         @SuppressWarnings("truffle-static-method")
         protected final Object doIndirect(final VirtualFrame frame, final Object receiver,
                         @Cached final DispatchIndirect0Node dispatchNode) {
-            return dispatchNode.execute(frame, false, selector, receiver);
+            return dispatchNode.execute(frame, canPrimFail, selector, receiver);
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector1Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector1Node.java
@@ -137,9 +137,15 @@ public final class DispatchSelector1Node extends DispatchSelectorNode {
             return new DispatchDirectMethod1Node(assumptions, method);
         }
 
-        private static DispatchDirectMessageFallback1Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
-            final CompiledCodeObject fallbackMethod = receiverClass.resolveDispatchFailure(selector);
-            return new DispatchDirectMessageFallback1Node(assumptions, selector, fallbackMethod);
+        private static DispatchDirect1Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
+            final ClassObject.DispatchFailureResult result = receiverClass.resolveDispatchFailure(selector, 1);
+            final Assumption[] finalAssumptions = DispatchUtils.getAssumptionsForMessageFallback(assumptions, selector, result.fallbackMethod());
+
+            return switch (result.convention()) {
+                case SHORTCUT_DNU -> new DispatchDirectShortcutFallback1Node(finalAssumptions, selector, result.fallbackMethod());
+                case STANDARD_DNU -> new DispatchDirectDNUFallback1Node(finalAssumptions, selector, result.fallbackMethod());
+                case CANNOT_INTERPRET -> new DispatchDirectCannotInterpretFallback1Node(finalAssumptions, selector, result.fallbackMethod(), result.fallbackDepth(), result.fallbackSelector());
+            };
         }
     }
 
@@ -218,21 +224,68 @@ public final class DispatchSelector1Node extends DispatchSelectorNode {
         }
     }
 
-    static final class DispatchDirectMessageFallback1Node extends DispatchDirectWithSender1Node {
-        private final NativeObject selector;
-        @Child private DirectCallNode callNode;
-        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+    abstract static class AbstractDispatchDirectFallback1Node extends DispatchDirectWithSender1Node {
+        protected final NativeObject selector;
+        @Child protected DirectCallNode callNode;
 
-        DispatchDirectMessageFallback1Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+        AbstractDispatchDirectFallback1Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject targetMethod) {
             super(assumptions);
             this.selector = selector;
-            callNode = DirectCallNode.create(dnuMethod.getCallTarget());
+            this.callNode = DirectCallNode.create(targetMethod.getCallTarget());
+        }
+
+        @Override
+        public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1);
+    }
+
+    static final class DispatchDirectDNUFallback1Node extends AbstractDispatchDirectFallback1Node {
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectDNUFallback1Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+            super(assumptions, selector, dnuMethod);
         }
 
         @Override
         public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1) {
             final PointersObject message = createMessageNode.execute(selector, receiver, new Object[]{arg1});
             return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
+        }
+    }
+
+    static final class DispatchDirectCannotInterpretFallback1Node extends AbstractDispatchDirectFallback1Node {
+        private final int fallbackDepth;
+        private final NativeObject ciSelector;
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectCannotInterpretFallback1Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject ciMethod, final int fallbackDepth,
+                        final NativeObject ciSelector) {
+            super(assumptions, selector, ciMethod);
+            this.fallbackDepth = fallbackDepth;
+            this.ciSelector = ciSelector;
+        }
+
+        @Override
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1) {
+            final PointersObject message = DispatchUtils.buildNestedMessage(
+                            createMessageNode,
+                            selector,
+                            ciSelector,
+                            receiver,
+                            new Object[]{arg1},
+                            fallbackDepth);
+            return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
+        }
+    }
+
+    static final class DispatchDirectShortcutFallback1Node extends AbstractDispatchDirectFallback1Node {
+
+        DispatchDirectShortcutFallback1Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject shortcutMethod) {
+            super(assumptions, selector, shortcutMethod);
+        }
+
+        @Override
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1) {
+            return callNode.call(FrameAccess.newWith(senderNode.execute(frame), null, receiver, arg1, selector));
         }
     }
 
@@ -271,7 +324,14 @@ public final class DispatchSelector1Node extends DispatchSelectorNode {
             final ClassObject receiverClass = classNode.executeLookup(node, receiver);
             final Object lookupResult = getContext(node).lookup(receiverClass, selector);
             final CompiledCodeObject method = methodNode.execute(node, getContext(node), 1, canPrimFail, selector, receiverClass, lookupResult);
-            final Object result = tryPrimitiveNode.execute(frame, method, receiver, arg1);
+
+            final Object result;
+            if (lookupResult instanceof CompiledCodeObject) {
+                result = tryPrimitiveNode.execute(frame, method, receiver, arg1);
+            } else {
+                result = null;
+            }
+
             if (result != null) {
                 return result;
             } else {
@@ -345,9 +405,21 @@ public final class DispatchSelector1Node extends DispatchSelectorNode {
             @Specialization(guards = "lookupResult == null")
             protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final ClassObject receiverClass,
                             @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
-                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode) {
+                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(1);
+
+                if (result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU) {
+                    return FrameAccess.newWith(sender, null, receiver, arg1, selector);
+                }
+
                 final Object[] arguments = new Object[]{arg1};
-                final PointersObject message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                final PointersObject message;
+                if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
+                    message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
+                } else {
+                    message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                }
                 return FrameAccess.newMessageFallbackWith(sender, receiver, message);
             }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector1Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector1Node.java
@@ -49,13 +49,21 @@ import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
 public final class DispatchSelector1Node extends AbstractDispatchSelectorNode {
     public abstract static class Dispatch1Node extends AbstractDispatchNode {
-        Dispatch1Node(final NativeObject selector) {
+        protected final boolean canPrimFail;
+
+        Dispatch1Node(final NativeObject selector, final boolean canPrimFail) {
             super(selector);
+            this.canPrimFail = canPrimFail;
         }
 
         @NeverDefault
         public static Dispatch1Node create(final NativeObject selector) {
-            return DispatchSelector1NodeFactory.Dispatch1NodeGen.create(selector);
+            return DispatchSelector1NodeFactory.Dispatch1NodeGen.create(selector, false);
+        }
+
+        @NeverDefault
+        public static Dispatch1Node create(final NativeObject selector, final boolean canPrimFail) {
+            return DispatchSelector1NodeFactory.Dispatch1NodeGen.create(selector, canPrimFail);
         }
 
         public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1);
@@ -73,7 +81,7 @@ public final class DispatchSelector1Node extends AbstractDispatchSelectorNode {
         @SuppressWarnings("truffle-static-method")
         protected final Object doIndirect(final VirtualFrame frame, final Object receiver, final Object arg1,
                         @Cached final DispatchIndirect1Node dispatchNode) {
-            return dispatchNode.execute(frame, false, selector, receiver, arg1);
+            return dispatchNode.execute(frame, canPrimFail, selector, receiver, arg1);
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector1Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector1Node.java
@@ -13,6 +13,7 @@ import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.HostCompilerDirectives;
 import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Cached.Exclusive;
 import com.oracle.truffle.api.dsl.GenerateCached;
 import com.oracle.truffle.api.dsl.GenerateInline;
 import com.oracle.truffle.api.dsl.ImportStatic;
@@ -46,10 +47,15 @@ import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive1;
 import de.hpi.swa.trufflesqueak.nodes.primitives.PrimitiveNodeFactory;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
-public final class DispatchSelector1Node extends DispatchSelectorNode {
+public final class DispatchSelector1Node extends AbstractDispatchSelectorNode {
     public abstract static class Dispatch1Node extends AbstractDispatchNode {
         Dispatch1Node(final NativeObject selector) {
             super(selector);
+        }
+
+        @NeverDefault
+        public static Dispatch1Node create(final NativeObject selector) {
+            return DispatchSelector1NodeFactory.Dispatch1NodeGen.create(selector);
         }
 
         public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1);
@@ -392,7 +398,7 @@ public final class DispatchSelector1Node extends DispatchSelectorNode {
 
         @GenerateInline
         @GenerateCached(false)
-        protected abstract static class CreateFrameArgumentsForIndirectCall1Node extends AbstractNode {
+        protected abstract static class CreateFrameArgumentsForIndirectCall1Node extends AbstractCreateFrameArgumentsForIndirectCallNode {
             abstract Object[] execute(Node node, AbstractSqueakObject sender, Object receiver, Object arg1, ClassObject receiverClass, Object lookupResult, NativeObject selector);
 
             @Specialization
@@ -402,25 +408,34 @@ public final class DispatchSelector1Node extends DispatchSelectorNode {
                 return FrameAccess.newWith(sender, null, receiver, arg1);
             }
 
-            @Specialization(guards = "lookupResult == null")
+            @Specialization(guards = "lookupResult == null", assumptions = {"image.getDnuShortcutsAbsent()"})
             protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final ClassObject receiverClass,
                             @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
-                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
-                            @Cached(inline = false) final CreateMessageNode createMessageNode) {
-                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(1);
-
-                if (result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU) {
-                    return FrameAccess.newWith(sender, null, receiver, arg1, selector);
-                }
-
+                            @Bind final SqueakImageContext image,
+                            @Exclusive @Cached final InlinedConditionProfile isCannotInterpretProfile,
+                            @Exclusive @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Exclusive @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = image.findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(1);
                 final Object[] arguments = new Object[]{arg1};
-                final PointersObject message;
-                if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
-                    message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
+                return newMessage(node, sender, receiver, arguments, receiverClass, selector, result, image, isCannotInterpretProfile, writeNode, createMessageNode);
+            }
+
+            @Specialization(guards = "lookupResult == null", replaces = "doMessageFallback")
+            protected static final Object[] doMessageFallbackWithShortcuts(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1,
+                            final ClassObject receiverClass,
+                            @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
+                            @Bind final SqueakImageContext image,
+                            @Exclusive @Cached final InlinedConditionProfile isShortcutProfile,
+                            @Exclusive @Cached final InlinedConditionProfile isCannotInterpretProfile,
+                            @Exclusive @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Exclusive @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = image.findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(1);
+                if (isShortcutProfile.profile(node, result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU)) {
+                    return FrameAccess.newWith(sender, null, receiver, arg1, selector);
                 } else {
-                    message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                    final Object[] arguments = new Object[]{arg1};
+                    return newMessage(node, sender, receiver, arguments, receiverClass, selector, result, image, isCannotInterpretProfile, writeNode, createMessageNode);
                 }
-                return FrameAccess.newMessageFallbackWith(sender, receiver, message);
             }
 
             @Specialization(guards = {"targetObject != null", "!isCompiledCodeObject(targetObject)"})

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector2Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector2Node.java
@@ -129,7 +129,7 @@ public final class DispatchSelector2Node extends DispatchSelectorNode {
             assert checkArgumentCount(method, 2);
             if (method.hasPrimitive()) {
                 final AbstractPrimitiveNode primitiveNode = PrimitiveNodeFactory.getOrCreateIndexedOrNamed(method);
-                if (primitiveNode instanceof Primitive2 primitive2) {
+                if (primitiveNode instanceof final Primitive2 primitive2) {
                     return new DispatchDirectPrimitive2Node(assumptions, method, primitive2);
                 }
                 DispatchUtils.logMissingPrimitive(primitiveNode, method);
@@ -137,9 +137,15 @@ public final class DispatchSelector2Node extends DispatchSelectorNode {
             return new DispatchDirectMethod2Node(assumptions, method);
         }
 
-        private static DispatchDirectMessageFallback2Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
-            final CompiledCodeObject fallbackMethod = receiverClass.resolveDispatchFailure(selector);
-            return new DispatchDirectMessageFallback2Node(assumptions, selector, fallbackMethod);
+        private static DispatchDirect2Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
+            final ClassObject.DispatchFailureResult result = receiverClass.resolveDispatchFailure(selector, 2);
+            final Assumption[] finalAssumptions = DispatchUtils.getAssumptionsForMessageFallback(assumptions, selector, result.fallbackMethod());
+
+            return switch (result.convention()) {
+                case SHORTCUT_DNU -> new DispatchDirectShortcutFallback2Node(finalAssumptions, selector, result.fallbackMethod());
+                case STANDARD_DNU -> new DispatchDirectDNUFallback2Node(finalAssumptions, selector, result.fallbackMethod());
+                case CANNOT_INTERPRET -> new DispatchDirectCannotInterpretFallback2Node(finalAssumptions, selector, result.fallbackMethod(), result.fallbackDepth(), result.fallbackSelector());
+            };
         }
     }
 
@@ -218,21 +224,68 @@ public final class DispatchSelector2Node extends DispatchSelectorNode {
         }
     }
 
-    static final class DispatchDirectMessageFallback2Node extends DispatchDirectWithSender2Node {
-        private final NativeObject selector;
-        @Child private DirectCallNode callNode;
-        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+    abstract static class AbstractDispatchDirectFallback2Node extends DispatchDirectWithSender2Node {
+        protected final NativeObject selector;
+        @Child protected DirectCallNode callNode;
 
-        DispatchDirectMessageFallback2Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+        AbstractDispatchDirectFallback2Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject targetMethod) {
             super(assumptions);
             this.selector = selector;
-            callNode = DirectCallNode.create(dnuMethod.getCallTarget());
+            this.callNode = DirectCallNode.create(targetMethod.getCallTarget());
+        }
+
+        @Override
+        public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2);
+    }
+
+    static final class DispatchDirectDNUFallback2Node extends AbstractDispatchDirectFallback2Node {
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectDNUFallback2Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+            super(assumptions, selector, dnuMethod);
         }
 
         @Override
         public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2) {
             final PointersObject message = createMessageNode.execute(selector, receiver, new Object[]{arg1, arg2});
             return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
+        }
+    }
+
+    static final class DispatchDirectCannotInterpretFallback2Node extends AbstractDispatchDirectFallback2Node {
+        private final int fallbackDepth;
+        private final NativeObject ciSelector;
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectCannotInterpretFallback2Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject ciMethod, final int fallbackDepth,
+                        final NativeObject ciSelector) {
+            super(assumptions, selector, ciMethod);
+            this.fallbackDepth = fallbackDepth;
+            this.ciSelector = ciSelector;
+        }
+
+        @Override
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2) {
+            final PointersObject message = DispatchUtils.buildNestedMessage(
+                            createMessageNode,
+                            selector,
+                            ciSelector,
+                            receiver,
+                            new Object[]{arg1, arg2},
+                            fallbackDepth);
+            return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
+        }
+    }
+
+    static final class DispatchDirectShortcutFallback2Node extends AbstractDispatchDirectFallback2Node {
+
+        DispatchDirectShortcutFallback2Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject shortcutMethod) {
+            super(assumptions, selector, shortcutMethod);
+        }
+
+        @Override
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2) {
+            return callNode.call(FrameAccess.newWith(senderNode.execute(frame), null, receiver, arg1, arg2, selector));
         }
     }
 
@@ -271,7 +324,14 @@ public final class DispatchSelector2Node extends DispatchSelectorNode {
             final ClassObject receiverClass = classNode.executeLookup(node, receiver);
             final Object lookupResult = getContext(node).lookup(receiverClass, selector);
             final CompiledCodeObject method = methodNode.execute(node, getContext(node), 2, canPrimFail, selector, receiverClass, lookupResult);
-            final Object result = tryPrimitiveNode.execute(frame, method, receiver, arg1, arg2);
+
+            final Object result;
+            if (lookupResult instanceof CompiledCodeObject) {
+                result = tryPrimitiveNode.execute(frame, method, receiver, arg1, arg2);
+            } else {
+                result = null;
+            }
+
             if (result != null) {
                 return result;
             } else {
@@ -346,9 +406,20 @@ public final class DispatchSelector2Node extends DispatchSelectorNode {
             protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final Object arg2,
                             final ClassObject receiverClass,
                             @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
-                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode) {
+                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(2);
+                if (result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU) {
+                    return FrameAccess.newWith(sender, null, receiver, arg1, arg2, selector);
+                }
+
                 final Object[] arguments = new Object[]{arg1, arg2};
-                final PointersObject message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                final PointersObject message;
+                if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
+                    message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
+                } else {
+                    message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                }
                 return FrameAccess.newMessageFallbackWith(sender, receiver, message);
             }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector2Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector2Node.java
@@ -13,6 +13,7 @@ import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.HostCompilerDirectives;
 import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Cached.Exclusive;
 import com.oracle.truffle.api.dsl.GenerateCached;
 import com.oracle.truffle.api.dsl.GenerateInline;
 import com.oracle.truffle.api.dsl.ImportStatic;
@@ -46,10 +47,15 @@ import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive2;
 import de.hpi.swa.trufflesqueak.nodes.primitives.PrimitiveNodeFactory;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
-public final class DispatchSelector2Node extends DispatchSelectorNode {
+public final class DispatchSelector2Node extends AbstractDispatchSelectorNode {
     public abstract static class Dispatch2Node extends AbstractDispatchNode {
         Dispatch2Node(final NativeObject selector) {
             super(selector);
+        }
+
+        @NeverDefault
+        public static Dispatch2Node create(final NativeObject selector) {
+            return DispatchSelector2NodeFactory.Dispatch2NodeGen.create(selector);
         }
 
         public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2);
@@ -392,7 +398,7 @@ public final class DispatchSelector2Node extends DispatchSelectorNode {
 
         @GenerateInline
         @GenerateCached(false)
-        protected abstract static class CreateFrameArgumentsForIndirectCall2Node extends AbstractNode {
+        protected abstract static class CreateFrameArgumentsForIndirectCall2Node extends AbstractCreateFrameArgumentsForIndirectCallNode {
             abstract Object[] execute(Node node, AbstractSqueakObject sender, Object receiver, Object arg1, Object arg2, ClassObject receiverClass, Object lookupResult, NativeObject selector);
 
             @Specialization
@@ -402,25 +408,35 @@ public final class DispatchSelector2Node extends DispatchSelectorNode {
                 return FrameAccess.newWith(sender, null, receiver, arg1, arg2);
             }
 
-            @Specialization(guards = "lookupResult == null")
+            @Specialization(guards = "lookupResult == null", assumptions = {"image.getDnuShortcutsAbsent()"})
             protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final Object arg2,
                             final ClassObject receiverClass,
                             @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
-                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
-                            @Cached(inline = false) final CreateMessageNode createMessageNode) {
-                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(2);
-                if (result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU) {
-                    return FrameAccess.newWith(sender, null, receiver, arg1, arg2, selector);
-                }
-
+                            @Bind final SqueakImageContext image,
+                            @Exclusive @Cached final InlinedConditionProfile isCannotInterpretProfile,
+                            @Exclusive @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Exclusive @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = image.findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(2);
                 final Object[] arguments = new Object[]{arg1, arg2};
-                final PointersObject message;
-                if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
-                    message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
+                return newMessage(node, sender, receiver, arguments, receiverClass, selector, result, image, isCannotInterpretProfile, writeNode, createMessageNode);
+            }
+
+            @Specialization(guards = "lookupResult == null", replaces = "doMessageFallback")
+            protected static final Object[] doMessageFallbackWithShortcuts(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final Object arg2,
+                            final ClassObject receiverClass,
+                            @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
+                            @Bind final SqueakImageContext image,
+                            @Exclusive @Cached final InlinedConditionProfile isShortcutProfile,
+                            @Exclusive @Cached final InlinedConditionProfile isCannotInterpretProfile,
+                            @Exclusive @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Exclusive @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = image.findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(2);
+                if (isShortcutProfile.profile(node, result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU)) {
+                    return FrameAccess.newWith(sender, null, receiver, arg1, arg2, selector);
                 } else {
-                    message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                    final Object[] arguments = new Object[]{arg1, arg2};
+                    return newMessage(node, sender, receiver, arguments, receiverClass, selector, result, image, isCannotInterpretProfile, writeNode, createMessageNode);
                 }
-                return FrameAccess.newMessageFallbackWith(sender, receiver, message);
             }
 
             @Specialization(guards = {"targetObject != null", "!isCompiledCodeObject(targetObject)"})

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector2Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector2Node.java
@@ -49,13 +49,21 @@ import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
 public final class DispatchSelector2Node extends AbstractDispatchSelectorNode {
     public abstract static class Dispatch2Node extends AbstractDispatchNode {
-        Dispatch2Node(final NativeObject selector) {
+        protected final boolean canPrimFail;
+
+        Dispatch2Node(final NativeObject selector, final boolean canPrimFail) {
             super(selector);
+            this.canPrimFail = canPrimFail;
         }
 
         @NeverDefault
         public static Dispatch2Node create(final NativeObject selector) {
-            return DispatchSelector2NodeFactory.Dispatch2NodeGen.create(selector);
+            return DispatchSelector2NodeFactory.Dispatch2NodeGen.create(selector, false);
+        }
+
+        @NeverDefault
+        public static Dispatch2Node create(final NativeObject selector, final boolean canPrimFail) {
+            return DispatchSelector2NodeFactory.Dispatch2NodeGen.create(selector, canPrimFail);
         }
 
         public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2);
@@ -73,7 +81,7 @@ public final class DispatchSelector2Node extends AbstractDispatchSelectorNode {
         @SuppressWarnings("truffle-static-method")
         protected final Object doIndirect(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2,
                         @Cached final DispatchIndirect2Node dispatchNode) {
-            return dispatchNode.execute(frame, false, selector, receiver, arg1, arg2);
+            return dispatchNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2);
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector3Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector3Node.java
@@ -106,9 +106,15 @@ public final class DispatchSelector3Node extends DispatchSelectorNode {
             return new DispatchDirectMethod3Node(assumptions, method);
         }
 
-        private static DispatchDirectMessageFallback3Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
-            final CompiledCodeObject fallbackMethod = receiverClass.resolveDispatchFailure(selector);
-            return new DispatchDirectMessageFallback3Node(assumptions, selector, fallbackMethod);
+        private static DispatchDirect3Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
+            final ClassObject.DispatchFailureResult result = receiverClass.resolveDispatchFailure(selector, 3);
+            final Assumption[] finalAssumptions = DispatchUtils.getAssumptionsForMessageFallback(assumptions, selector, result.fallbackMethod());
+
+            return switch (result.convention()) {
+                case SHORTCUT_DNU -> new DispatchDirectShortcutFallback3Node(finalAssumptions, selector, result.fallbackMethod());
+                case STANDARD_DNU -> new DispatchDirectDNUFallback3Node(finalAssumptions, selector, result.fallbackMethod());
+                case CANNOT_INTERPRET -> new DispatchDirectCannotInterpretFallback3Node(finalAssumptions, selector, result.fallbackMethod(), result.fallbackDepth(), result.fallbackSelector());
+            };
         }
     }
 
@@ -187,21 +193,68 @@ public final class DispatchSelector3Node extends DispatchSelectorNode {
         }
     }
 
-    static final class DispatchDirectMessageFallback3Node extends DispatchDirectWithSender3Node {
-        private final NativeObject selector;
-        @Child private DirectCallNode callNode;
-        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+    abstract static class AbstractDispatchDirectFallback3Node extends DispatchDirectWithSender3Node {
+        protected final NativeObject selector;
+        @Child protected DirectCallNode callNode;
 
-        DispatchDirectMessageFallback3Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+        AbstractDispatchDirectFallback3Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject targetMethod) {
             super(assumptions);
             this.selector = selector;
-            callNode = DirectCallNode.create(dnuMethod.getCallTarget());
+            this.callNode = DirectCallNode.create(targetMethod.getCallTarget());
+        }
+
+        @Override
+        public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2, Object arg3);
+    }
+
+    static final class DispatchDirectDNUFallback3Node extends AbstractDispatchDirectFallback3Node {
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectDNUFallback3Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+            super(assumptions, selector, dnuMethod);
         }
 
         @Override
         public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3) {
             final PointersObject message = createMessageNode.execute(selector, receiver, new Object[]{arg1, arg2, arg3});
             return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
+        }
+    }
+
+    static final class DispatchDirectCannotInterpretFallback3Node extends AbstractDispatchDirectFallback3Node {
+        private final int fallbackDepth;
+        private final NativeObject ciSelector;
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectCannotInterpretFallback3Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject ciMethod, final int fallbackDepth,
+                        final NativeObject ciSelector) {
+            super(assumptions, selector, ciMethod);
+            this.fallbackDepth = fallbackDepth;
+            this.ciSelector = ciSelector;
+        }
+
+        @Override
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3) {
+            final PointersObject message = DispatchUtils.buildNestedMessage(
+                            createMessageNode,
+                            selector,
+                            ciSelector,
+                            receiver,
+                            new Object[]{arg1, arg2, arg3},
+                            fallbackDepth);
+            return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
+        }
+    }
+
+    static final class DispatchDirectShortcutFallback3Node extends AbstractDispatchDirectFallback3Node {
+
+        DispatchDirectShortcutFallback3Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject shortcutMethod) {
+            super(assumptions, selector, shortcutMethod);
+        }
+
+        @Override
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3) {
+            return callNode.call(FrameAccess.newWith(senderNode.execute(frame), null, receiver, arg1, arg2, arg3, selector));
         }
     }
 
@@ -241,7 +294,14 @@ public final class DispatchSelector3Node extends DispatchSelectorNode {
             final ClassObject receiverClass = classNode.executeLookup(node, receiver);
             final Object lookupResult = getContext(node).lookup(receiverClass, selector);
             final CompiledCodeObject method = methodNode.execute(node, getContext(node), 3, canPrimFail, selector, receiverClass, lookupResult);
-            final Object result = tryPrimitiveNode.execute(frame, method, receiver, arg1, arg2, arg3);
+
+            final Object result;
+            if (lookupResult instanceof CompiledCodeObject) {
+                result = tryPrimitiveNode.execute(frame, method, receiver, arg1, arg2, arg3);
+            } else {
+                result = null;
+            }
+
             if (result != null) {
                 return result;
             } else {
@@ -317,9 +377,21 @@ public final class DispatchSelector3Node extends DispatchSelectorNode {
             @Specialization(guards = "lookupResult == null")
             protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final Object arg2, final Object arg3,
                             final ClassObject receiverClass, @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
-                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode) {
+                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(3);
+
+                if (result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU) {
+                    return FrameAccess.newWith(sender, null, receiver, arg1, arg2, arg3, selector);
+                }
+
                 final Object[] arguments = new Object[]{arg1, arg2, arg3};
-                final PointersObject message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                final PointersObject message;
+                if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
+                    message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
+                } else {
+                    message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                }
                 return FrameAccess.newMessageFallbackWith(sender, receiver, message);
             }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector3Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector3Node.java
@@ -10,12 +10,15 @@ import com.oracle.truffle.api.Assumption;
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.HostCompilerDirectives;
 import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Cached.Exclusive;
 import com.oracle.truffle.api.dsl.GenerateCached;
 import com.oracle.truffle.api.dsl.GenerateInline;
 import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.NeverDefault;
+import com.oracle.truffle.api.dsl.ReportPolymorphism;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
@@ -44,13 +47,47 @@ import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive3;
 import de.hpi.swa.trufflesqueak.nodes.primitives.PrimitiveNodeFactory;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
-public final class DispatchSelector3Node extends DispatchSelectorNode {
+public final class DispatchSelector3Node extends AbstractDispatchSelectorNode {
+    public abstract static class Dispatch3Node extends AbstractDispatchNode {
+        Dispatch3Node(final NativeObject selector) {
+            super(selector);
+        }
+
+        @NeverDefault
+        public static Dispatch3Node create(final NativeObject selector) {
+            return DispatchSelector3NodeFactory.Dispatch3NodeGen.create(selector);
+        }
+
+        public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2, Object arg3);
+
+        @Specialization(guards = "guard.check(receiver)", assumptions = "dispatchDirectNode.getAssumptions()", limit = "INLINE_METHOD_CACHE_LIMIT")
+        protected static final Object doDirect(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3,
+                        @SuppressWarnings("unused") @Cached("create(receiver)") final LookupClassGuard guard,
+                        @Cached("create(selector, guard)") final DispatchDirect3Node dispatchDirectNode) {
+            return dispatchDirectNode.execute(frame, receiver, arg1, arg2, arg3);
+        }
+
+        @ReportPolymorphism.Megamorphic
+        @Specialization(replaces = "doDirect")
+        @HostCompilerDirectives.InliningCutoff
+        @SuppressWarnings("truffle-static-method")
+        protected final Object doIndirect(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3,
+                        @Cached final DispatchIndirect3Node dispatchNode) {
+            return dispatchNode.execute(frame, false, selector, receiver, arg1, arg2, arg3);
+        }
+    }
+
     public abstract static class DispatchDirect3Node extends AbstractDispatchDirectNode {
         DispatchDirect3Node(final Assumption[] assumptions) {
             super(assumptions);
         }
 
         public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2, Object arg3);
+
+        @NeverDefault
+        protected static final DispatchDirect3Node create(final NativeObject selector, final LookupClassGuard guard) {
+            return create(selector, guard, true);
+        }
 
         @NeverDefault
         public static final DispatchDirect3Node create(final NativeObject selector, final LookupClassGuard guard, final boolean canPrimFail) {
@@ -363,7 +400,7 @@ public final class DispatchSelector3Node extends DispatchSelectorNode {
 
         @GenerateInline
         @GenerateCached(false)
-        protected abstract static class CreateFrameArgumentsForIndirectCall3Node extends AbstractNode {
+        protected abstract static class CreateFrameArgumentsForIndirectCall3Node extends AbstractCreateFrameArgumentsForIndirectCallNode {
             abstract Object[] execute(Node node, AbstractSqueakObject sender, Object receiver, Object arg1, Object arg2, Object arg3, ClassObject receiverClass, Object lookupResult,
                             NativeObject selector);
 
@@ -374,25 +411,34 @@ public final class DispatchSelector3Node extends DispatchSelectorNode {
                 return FrameAccess.newWith(sender, null, receiver, arg1, arg2, arg3);
             }
 
-            @Specialization(guards = "lookupResult == null")
+            @Specialization(guards = "lookupResult == null", assumptions = {"image.getDnuShortcutsAbsent()"})
             protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final Object arg2, final Object arg3,
                             final ClassObject receiverClass, @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
-                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
-                            @Cached(inline = false) final CreateMessageNode createMessageNode) {
-                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(3);
-
-                if (result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU) {
-                    return FrameAccess.newWith(sender, null, receiver, arg1, arg2, arg3, selector);
-                }
-
+                            @Bind final SqueakImageContext image,
+                            @Exclusive @Cached final InlinedConditionProfile isCannotInterpretProfile,
+                            @Exclusive @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Exclusive @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = image.findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(3);
                 final Object[] arguments = new Object[]{arg1, arg2, arg3};
-                final PointersObject message;
-                if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
-                    message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
+                return newMessage(node, sender, receiver, arguments, receiverClass, selector, result, image, isCannotInterpretProfile, writeNode, createMessageNode);
+            }
+
+            @Specialization(guards = "lookupResult == null", replaces = "doMessageFallback")
+            protected static final Object[] doMessageFallbackWithShortcuts(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final Object arg2,
+                            final Object arg3,
+                            final ClassObject receiverClass, @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
+                            @Bind final SqueakImageContext image,
+                            @Exclusive @Cached final InlinedConditionProfile isShortcutProfile,
+                            @Exclusive @Cached final InlinedConditionProfile isCannotInterpretProfile,
+                            @Exclusive @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Exclusive @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = image.findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(3);
+                if (isShortcutProfile.profile(node, result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU)) {
+                    return FrameAccess.newWith(sender, null, receiver, arg1, arg2, arg3, selector);
                 } else {
-                    message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                    final Object[] arguments = new Object[]{arg1, arg2, arg3};
+                    return newMessage(node, sender, receiver, arguments, receiverClass, selector, result, image, isCannotInterpretProfile, writeNode, createMessageNode);
                 }
-                return FrameAccess.newMessageFallbackWith(sender, receiver, message);
             }
 
             @Specialization(guards = {"targetObject != null", "!isCompiledCodeObject(targetObject)"})

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector3Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector3Node.java
@@ -49,13 +49,21 @@ import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
 public final class DispatchSelector3Node extends AbstractDispatchSelectorNode {
     public abstract static class Dispatch3Node extends AbstractDispatchNode {
-        Dispatch3Node(final NativeObject selector) {
+        protected final boolean canPrimFail;
+
+        Dispatch3Node(final NativeObject selector, final boolean canPrimFail) {
             super(selector);
+            this.canPrimFail = canPrimFail;
         }
 
         @NeverDefault
         public static Dispatch3Node create(final NativeObject selector) {
-            return DispatchSelector3NodeFactory.Dispatch3NodeGen.create(selector);
+            return DispatchSelector3NodeFactory.Dispatch3NodeGen.create(selector, false);
+        }
+
+        @NeverDefault
+        public static Dispatch3Node create(final NativeObject selector, final boolean canPrimFail) {
+            return DispatchSelector3NodeFactory.Dispatch3NodeGen.create(selector, canPrimFail);
         }
 
         public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2, Object arg3);
@@ -73,7 +81,7 @@ public final class DispatchSelector3Node extends AbstractDispatchSelectorNode {
         @SuppressWarnings("truffle-static-method")
         protected final Object doIndirect(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3,
                         @Cached final DispatchIndirect3Node dispatchNode) {
-            return dispatchNode.execute(frame, false, selector, receiver, arg1, arg2, arg3);
+            return dispatchNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3);
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector4Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector4Node.java
@@ -106,9 +106,16 @@ public final class DispatchSelector4Node extends DispatchSelectorNode {
             return new DispatchDirectMethod4Node(assumptions, method);
         }
 
-        private static DispatchDirectMessageFallback4Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
-            final CompiledCodeObject fallbackMethod = receiverClass.resolveDispatchFailure(selector);
-            return new DispatchDirectMessageFallback4Node(assumptions, selector, fallbackMethod);
+        private static DispatchDirect4Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
+            final ClassObject.DispatchFailureResult result = receiverClass.resolveDispatchFailure(selector, 4);
+            final Assumption[] finalAssumptions = DispatchUtils.getAssumptionsForMessageFallback(assumptions, selector, result.fallbackMethod());
+
+            if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
+                return new DispatchDirectCannotInterpretFallback4Node(finalAssumptions, selector, result.fallbackMethod(), result.fallbackDepth(), result.fallbackSelector());
+            } else {
+                assert result.convention() == ClassObject.FallbackConvention.STANDARD_DNU : "DNU shortcuts are not supported for arity 4+";
+                return new DispatchDirectDNUFallback4Node(finalAssumptions, selector, result.fallbackMethod());
+            }
         }
     }
 
@@ -188,20 +195,55 @@ public final class DispatchSelector4Node extends DispatchSelectorNode {
         }
     }
 
-    static final class DispatchDirectMessageFallback4Node extends DispatchDirectWithSender4Node {
-        private final NativeObject selector;
-        @Child private DirectCallNode callNode;
-        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+    abstract static class AbstractDispatchDirectFallback4Node extends DispatchDirectWithSender4Node {
+        protected final NativeObject selector;
+        @Child protected DirectCallNode callNode;
 
-        DispatchDirectMessageFallback4Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+        AbstractDispatchDirectFallback4Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject targetMethod) {
             super(assumptions);
             this.selector = selector;
-            callNode = DirectCallNode.create(dnuMethod.getCallTarget());
+            this.callNode = DirectCallNode.create(targetMethod.getCallTarget());
+        }
+
+        @Override
+        public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2, Object arg3, Object arg4);
+    }
+
+    static final class DispatchDirectDNUFallback4Node extends AbstractDispatchDirectFallback4Node {
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectDNUFallback4Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+            super(assumptions, selector, dnuMethod);
         }
 
         @Override
         public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4) {
             final PointersObject message = createMessageNode.execute(selector, receiver, new Object[]{arg1, arg2, arg3, arg4});
+            return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
+        }
+    }
+
+    static final class DispatchDirectCannotInterpretFallback4Node extends AbstractDispatchDirectFallback4Node {
+        private final int fallbackDepth;
+        private final NativeObject ciSelector;
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectCannotInterpretFallback4Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject ciMethod, final int fallbackDepth,
+                        final NativeObject ciSelector) {
+            super(assumptions, selector, ciMethod);
+            this.fallbackDepth = fallbackDepth;
+            this.ciSelector = ciSelector;
+        }
+
+        @Override
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4) {
+            final PointersObject message = DispatchUtils.buildNestedMessage(
+                            createMessageNode,
+                            selector,
+                            ciSelector,
+                            receiver,
+                            new Object[]{arg1, arg2, arg3, arg4},
+                            fallbackDepth);
             return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
         }
     }
@@ -242,7 +284,14 @@ public final class DispatchSelector4Node extends DispatchSelectorNode {
             final ClassObject receiverClass = classNode.executeLookup(node, receiver);
             final Object lookupResult = getContext(node).lookup(receiverClass, selector);
             final CompiledCodeObject method = methodNode.execute(node, getContext(node), 4, canPrimFail, selector, receiverClass, lookupResult);
-            final Object result = tryPrimitiveNode.execute(frame, method, receiver, arg1, arg2, arg3, arg4);
+
+            final Object result;
+            if (lookupResult instanceof CompiledCodeObject) {
+                result = tryPrimitiveNode.execute(frame, method, receiver, arg1, arg2, arg3, arg4);
+            } else {
+                result = null;
+            }
+
             if (result != null) {
                 return result;
             } else {
@@ -319,9 +368,17 @@ public final class DispatchSelector4Node extends DispatchSelectorNode {
             @Specialization(guards = "lookupResult == null")
             protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final Object arg2, final Object arg3,
                             final Object arg4, final ClassObject receiverClass, @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
-                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode) {
+                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(4);
                 final Object[] arguments = new Object[]{arg1, arg2, arg3, arg4};
-                final PointersObject message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+
+                final PointersObject message;
+                if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
+                    message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
+                } else {
+                    message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                }
                 return FrameAccess.newMessageFallbackWith(sender, receiver, message);
             }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector4Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector4Node.java
@@ -10,12 +10,14 @@ import com.oracle.truffle.api.Assumption;
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.HostCompilerDirectives;
 import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.GenerateCached;
 import com.oracle.truffle.api.dsl.GenerateInline;
 import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.NeverDefault;
+import com.oracle.truffle.api.dsl.ReportPolymorphism;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
@@ -44,13 +46,47 @@ import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive4;
 import de.hpi.swa.trufflesqueak.nodes.primitives.PrimitiveNodeFactory;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
-public final class DispatchSelector4Node extends DispatchSelectorNode {
+public final class DispatchSelector4Node extends AbstractDispatchSelectorNode {
+    public abstract static class Dispatch4Node extends AbstractDispatchNode {
+        Dispatch4Node(final NativeObject selector) {
+            super(selector);
+        }
+
+        @NeverDefault
+        public static Dispatch4Node create(final NativeObject selector) {
+            return DispatchSelector4NodeFactory.Dispatch4NodeGen.create(selector);
+        }
+
+        public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2, Object arg3, Object arg4);
+
+        @Specialization(guards = "guard.check(receiver)", assumptions = "dispatchDirectNode.getAssumptions()", limit = "INLINE_METHOD_CACHE_LIMIT")
+        protected static final Object doDirect(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4,
+                        @SuppressWarnings("unused") @Cached("create(receiver)") final LookupClassGuard guard,
+                        @Cached("create(selector, guard)") final DispatchDirect4Node dispatchDirectNode) {
+            return dispatchDirectNode.execute(frame, receiver, arg1, arg2, arg3, arg4);
+        }
+
+        @ReportPolymorphism.Megamorphic
+        @Specialization(replaces = "doDirect")
+        @HostCompilerDirectives.InliningCutoff
+        @SuppressWarnings("truffle-static-method")
+        protected final Object doIndirect(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4,
+                        @Cached final DispatchIndirect4Node dispatchNode) {
+            return dispatchNode.execute(frame, false, selector, receiver, arg1, arg2, arg3, arg4);
+        }
+    }
+
     public abstract static class DispatchDirect4Node extends AbstractDispatchDirectNode {
         DispatchDirect4Node(final Assumption[] assumptions) {
             super(assumptions);
         }
 
         public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2, Object arg3, Object arg4);
+
+        @NeverDefault
+        protected static final DispatchDirect4Node create(final NativeObject selector, final LookupClassGuard guard) {
+            return create(selector, guard, true);
+        }
 
         @NeverDefault
         public static final DispatchDirect4Node create(final NativeObject selector, final LookupClassGuard guard, final boolean canPrimFail) {
@@ -354,7 +390,7 @@ public final class DispatchSelector4Node extends DispatchSelectorNode {
 
         @GenerateInline
         @GenerateCached(false)
-        protected abstract static class CreateFrameArgumentsForIndirectCall4Node extends AbstractNode {
+        protected abstract static class CreateFrameArgumentsForIndirectCall4Node extends AbstractCreateFrameArgumentsForIndirectCallNode {
             abstract Object[] execute(Node node, AbstractSqueakObject sender, Object receiver, Object arg1, Object arg2, Object arg3, Object arg4, ClassObject receiverClass, Object lookupResult,
                             NativeObject selector);
 
@@ -368,18 +404,13 @@ public final class DispatchSelector4Node extends DispatchSelectorNode {
             @Specialization(guards = "lookupResult == null")
             protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final Object arg2, final Object arg3,
                             final Object arg4, final ClassObject receiverClass, @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
+                            @Bind final SqueakImageContext image,
+                            @Cached final InlinedConditionProfile isCannotInterpretProfile,
                             @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
                             @Cached(inline = false) final CreateMessageNode createMessageNode) {
-                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(4);
+                final ClassObject.DispatchFailureResult result = image.findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(4);
                 final Object[] arguments = new Object[]{arg1, arg2, arg3, arg4};
-
-                final PointersObject message;
-                if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
-                    message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
-                } else {
-                    message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
-                }
-                return FrameAccess.newMessageFallbackWith(sender, receiver, message);
+                return newMessage(node, sender, receiver, arguments, receiverClass, selector, result, image, isCannotInterpretProfile, writeNode, createMessageNode);
             }
 
             @Specialization(guards = {"targetObject != null", "!isCompiledCodeObject(targetObject)"})

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector4Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector4Node.java
@@ -48,13 +48,21 @@ import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
 public final class DispatchSelector4Node extends AbstractDispatchSelectorNode {
     public abstract static class Dispatch4Node extends AbstractDispatchNode {
-        Dispatch4Node(final NativeObject selector) {
+        protected final boolean canPrimFail;
+
+        Dispatch4Node(final NativeObject selector, final boolean canPrimFail) {
             super(selector);
+            this.canPrimFail = canPrimFail;
         }
 
         @NeverDefault
         public static Dispatch4Node create(final NativeObject selector) {
-            return DispatchSelector4NodeFactory.Dispatch4NodeGen.create(selector);
+            return DispatchSelector4NodeFactory.Dispatch4NodeGen.create(selector, false);
+        }
+
+        @NeverDefault
+        public static Dispatch4Node create(final NativeObject selector, final boolean canPrimFail) {
+            return DispatchSelector4NodeFactory.Dispatch4NodeGen.create(selector, canPrimFail);
         }
 
         public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2, Object arg3, Object arg4);
@@ -72,7 +80,7 @@ public final class DispatchSelector4Node extends AbstractDispatchSelectorNode {
         @SuppressWarnings("truffle-static-method")
         protected final Object doIndirect(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4,
                         @Cached final DispatchIndirect4Node dispatchNode) {
-            return dispatchNode.execute(frame, false, selector, receiver, arg1, arg2, arg3, arg4);
+            return dispatchNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3, arg4);
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector5Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector5Node.java
@@ -99,9 +99,16 @@ public final class DispatchSelector5Node extends DispatchSelectorNode {
             return new DispatchDirectMethod5Node(assumptions, method);
         }
 
-        private static DispatchDirectMessageFallback5Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
-            final CompiledCodeObject fallbackMethod = receiverClass.resolveDispatchFailure(selector);
-            return new DispatchDirectMessageFallback5Node(assumptions, selector, fallbackMethod);
+        private static DispatchDirect5Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
+            final ClassObject.DispatchFailureResult result = receiverClass.resolveDispatchFailure(selector, 5);
+            final Assumption[] finalAssumptions = DispatchUtils.getAssumptionsForMessageFallback(assumptions, selector, result.fallbackMethod());
+
+            if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
+                return new DispatchDirectCannotInterpretFallback5Node(finalAssumptions, selector, result.fallbackMethod(), result.fallbackDepth(), result.fallbackSelector());
+            } else {
+                assert result.convention() == ClassObject.FallbackConvention.STANDARD_DNU : "DNU shortcuts are not supported for arity 4+";
+                return new DispatchDirectDNUFallback5Node(finalAssumptions, selector, result.fallbackMethod());
+            }
         }
     }
 
@@ -181,20 +188,55 @@ public final class DispatchSelector5Node extends DispatchSelectorNode {
         }
     }
 
-    static final class DispatchDirectMessageFallback5Node extends DispatchDirectWithSender5Node {
-        private final NativeObject selector;
-        @Child private DirectCallNode callNode;
-        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+    abstract static class AbstractDispatchDirectFallback5Node extends DispatchDirectWithSender5Node {
+        protected final NativeObject selector;
+        @Child protected DirectCallNode callNode;
 
-        DispatchDirectMessageFallback5Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+        AbstractDispatchDirectFallback5Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject targetMethod) {
             super(assumptions);
             this.selector = selector;
-            callNode = DirectCallNode.create(dnuMethod.getCallTarget());
+            this.callNode = DirectCallNode.create(targetMethod.getCallTarget());
+        }
+
+        @Override
+        public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5);
+    }
+
+    static final class DispatchDirectDNUFallback5Node extends AbstractDispatchDirectFallback5Node {
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectDNUFallback5Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+            super(assumptions, selector, dnuMethod);
         }
 
         @Override
         public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5) {
             final PointersObject message = createMessageNode.execute(selector, receiver, new Object[]{arg1, arg2, arg3, arg4, arg5});
+            return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
+        }
+    }
+
+    static final class DispatchDirectCannotInterpretFallback5Node extends AbstractDispatchDirectFallback5Node {
+        private final int fallbackDepth;
+        private final NativeObject ciSelector;
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectCannotInterpretFallback5Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject ciMethod, final int fallbackDepth,
+                        final NativeObject ciSelector) {
+            super(assumptions, selector, ciMethod);
+            this.fallbackDepth = fallbackDepth;
+            this.ciSelector = ciSelector;
+        }
+
+        @Override
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5) {
+            final PointersObject message = DispatchUtils.buildNestedMessage(
+                            createMessageNode,
+                            selector,
+                            ciSelector,
+                            receiver,
+                            new Object[]{arg1, arg2, arg3, arg4, arg5},
+                            fallbackDepth);
             return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
         }
     }
@@ -235,7 +277,14 @@ public final class DispatchSelector5Node extends DispatchSelectorNode {
             final ClassObject receiverClass = classNode.executeLookup(node, receiver);
             final Object lookupResult = getContext(node).lookup(receiverClass, selector);
             final CompiledCodeObject method = methodNode.execute(node, getContext(node), 5, canPrimFail, selector, receiverClass, lookupResult);
-            final Object result = tryPrimitiveNode.execute(frame, method, receiver, arg1, arg2, arg3, arg4, arg5);
+
+            final Object result;
+            if (lookupResult instanceof CompiledCodeObject) {
+                result = tryPrimitiveNode.execute(frame, method, receiver, arg1, arg2, arg3, arg4, arg5);
+            } else {
+                result = null;
+            }
+
             if (result != null) {
                 return result;
             } else {
@@ -314,9 +363,17 @@ public final class DispatchSelector5Node extends DispatchSelectorNode {
             @Specialization(guards = "lookupResult == null")
             protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final Object arg2, final Object arg3,
                             final Object arg4, final Object arg5, final ClassObject receiverClass, @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
-                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode) {
+                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(5);
                 final Object[] arguments = new Object[]{arg1, arg2, arg3, arg4, arg5};
-                final PointersObject message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+
+                final PointersObject message;
+                if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
+                    message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
+                } else {
+                    message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                }
                 return FrameAccess.newMessageFallbackWith(sender, receiver, message);
             }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector5Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector5Node.java
@@ -10,12 +10,14 @@ import com.oracle.truffle.api.Assumption;
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.HostCompilerDirectives;
 import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.GenerateCached;
 import com.oracle.truffle.api.dsl.GenerateInline;
 import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.NeverDefault;
+import com.oracle.truffle.api.dsl.ReportPolymorphism;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
@@ -44,13 +46,47 @@ import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive5;
 import de.hpi.swa.trufflesqueak.nodes.primitives.PrimitiveNodeFactory;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
-public final class DispatchSelector5Node extends DispatchSelectorNode {
+public final class DispatchSelector5Node extends AbstractDispatchSelectorNode {
+    public abstract static class Dispatch5Node extends AbstractDispatchNode {
+        Dispatch5Node(final NativeObject selector) {
+            super(selector);
+        }
+
+        @NeverDefault
+        public static Dispatch5Node create(final NativeObject selector) {
+            return DispatchSelector5NodeFactory.Dispatch5NodeGen.create(selector);
+        }
+
+        public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5);
+
+        @Specialization(guards = "guard.check(receiver)", assumptions = "dispatchDirectNode.getAssumptions()", limit = "INLINE_METHOD_CACHE_LIMIT")
+        protected static final Object doDirect(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5,
+                        @SuppressWarnings("unused") @Cached("create(receiver)") final LookupClassGuard guard,
+                        @Cached("create(selector, guard)") final DispatchDirect5Node dispatchDirectNode) {
+            return dispatchDirectNode.execute(frame, receiver, arg1, arg2, arg3, arg4, arg5);
+        }
+
+        @ReportPolymorphism.Megamorphic
+        @Specialization(replaces = "doDirect")
+        @HostCompilerDirectives.InliningCutoff
+        @SuppressWarnings("truffle-static-method")
+        protected final Object doIndirect(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5,
+                        @Cached final DispatchIndirect5Node dispatchNode) {
+            return dispatchNode.execute(frame, false, selector, receiver, arg1, arg2, arg3, arg4, arg5);
+        }
+    }
+
     public abstract static class DispatchDirect5Node extends AbstractDispatchDirectNode {
         DispatchDirect5Node(final Assumption[] assumptions) {
             super(assumptions);
         }
 
         public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5);
+
+        @NeverDefault
+        protected static final DispatchDirect5Node create(final NativeObject selector, final LookupClassGuard guard) {
+            return create(selector, guard, true);
+        }
 
         @NeverDefault
         public static final DispatchDirect5Node create(final NativeObject selector, final LookupClassGuard guard, final boolean canPrimFail) {
@@ -349,7 +385,7 @@ public final class DispatchSelector5Node extends DispatchSelectorNode {
 
         @GenerateInline
         @GenerateCached(false)
-        protected abstract static class CreateFrameArgumentsForIndirectCall5Node extends AbstractNode {
+        protected abstract static class CreateFrameArgumentsForIndirectCall5Node extends AbstractCreateFrameArgumentsForIndirectCallNode {
             abstract Object[] execute(Node node, AbstractSqueakObject sender, Object receiver, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, ClassObject receiverClass,
                             Object lookupResult, NativeObject selector);
 
@@ -363,18 +399,13 @@ public final class DispatchSelector5Node extends DispatchSelectorNode {
             @Specialization(guards = "lookupResult == null")
             protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final Object arg2, final Object arg3,
                             final Object arg4, final Object arg5, final ClassObject receiverClass, @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
+                            @Bind final SqueakImageContext image,
+                            @Cached final InlinedConditionProfile isCannotInterpretProfile,
                             @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
                             @Cached(inline = false) final CreateMessageNode createMessageNode) {
-                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(5);
+                final ClassObject.DispatchFailureResult result = image.findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(5);
                 final Object[] arguments = new Object[]{arg1, arg2, arg3, arg4, arg5};
-
-                final PointersObject message;
-                if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
-                    message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
-                } else {
-                    message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
-                }
-                return FrameAccess.newMessageFallbackWith(sender, receiver, message);
+                return newMessage(node, sender, receiver, arguments, receiverClass, selector, result, image, isCannotInterpretProfile, writeNode, createMessageNode);
             }
 
             @Specialization(guards = {"targetObject != null", "!isCompiledCodeObject(targetObject)"})

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector5Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector5Node.java
@@ -48,13 +48,21 @@ import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
 public final class DispatchSelector5Node extends AbstractDispatchSelectorNode {
     public abstract static class Dispatch5Node extends AbstractDispatchNode {
-        Dispatch5Node(final NativeObject selector) {
+        protected final boolean canPrimFail;
+
+        Dispatch5Node(final NativeObject selector, final boolean canPrimFail) {
             super(selector);
+            this.canPrimFail = canPrimFail;
         }
 
         @NeverDefault
         public static Dispatch5Node create(final NativeObject selector) {
-            return DispatchSelector5NodeFactory.Dispatch5NodeGen.create(selector);
+            return DispatchSelector5NodeFactory.Dispatch5NodeGen.create(selector, false);
+        }
+
+        @NeverDefault
+        public static Dispatch5Node create(final NativeObject selector, final boolean canPrimFail) {
+            return DispatchSelector5NodeFactory.Dispatch5NodeGen.create(selector, canPrimFail);
         }
 
         public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5);
@@ -72,7 +80,7 @@ public final class DispatchSelector5Node extends AbstractDispatchSelectorNode {
         @SuppressWarnings("truffle-static-method")
         protected final Object doIndirect(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5,
                         @Cached final DispatchIndirect5Node dispatchNode) {
-            return dispatchNode.execute(frame, false, selector, receiver, arg1, arg2, arg3, arg4, arg5);
+            return dispatchNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3, arg4, arg5);
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
@@ -82,10 +82,11 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
             return DispatchSelectorNaryNodeFactory.DispatchNaryNodeGen.create(selector);
         }
 
-        @Specialization(guards = "guard.check(receiver)", assumptions = "dispatchDirectNode.getAssumptions()", limit = "INLINE_METHOD_CACHE_LIMIT")
+        @Specialization(guards = {"guard.check(receiver)", "arguments.length == cachedArity"}, assumptions = "dispatchDirectNode.getAssumptions()", limit = "INLINE_METHOD_CACHE_LIMIT")
         protected static final Object doDirect(final VirtualFrame frame, final Object receiver, final Object[] arguments,
                         @SuppressWarnings("unused") @Cached("create(receiver)") final LookupClassGuard guard,
-                        @Cached("create(selector, guard, arguments.length)") final DispatchDirectNaryNode dispatchDirectNode) {
+                        @SuppressWarnings("unused") @Cached("arguments.length") final int cachedArity,
+                        @Cached("create(selector, guard, cachedArity)") final DispatchDirectNaryNode dispatchDirectNode) {
             return dispatchDirectNode.execute(frame, receiver, arguments);
         }
 
@@ -109,10 +110,11 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
             return DispatchSelectorNaryNodeFactory.DispatchPerformNaryNodeGen.create(selector);
         }
 
-        @Specialization(guards = "guard.check(receiver)", assumptions = "dispatchDirectNode.getAssumptions()", limit = "INLINE_METHOD_CACHE_LIMIT")
+        @Specialization(guards = {"guard.check(receiver)", "arguments.length == cachedArity"}, assumptions = "dispatchDirectNode.getAssumptions()", limit = "INLINE_METHOD_CACHE_LIMIT")
         protected static final Object doDirect(final VirtualFrame frame, final Object receiver, final Object[] arguments,
                         @SuppressWarnings("unused") @Cached("create(receiver)") final LookupClassGuard guard,
-                        @Cached("create(selector, guard, arguments.length)") final DispatchDirectNaryNode dispatchDirectNode) {
+                        @SuppressWarnings("unused") @Cached("arguments.length") final int cachedArity,
+                        @Cached("create(selector, guard, cachedArity)") final DispatchDirectNaryNode dispatchDirectNode) {
             return dispatchDirectNode.executeWithCheckedArguments(frame, receiver, arguments);
         }
 
@@ -122,7 +124,7 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
         @SuppressWarnings("truffle-static-method")
         protected final Object doIndirect(final VirtualFrame frame, final Object receiver, final Object[] arguments,
                         @Cached final DispatchIndirectNaryNode dispatchNode) {
-            return dispatchNode.execute(frame, false, selector, receiver, arguments);
+            return dispatchNode.execute(frame, true, selector, receiver, arguments);
         }
     }
 
@@ -597,18 +599,17 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
         }
 
         @Override
-        @ExplodeLoop
         public Object execute(final VirtualFrame frame, final Object receiver, final Object[] arguments) {
             assert arguments.length == arity : "Shortcut arity mismatch!";
+            final AbstractSqueakObject sender = senderNode.execute(frame);
 
-            // Build the shortcut arguments: [arg0, arg1, ..., argN, selector]
-            final Object[] shortcutArgs = new Object[arity + 1];
-            for (int i = 0; i < arity; i++) {
-                shortcutArgs[i] = arguments[i];
-            }
-            shortcutArgs[arity] = selector;
-
-            return callNode.call(FrameAccess.newWith(senderNode.execute(frame), null, receiver, shortcutArgs));
+            return switch (arity) {
+                case 0 -> callNode.call(FrameAccess.newWith(sender, null, receiver, selector));
+                case 1 -> callNode.call(FrameAccess.newWith(sender, null, receiver, arguments[0], selector));
+                case 2 -> callNode.call(FrameAccess.newWith(sender, null, receiver, arguments[0], arguments[1], selector));
+                case 3 -> callNode.call(FrameAccess.newWith(sender, null, receiver, arguments[0], arguments[1], arguments[2], selector));
+                default -> throw CompilerDirectives.shouldNotReachHere("Shortcuts have a maximum arity of 3");
+            };
         }
     }
 
@@ -802,14 +803,13 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
                             final CreateMessageNode createMessageNode) {
                 final ClassObject.DispatchFailureResult result = image.findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(arity);
                 if (isShortcutProfile.profile(node, result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU)) {
-                    final Object[] shortcutArgs = new Object[arity + 1];
-                    if (CompilerDirectives.isPartialEvaluationConstant(arity)) {
-                        ArrayUtils.copyExploded(arguments, shortcutArgs, arity);
-                    } else {
-                        ArrayUtils.arraycopy(arguments, 0, shortcutArgs, 0, arity);
-                    }
-                    shortcutArgs[arity] = selector;
-                    return FrameAccess.newWith(sender, null, receiver, shortcutArgs);
+                    return switch (arity) {
+                        case 0 -> FrameAccess.newWith(sender, null, receiver, selector);
+                        case 1 -> FrameAccess.newWith(sender, null, receiver, arguments[0], selector);
+                        case 2 -> FrameAccess.newWith(sender, null, receiver, arguments[0], arguments[1], selector);
+                        case 3 -> FrameAccess.newWith(sender, null, receiver, arguments[0], arguments[1], arguments[2], selector);
+                        default -> throw CompilerDirectives.shouldNotReachHere("Shortcuts have a maximum arity of 3");
+                    };
                 } else {
                     return newMessage(node, sender, receiver, arguments, receiverClass, selector, result, image, isCannotInterpretProfile, writeNode, createMessageNode);
                 }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
@@ -59,10 +59,11 @@ import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive7;
 import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive8;
 import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive9;
 import de.hpi.swa.trufflesqueak.nodes.primitives.PrimitiveNodeFactory;
+import de.hpi.swa.trufflesqueak.util.ArrayUtils;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
 import de.hpi.swa.trufflesqueak.util.MiscUtils;
 
-public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
+public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode {
     protected abstract static class AbstractDispatchNaryNode extends AbstractDispatchNode {
         AbstractDispatchNaryNode(final NativeObject selector) {
             super(selector);
@@ -76,11 +77,43 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
             super(selector);
         }
 
+        @NeverDefault
+        public static DispatchNaryNode create(final NativeObject selector) {
+            return DispatchSelectorNaryNodeFactory.DispatchNaryNodeGen.create(selector);
+        }
+
         @Specialization(guards = "guard.check(receiver)", assumptions = "dispatchDirectNode.getAssumptions()", limit = "INLINE_METHOD_CACHE_LIMIT")
         protected static final Object doDirect(final VirtualFrame frame, final Object receiver, final Object[] arguments,
                         @SuppressWarnings("unused") @Cached("create(receiver)") final LookupClassGuard guard,
                         @Cached("create(selector, guard, arguments.length)") final DispatchDirectNaryNode dispatchDirectNode) {
             return dispatchDirectNode.execute(frame, receiver, arguments);
+        }
+
+        @ReportPolymorphism.Megamorphic
+        @Specialization(replaces = "doDirect")
+        @HostCompilerDirectives.InliningCutoff
+        @SuppressWarnings("truffle-static-method")
+        protected final Object doIndirect(final VirtualFrame frame, final Object receiver, final Object[] arguments,
+                        @Cached final DispatchIndirectNaryNode dispatchNode) {
+            return dispatchNode.execute(frame, false, selector, receiver, arguments);
+        }
+    }
+
+    public abstract static class DispatchPerformNaryNode extends AbstractDispatchNaryNode {
+        DispatchPerformNaryNode(final NativeObject selector) {
+            super(selector);
+        }
+
+        @NeverDefault
+        public static DispatchPerformNaryNode create(final NativeObject selector) {
+            return DispatchSelectorNaryNodeFactory.DispatchPerformNaryNodeGen.create(selector);
+        }
+
+        @Specialization(guards = "guard.check(receiver)", assumptions = "dispatchDirectNode.getAssumptions()", limit = "INLINE_METHOD_CACHE_LIMIT")
+        protected static final Object doDirect(final VirtualFrame frame, final Object receiver, final Object[] arguments,
+                        @SuppressWarnings("unused") @Cached("create(receiver)") final LookupClassGuard guard,
+                        @Cached("create(selector, guard, arguments.length)") final DispatchDirectNaryNode dispatchDirectNode) {
+            return dispatchDirectNode.executeWithCheckedArguments(frame, receiver, arguments);
         }
 
         @ReportPolymorphism.Megamorphic
@@ -185,7 +218,7 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
                 if (primitiveNode != null) {
                     return new DispatchDirectPrimitiveNaryNode(assumptions, method, primitiveNode);
                 }
-                DispatchUtils.logMissingPrimitive(primitiveNode, method);
+                DispatchUtils.logMissingPrimitive(null, method);
             }
             return new DispatchDirectMethodNaryNode(assumptions, method);
         }
@@ -693,7 +726,7 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
 
         @GenerateInline
         @GenerateCached(false)
-        public abstract static class CreateFrameArgumentsForIndirectCallNaryNode extends AbstractNode {
+        public abstract static class CreateFrameArgumentsForIndirectCallNaryNode extends AbstractCreateFrameArgumentsForIndirectCallNode {
             public abstract Object[] execute(Node node, AbstractSqueakObject sender, Object receiver, Object[] arguments, ClassObject receiverClass, Object lookupResult, NativeObject selector);
 
             @Specialization
@@ -703,55 +736,82 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
                 return FrameAccess.newWith(sender, null, receiver, arguments);
             }
 
-            @Specialization(guards = {"lookupResult == null", "arguments.length == cachedArity"}, limit = "1")
-            @ExplodeLoop
+            @Specialization(guards = {"lookupResult == null", "arguments.length == cachedArity"}, limit = "1", assumptions = {"image.getDnuShortcutsAbsent()"})
             protected static final Object[] doMessageFallbackCached(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object[] arguments,
                             final ClassObject receiverClass,
                             @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
+                            @Bind final SqueakImageContext image,
+                            @Shared("isCannotInterpret") @Cached final InlinedConditionProfile isCannotInterpretProfile,
                             @Cached("arguments.length") final int cachedArity,
                             @Shared("writeNode") @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
                             @Shared("createNode") @Cached(inline = false) final CreateMessageNode createMessageNode) {
-                return doMessageFallbackShared(node, sender, receiver, arguments, receiverClass, selector, cachedArity, writeNode, createMessageNode);
+                return doMessageFallbackShared(node, sender, receiver, arguments, receiverClass, selector, cachedArity, image, isCannotInterpretProfile, writeNode, createMessageNode);
             }
 
-            @Specialization(guards = "lookupResult == null", replaces = "doMessageFallbackCached")
+            @Specialization(guards = "lookupResult == null", replaces = "doMessageFallbackCached", assumptions = {"image.getDnuShortcutsAbsent()"})
             protected static final Object[] doMessageFallbackGeneric(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object[] arguments,
                             final ClassObject receiverClass,
                             @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
+                            @Bind final SqueakImageContext image,
+                            @Shared("isCannotInterpret") @Cached final InlinedConditionProfile isCannotInterpretProfile,
                             @Shared("writeNode") @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
                             @Shared("createNode") @Cached(inline = false) final CreateMessageNode createMessageNode) {
-                return doMessageFallbackShared(node, sender, receiver, arguments, receiverClass, selector, arguments.length, writeNode, createMessageNode);
+                return doMessageFallbackShared(node, sender, receiver, arguments, receiverClass, selector, arguments.length, image, isCannotInterpretProfile, writeNode, createMessageNode);
             }
 
-            private static Object[] doMessageFallbackShared(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object[] arguments, final ClassObject receiverClass,
-                            final NativeObject selector, final int arity, final AbstractPointersObjectWriteNode writeNode, final CreateMessageNode createMessageNode) {
+            private static Object[] doMessageFallbackShared(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object[] arguments,
+                            final ClassObject receiverClass,
+                            final NativeObject selector, final int arity, final SqueakImageContext image,
+                            final InlinedConditionProfile isCannotInterpretProfile, final AbstractPointersObjectWriteNode writeNode, final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = image.findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(arity);
+                return newMessage(node, sender, receiver, arguments, receiverClass, selector, result, image, isCannotInterpretProfile, writeNode, createMessageNode);
+            }
 
-                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(arity);
+            @Specialization(guards = {"lookupResult == null", "arguments.length == cachedArity"}, limit = "1", replaces = {"doMessageFallbackCached", "doMessageFallbackGeneric"})
+            @ExplodeLoop
+            protected static final Object[] doMessageFallbackWithShortcutsCached(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object[] arguments,
+                            final ClassObject receiverClass,
+                            @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
+                            @Bind final SqueakImageContext image,
+                            @Shared("isShortcut") @Cached final InlinedConditionProfile isShortcutProfile,
+                            @Shared("isCannotInterpret") @Cached final InlinedConditionProfile isCannotInterpretProfile,
+                            @Cached("arguments.length") final int cachedArity,
+                            @Shared("writeNode") @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Shared("createNode") @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                return doMessageFallbackWithShortcutsShared(node, sender, receiver, arguments, receiverClass, selector, cachedArity, image, isShortcutProfile, isCannotInterpretProfile, writeNode,
+                                createMessageNode);
+            }
 
-                if (result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU) {
+            @Specialization(guards = "lookupResult == null", replaces = {"doMessageFallbackCached", "doMessageFallbackGeneric", "doMessageFallbackWithShortcutsCached"})
+            protected static final Object[] doMessageFallbackWithShortcutsGeneric(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object[] arguments,
+                            final ClassObject receiverClass,
+                            @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
+                            @Bind final SqueakImageContext image,
+                            @Shared("isShortcut") @Cached final InlinedConditionProfile isShortcutProfile,
+                            @Shared("isCannotInterpret") @Cached final InlinedConditionProfile isCannotInterpretProfile,
+                            @Shared("writeNode") @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Shared("createNode") @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                return doMessageFallbackWithShortcutsShared(node, sender, receiver, arguments, receiverClass, selector, arguments.length, image, isShortcutProfile, isCannotInterpretProfile, writeNode,
+                                createMessageNode);
+            }
+
+            private static Object[] doMessageFallbackWithShortcutsShared(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object[] arguments,
+                            final ClassObject receiverClass,
+                            final NativeObject selector, final int arity, final SqueakImageContext image,
+                            final InlinedConditionProfile isShortcutProfile, final InlinedConditionProfile isCannotInterpretProfile, final AbstractPointersObjectWriteNode writeNode,
+                            final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = image.findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(arity);
+                if (isShortcutProfile.profile(node, result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU)) {
                     final Object[] shortcutArgs = new Object[arity + 1];
                     if (CompilerDirectives.isPartialEvaluationConstant(arity)) {
-                        copyExploded(arguments, shortcutArgs, arity);
+                        ArrayUtils.copyExploded(arguments, shortcutArgs, arity);
                     } else {
-                        System.arraycopy(arguments, 0, shortcutArgs, 0, arity);
+                        ArrayUtils.arraycopy(arguments, 0, shortcutArgs, 0, arity);
                     }
                     shortcutArgs[arity] = selector;
                     return FrameAccess.newWith(sender, null, receiver, shortcutArgs);
-                }
-
-                final PointersObject message;
-                if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
-                    message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
                 } else {
-                    message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
-                }
-                return FrameAccess.newMessageFallbackWith(sender, receiver, message);
-            }
-
-            @ExplodeLoop
-            private static void copyExploded(final Object[] source, final Object[] dest, final int length) {
-                for (int i = 0; i < length; i++) {
-                    dest[i] = source[i];
+                    return newMessage(node, sender, receiver, arguments, receiverClass, selector, result, image, isCannotInterpretProfile, writeNode, createMessageNode);
                 }
             }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
@@ -13,6 +13,7 @@ import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.HostCompilerDirectives;
 import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Cached.Shared;
 import com.oracle.truffle.api.dsl.GenerateCached;
 import com.oracle.truffle.api.dsl.GenerateInline;
 import com.oracle.truffle.api.dsl.GenerateUncached;
@@ -23,6 +24,7 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.DirectCallNode;
+import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.IndirectCallNode;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.InlinedBranchProfile;
@@ -77,7 +79,7 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
         @Specialization(guards = "guard.check(receiver)", assumptions = "dispatchDirectNode.getAssumptions()", limit = "INLINE_METHOD_CACHE_LIMIT")
         protected static final Object doDirect(final VirtualFrame frame, final Object receiver, final Object[] arguments,
                         @SuppressWarnings("unused") @Cached("create(receiver)") final LookupClassGuard guard,
-                        @Cached("create(selector, guard)") final DispatchDirectNaryNode dispatchDirectNode) {
+                        @Cached("create(selector, guard, arguments.length)") final DispatchDirectNaryNode dispatchDirectNode) {
             return dispatchDirectNode.execute(frame, receiver, arguments);
         }
 
@@ -102,7 +104,7 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
         @Specialization(assumptions = {"cachedMethodClass.getClassHierarchyAndMethodDictStable()", "dispatchDirectNode.getAssumptions()"})
         protected static final Object doCached(final VirtualFrame frame, final Object receiver, final Object[] arguments,
                         @SuppressWarnings("unused") @Cached("method.getMethodClassSlow()") final ClassObject cachedMethodClass,
-                        @Cached("create(selector, cachedMethodClass.getResolvedSuperclass())") final DispatchDirectNaryNode dispatchDirectNode) {
+                        @Cached("create(selector, cachedMethodClass.getResolvedSuperclass(), arguments.length)") final DispatchDirectNaryNode dispatchDirectNode) {
             return dispatchDirectNode.execute(frame, receiver, arguments);
         }
     }
@@ -118,7 +120,7 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
                         "dispatchDirectNode.getAssumptions()"}, limit = "3")
         protected static final Object doCached(final VirtualFrame frame, @SuppressWarnings("unused") final ClassObject lookupClass, final Object receiver, final Object[] arguments,
                         @SuppressWarnings("unused") @Cached("lookupClass") final ClassObject cachedLookupClass,
-                        @Cached("create(selector, cachedLookupClass)") final DispatchDirectNaryNode dispatchDirectNode) {
+                        @Cached("create(selector, cachedLookupClass, arguments.length)") final DispatchDirectNaryNode dispatchDirectNode) {
             return dispatchDirectNode.execute(frame, receiver, arguments);
         }
     }
@@ -145,9 +147,9 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
         }
 
         @NeverDefault
-        public static final DispatchDirectNaryNode create(final NativeObject selector, final LookupClassGuard guard) {
+        public static final DispatchDirectNaryNode create(final NativeObject selector, final LookupClassGuard guard, final int arity) {
             final ClassObject receiverClass = guard.getSqueakClassInternal(null);
-            return create(selector, receiverClass);
+            return create(selector, receiverClass, arity);
         }
 
         @NeverDefault
@@ -158,13 +160,13 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
         }
 
         @NeverDefault
-        public static final DispatchDirectNaryNode create(final NativeObject selector, final ClassObject lookupClass) {
+        public static final DispatchDirectNaryNode create(final NativeObject selector, final ClassObject lookupClass, final int arity) {
             final Object lookupResult = lookupClass.lookupInMethodDictSlow(selector);
             final Assumption[] assumptions = DispatchUtils.createAssumptions(lookupClass, lookupResult);
             if (lookupResult instanceof final CompiledCodeObject lookupMethod) {
                 return create(assumptions, lookupMethod);
             } else if (lookupResult == null) {
-                return createMessageFallbackNode(selector, assumptions, lookupClass);
+                return createMessageFallbackNode(selector, assumptions, lookupClass, arity);
             } else {
                 final ClassObject lookupResultClass = SqueakObjectClassNode.executeUncached(lookupResult);
                 final Object runWithInLookupResult = LookupMethodNode.executeUncached(lookupResultClass, SqueakImageContext.getSlow().runWithInSelector);
@@ -172,26 +174,31 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
                     return new DispatchDirectObjectAsMethodNaryNode(assumptions, selector, runWithInMethod, lookupResult);
                 } else {
                     assert runWithInLookupResult == null : "runWithInLookupResult should not be another Object";
-                    return createMessageFallbackNode(selector, assumptions, lookupResultClass);
+                    return createMessageFallbackNode(selector, assumptions, lookupResultClass, arity);
                 }
             }
         }
 
         private static DispatchDirectNaryNode create(final Assumption[] assumptions, final CompiledCodeObject method) {
-            // Cannot check argument count here (actual count of arguments only known when called).
             if (method.hasPrimitive()) {
                 final AbstractPrimitiveNode primitiveNode = PrimitiveNodeFactory.getOrCreateIndexedOrNamed(method);
                 if (primitiveNode != null) {
                     return new DispatchDirectPrimitiveNaryNode(assumptions, method, primitiveNode);
                 }
-                DispatchUtils.logMissingPrimitive(null, method);
+                DispatchUtils.logMissingPrimitive(primitiveNode, method);
             }
             return new DispatchDirectMethodNaryNode(assumptions, method);
         }
 
-        private static DispatchDirectMessageFallbackNaryNode createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
-            final CompiledCodeObject fallbackMethod = receiverClass.resolveDispatchFailure(selector);
-            return new DispatchDirectMessageFallbackNaryNode(assumptions, selector, fallbackMethod);
+        private static DispatchDirectNaryNode createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass, final int arity) {
+            final ClassObject.DispatchFailureResult result = receiverClass.resolveDispatchFailure(selector, arity);
+            final Assumption[] finalAssumptions = DispatchUtils.getAssumptionsForMessageFallback(assumptions, selector, result.fallbackMethod());
+
+            return switch (result.convention()) {
+                case SHORTCUT_DNU -> new DispatchDirectShortcutFallbackNaryNode(finalAssumptions, selector, result.fallbackMethod(), arity);
+                case STANDARD_DNU -> new DispatchDirectDNUFallbackNaryNode(finalAssumptions, selector, result.fallbackMethod());
+                case CANNOT_INTERPRET -> new DispatchDirectCannotInterpretFallbackNaryNode(finalAssumptions, selector, result.fallbackMethod(), result.fallbackDepth(), result.fallbackSelector());
+            };
         }
     }
 
@@ -490,26 +497,85 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
         }
     }
 
-    static final class DispatchDirectMessageFallbackNaryNode extends DispatchDirectWithSenderNaryNode {
-        private final NativeObject selector;
-        @Child private DirectCallNode callNode;
-        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+    abstract static class AbstractDispatchDirectFallbackNaryNode extends DispatchDirectWithSenderNaryNode {
+        protected final NativeObject selector;
+        @Child protected DirectCallNode callNode;
 
-        DispatchDirectMessageFallbackNaryNode(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+        AbstractDispatchDirectFallbackNaryNode(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject targetMethod) {
             super(assumptions);
             this.selector = selector;
-            callNode = DirectCallNode.create(dnuMethod.getCallTarget());
+            this.callNode = DirectCallNode.create(targetMethod.getCallTarget());
         }
 
         @Override
         protected void checkNumArguments(final Object[] arguments) {
-            // nothing to do
+            // Nothing to do; fallback message creation handles arbitrary arrays
+        }
+
+        @Override
+        public abstract Object execute(VirtualFrame frame, Object receiver, Object[] arguments);
+    }
+
+    static final class DispatchDirectDNUFallbackNaryNode extends AbstractDispatchDirectFallbackNaryNode {
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectDNUFallbackNaryNode(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+            super(assumptions, selector, dnuMethod);
         }
 
         @Override
         public Object execute(final VirtualFrame frame, final Object receiver, final Object[] arguments) {
             final PointersObject message = createMessageNode.execute(selector, receiver, arguments);
             return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
+        }
+    }
+
+    static final class DispatchDirectCannotInterpretFallbackNaryNode extends AbstractDispatchDirectFallbackNaryNode {
+        private final int fallbackDepth;
+        private final NativeObject ciSelector;
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectCannotInterpretFallbackNaryNode(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject ciMethod, final int fallbackDepth,
+                        final NativeObject ciSelector) {
+            super(assumptions, selector, ciMethod);
+            this.fallbackDepth = fallbackDepth;
+            this.ciSelector = ciSelector;
+        }
+
+        @Override
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object[] arguments) {
+            final PointersObject message = DispatchUtils.buildNestedMessage(
+                            createMessageNode,
+                            selector,
+                            ciSelector,
+                            receiver,
+                            arguments,
+                            fallbackDepth);
+            return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
+        }
+    }
+
+    static final class DispatchDirectShortcutFallbackNaryNode extends AbstractDispatchDirectFallbackNaryNode {
+        private final int arity;
+
+        DispatchDirectShortcutFallbackNaryNode(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject shortcutMethod, final int arity) {
+            super(assumptions, selector, shortcutMethod);
+            this.arity = arity;
+        }
+
+        @Override
+        @ExplodeLoop
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object[] arguments) {
+            assert arguments.length == arity : "Shortcut arity mismatch!";
+
+            // Build the shortcut arguments: [arg0, arg1, ..., argN, selector]
+            final Object[] shortcutArgs = new Object[arity + 1];
+            for (int i = 0; i < arity; i++) {
+                shortcutArgs[i] = arguments[i];
+            }
+            shortcutArgs[arity] = selector;
+
+            return callNode.call(FrameAccess.newWith(senderNode.execute(frame), null, receiver, shortcutArgs));
         }
     }
 
@@ -553,7 +619,14 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
             final ClassObject receiverClass = classNode.executeLookup(node, receiver);
             final Object lookupResult = getContext(node).lookup(receiverClass, selector);
             final CompiledCodeObject method = methodNode.execute(node, getContext(node), arguments.length, canPrimFail, selector, receiverClass, lookupResult);
-            final Object result = tryPrimitiveNode.execute(frame, method, receiver, arguments);
+
+            final Object result;
+            if (lookupResult instanceof CompiledCodeObject) {
+                result = tryPrimitiveNode.execute(frame, method, receiver, arguments);
+            } else {
+                result = null;
+            }
+
             if (result != null) {
                 return result;
             } else {
@@ -630,12 +703,56 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
                 return FrameAccess.newWith(sender, null, receiver, arguments);
             }
 
-            @Specialization(guards = "lookupResult == null")
-            protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object[] arguments, final ClassObject receiverClass,
+            @Specialization(guards = {"lookupResult == null", "arguments.length == cachedArity"}, limit = "1")
+            @ExplodeLoop
+            protected static final Object[] doMessageFallbackCached(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object[] arguments,
+                            final ClassObject receiverClass,
                             @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
-                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode) {
-                final PointersObject message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                            @Cached("arguments.length") final int cachedArity,
+                            @Shared("writeNode") @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Shared("createNode") @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                return doMessageFallbackShared(node, sender, receiver, arguments, receiverClass, selector, cachedArity, writeNode, createMessageNode);
+            }
+
+            @Specialization(guards = "lookupResult == null", replaces = "doMessageFallbackCached")
+            protected static final Object[] doMessageFallbackGeneric(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object[] arguments,
+                            final ClassObject receiverClass,
+                            @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
+                            @Shared("writeNode") @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Shared("createNode") @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                return doMessageFallbackShared(node, sender, receiver, arguments, receiverClass, selector, arguments.length, writeNode, createMessageNode);
+            }
+
+            private static Object[] doMessageFallbackShared(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object[] arguments, final ClassObject receiverClass,
+                            final NativeObject selector, final int arity, final AbstractPointersObjectWriteNode writeNode, final CreateMessageNode createMessageNode) {
+
+                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(arity);
+
+                if (result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU) {
+                    final Object[] shortcutArgs = new Object[arity + 1];
+                    if (CompilerDirectives.isPartialEvaluationConstant(arity)) {
+                        copyExploded(arguments, shortcutArgs, arity);
+                    } else {
+                        System.arraycopy(arguments, 0, shortcutArgs, 0, arity);
+                    }
+                    shortcutArgs[arity] = selector;
+                    return FrameAccess.newWith(sender, null, receiver, shortcutArgs);
+                }
+
+                final PointersObject message;
+                if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
+                    message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
+                } else {
+                    message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                }
                 return FrameAccess.newMessageFallbackWith(sender, receiver, message);
+            }
+
+            @ExplodeLoop
+            private static void copyExploded(final Object[] source, final Object[] dest, final int length) {
+                for (int i = 0; i < length; i++) {
+                    dest[i] = source[i];
+                }
             }
 
             @Specialization(guards = {"targetObject != null", "!isCompiledCodeObject(targetObject)"})

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
@@ -24,7 +24,6 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.DirectCallNode;
-import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.IndirectCallNode;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.InlinedBranchProfile;
@@ -769,7 +768,6 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
             }
 
             @Specialization(guards = {"lookupResult == null", "arguments.length == cachedArity"}, limit = "1", replaces = {"doMessageFallbackCached", "doMessageFallbackGeneric"})
-            @ExplodeLoop
             protected static final Object[] doMessageFallbackWithShortcutsCached(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object[] arguments,
                             final ClassObject receiverClass,
                             @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchUtils.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchUtils.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 
 import com.oracle.truffle.api.Assumption;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.NodeInterface;
 
@@ -17,6 +18,8 @@ import de.hpi.swa.trufflesqueak.exceptions.PrimitiveFailed;
 import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
 import de.hpi.swa.trufflesqueak.model.ClassObject;
 import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
+import de.hpi.swa.trufflesqueak.model.NativeObject;
+import de.hpi.swa.trufflesqueak.model.PointersObject;
 import de.hpi.swa.trufflesqueak.nodes.primitives.AbstractPrimitiveNode;
 import de.hpi.swa.trufflesqueak.nodes.primitives.PrimitiveNodeFactory;
 import de.hpi.swa.trufflesqueak.util.LogUtils;
@@ -63,6 +66,38 @@ public final class DispatchUtils {
             // be avoided.
             return list.toArray(new Assumption[0]);
         }
+    }
+
+    /**
+     * Creates the complete assumption array for a message fallback node (DNU or CI). On top of the
+     * standard class hierarchy stability, it registers two assumptions:
+     *
+     * Fallback Method Stability: Tracks the `callTargetStable` of the resolved fallback method
+     * itself. This ensures the AST node is invalidated if the actual #doesNotUnderstand: or
+     * #cannotInterpret: method is later modified or recompiled.
+     *
+     * Absent Selector Stability: Tracks an image-global assumption that the specific failing
+     * selector does not exist. If a method for this missing selector is compiled, the VM's cache
+     * flush (primitive 119) will trip this assumption globally. This prevents "stranded DNU" nodes
+     * by forcing them to drop and re-resolve to the newly added method.
+     */
+    static Assumption[] getAssumptionsForMessageFallback(final Assumption[] classAssumptions, final NativeObject selector, final CompiledCodeObject fallbackMethod) {
+        final Assumption[] finalAssumptions = new Assumption[classAssumptions.length + 2];
+        System.arraycopy(classAssumptions, 0, finalAssumptions, 0, classAssumptions.length);
+        finalAssumptions[classAssumptions.length] = fallbackMethod.getCallTargetStable();
+        finalAssumptions[classAssumptions.length + 1] = SqueakImageContext.getSlow().getAbsentSelectorAssumption(selector);
+        return finalAssumptions;
+    }
+
+    @ExplodeLoop
+    static PointersObject buildNestedMessage(final CreateMessageNode createMessageNode,
+                    final NativeObject originalSelector, final NativeObject cannotInterpretSelector,
+                    final Object receiver, final Object[] arguments, final int fallbackDepth) {
+        PointersObject message = createMessageNode.execute(originalSelector, receiver, arguments);
+        for (int i = 1; i < fallbackDepth; i++) {
+            message = createMessageNode.execute(cannotInterpretSelector, receiver, new Object[]{message});
+        }
+        return message;
     }
 
     static void logMissingPrimitive(final AbstractPrimitiveNode primitiveNode, final CompiledCodeObject code) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchUtils.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchUtils.java
@@ -71,11 +71,11 @@ public final class DispatchUtils {
     /**
      * Creates the complete assumption array for a message fallback node (DNU or CI). On top of the
      * standard class hierarchy stability, it registers two assumptions:
-     *
+     * <p>
      * Fallback Method Stability: Tracks the `callTargetStable` of the resolved fallback method
      * itself. This ensures the AST node is invalidated if the actual #doesNotUnderstand: or
      * #cannotInterpret: method is later modified or recompiled.
-     *
+     * <p>
      * Absent Selector Stability: Tracks an image-global assumption that the specific failing
      * selector does not exist. If a method for this missing selector is compiled, the VM's cache
      * flush (primitive 119) will trip this assumption globally. This prevents "stranded DNU" nodes

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchValueWithArgNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchValueWithArgNode.java
@@ -70,11 +70,11 @@ public abstract class DispatchValueWithArgNode extends AbstractNode {
 
     @Fallback
     protected static final Object doSend(final VirtualFrame frame, final Object receiver, final Object arg1,
-                    @Cached("create(getValueWitArgSelector())") final DispatchSelector1Node.Dispatch1Node genericDispatchNode) {
+                    @Cached("create(getValueWithArgSelector())") final DispatchSelector1Node.Dispatch1Node genericDispatchNode) {
         return genericDispatchNode.execute(frame, receiver, arg1);
     }
 
-    protected static final NativeObject getValueWitArgSelector() {
+    protected static final NativeObject getValueWithArgSelector() {
         return SqueakImageContext.getSlow().getSpecialSelector(SPECIAL_SELECTOR.VALUE_WITH_ARG);
     }
 }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/ResolveMethodNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/ResolveMethodNode.java
@@ -48,12 +48,15 @@ public abstract class ResolveMethodNode extends AbstractNode {
 
     @SuppressWarnings("unused")
     @Specialization(guards = "lookupResult == null")
-    protected static final CompiledCodeObject doDispatchFailure(final SqueakImageContext image, final int expectedNumArgs, final boolean canPrimFail, final NativeObject selector,
+    protected static final CompiledCodeObject doDispatchFailure(final SqueakImageContext image, final int expectedNumArgs, final boolean canPrimFail,
+                    final NativeObject selector,
                     final ClassObject receiverClass,
                     final Object lookupResult) {
         final MethodCacheEntry cacheEntry = image.findMethodCacheEntry(receiverClass, selector);
-        final CompiledCodeObject fallbackMethod = cacheEntry.getOrCreateFallbackMethod();
-        assert fallbackMethod.getNumArgs() == 1 : "Fallback method with unexpected number of arguments, got " + fallbackMethod.getNumArgs();
+        final ClassObject.DispatchFailureResult result = cacheEntry.getOrCreateDispatchFailureResult(expectedNumArgs);
+        final CompiledCodeObject fallbackMethod = result.fallbackMethod();
+        assert fallbackMethod.getNumArgs() == 1 || (result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU &&
+                        fallbackMethod.getNumArgs() == expectedNumArgs + 1) : "Fallback method with unexpected number of arguments";
         return fallbackMethod;
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractInterpreterNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractInterpreterNode.java
@@ -40,6 +40,7 @@ import de.hpi.swa.trufflesqueak.model.BlockClosureObject;
 import de.hpi.swa.trufflesqueak.model.ClassObject;
 import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
 import de.hpi.swa.trufflesqueak.model.ContextObject;
+import de.hpi.swa.trufflesqueak.model.NativeObject;
 import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.ASSOCIATION;
 import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.PROCESS;
 import de.hpi.swa.trufflesqueak.nodes.AbstractNode;
@@ -47,10 +48,13 @@ import de.hpi.swa.trufflesqueak.nodes.accessing.AbstractPointersObjectNodes.Abst
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectAt0NodeGen;
 import de.hpi.swa.trufflesqueak.nodes.context.GetOrCreateContextWithFrameNode;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.AbstractDispatchNode;
-import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector0NodeFactory.Dispatch0NodeGen;
-import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector1NodeFactory.Dispatch1NodeGen;
-import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector2NodeFactory.Dispatch2NodeGen;
-import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNodeFactory.DispatchNaryNodeGen;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector0Node.Dispatch0Node;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector1Node.Dispatch1Node;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector2Node.Dispatch2Node;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector3Node.Dispatch3Node;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector4Node.Dispatch4Node;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector5Node.Dispatch5Node;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNode.DispatchNaryNode;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchValueNodeGen;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchValueWithArgNodeGen;
 import de.hpi.swa.trufflesqueak.nodes.interrupts.CheckForInterruptsNode.CheckForInterruptsInLoopNode;
@@ -178,52 +182,81 @@ public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrum
         return new BlockClosureObject(true, block, block.getShadowBlockNumArgs(), copiedValues, FrameAccess.getReceiver(frame), outerContext);
     }
 
-    protected final Object send(final VirtualFrame frame, final int currentPC, final Object receiver) {
-        return followForwarded(currentPC, dispatch(frame, currentPC, receiver));
+    protected static final AbstractDispatchNode createDispatchNode(final int numArgs, final NativeObject selector) {
+        return switch (numArgs) {
+            case 0 -> Dispatch0Node.create(selector);
+            case 1 -> Dispatch1Node.create(selector);
+            case 2 -> Dispatch2Node.create(selector);
+            case 3 -> Dispatch3Node.create(selector);
+            case 4 -> Dispatch4Node.create(selector);
+            case 5 -> Dispatch5Node.create(selector);
+            default -> DispatchNaryNode.create(selector);
+        };
     }
 
-    private Object dispatch(final VirtualFrame frame, final int currentPC, final Object receiver) {
+    protected final Object send(final VirtualFrame frame, final int currentPC, final Object receiver) {
+        return followForwarded(currentPC, dispatchHandled(frame, currentPC, receiver));
+    }
+
+    private Object dispatchHandled(final VirtualFrame frame, final int currentPC, final Object receiver) {
         try {
-            return ACCESS.uncheckedCast(getData(currentPC), Dispatch0NodeGen.class).execute(frame, receiver);
+            return dispatch(frame, currentPC, receiver);
         } catch (final AbstractStandardSendReturn r) {
             return handleReturnException(frame, currentPC, r);
         }
+    }
+
+    protected final Object dispatch(final VirtualFrame frame, final int currentPC, final Object receiver) {
+        return ACCESS.uncheckedCast(getData(currentPC), Dispatch0Node.class).execute(frame, receiver);
     }
 
     protected final Object send(final VirtualFrame frame, final int currentPC, final Object receiver, final Object arg) {
-        return followForwarded(currentPC, dispatch(frame, currentPC, receiver, arg));
+        return followForwarded(currentPC, dispatchHandled(frame, currentPC, receiver, arg));
     }
 
-    private Object dispatch(final VirtualFrame frame, final int currentPC, final Object receiver, final Object arg) {
+    private Object dispatchHandled(final VirtualFrame frame, final int currentPC, final Object receiver, final Object arg) {
         try {
-            return ACCESS.uncheckedCast(getData(currentPC), Dispatch1NodeGen.class).execute(frame, receiver, arg);
+            return dispatch(frame, currentPC, receiver, arg);
         } catch (final AbstractStandardSendReturn r) {
             return handleReturnException(frame, currentPC, r);
         }
+    }
+
+    protected final Object dispatch(final VirtualFrame frame, final int currentPC, final Object receiver, final Object arg) {
+        return ACCESS.uncheckedCast(getData(currentPC), Dispatch1Node.class).execute(frame, receiver, arg);
     }
 
     protected final Object send(final VirtualFrame frame, final int currentPC, final Object receiver, final Object arg1, final Object arg2) {
-        return followForwarded(currentPC, dispatch(frame, currentPC, receiver, arg1, arg2));
+        return followForwarded(currentPC, dispatchHandled(frame, currentPC, receiver, arg1, arg2));
     }
 
-    private Object dispatch(final VirtualFrame frame, final int currentPC, final Object receiver, final Object arg1, final Object arg2) {
+    private Object dispatchHandled(final VirtualFrame frame, final int currentPC, final Object receiver, final Object arg1, final Object arg2) {
         try {
-            return ACCESS.uncheckedCast(getData(currentPC), Dispatch2NodeGen.class).execute(frame, receiver, arg1, arg2);
+            return dispatch(frame, currentPC, receiver, arg1, arg2);
         } catch (final AbstractStandardSendReturn r) {
             return handleReturnException(frame, currentPC, r);
         }
     }
 
-    protected final Object sendNary(final VirtualFrame frame, final int currentPC, final Object receiver, final Object[] arguments) {
-        return followForwarded(currentPC, dispatchNary(frame, currentPC, receiver, arguments));
+    protected final Object dispatch(final VirtualFrame frame, final int currentPC, final Object receiver, final Object arg1, final Object arg2) {
+        return ACCESS.uncheckedCast(getData(currentPC), Dispatch2Node.class).execute(frame, receiver, arg1, arg2);
     }
 
-    private Object dispatchNary(final VirtualFrame frame, final int currentPC, final Object receiver, final Object[] arguments) {
-        try {
-            return ACCESS.uncheckedCast(getData(currentPC), DispatchNaryNodeGen.class).execute(frame, receiver, arguments);
-        } catch (final AbstractStandardSendReturn r) {
-            return handleReturnException(frame, currentPC, r);
-        }
+    protected final Object dispatch(final VirtualFrame frame, final int currentPC, final Object receiver, final Object arg1, final Object arg2, final Object arg3) {
+        return ACCESS.uncheckedCast(getData(currentPC), Dispatch3Node.class).execute(frame, receiver, arg1, arg2, arg3);
+    }
+
+    protected final Object dispatch(final VirtualFrame frame, final int currentPC, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4) {
+        return ACCESS.uncheckedCast(getData(currentPC), Dispatch4Node.class).execute(frame, receiver, arg1, arg2, arg3, arg4);
+    }
+
+    protected final Object dispatch(final VirtualFrame frame, final int currentPC, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4,
+                    final Object arg5) {
+        return ACCESS.uncheckedCast(getData(currentPC), Dispatch5Node.class).execute(frame, receiver, arg1, arg2, arg3, arg4, arg5);
+    }
+
+    protected final Object dispatchNary(final VirtualFrame frame, final int currentPC, final Object receiver, final Object[] arguments) {
+        return ACCESS.uncheckedCast(getData(currentPC), DispatchNaryNode.class).execute(frame, receiver, arguments);
     }
 
     protected final Object sendValue(final VirtualFrame frame, final int currentPC, final Object receiver) {
@@ -396,9 +429,9 @@ public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrum
                 FrameAccess.externalizePCAndSP(frame, pc, sp);
                 if (getData(currentPC) == null) {
                     CompilerDirectives.transferToInterpreterAndInvalidate();
-                    setData(currentPC, insert(Dispatch2NodeGen.create(getContext().aboutToReturnSelector)));
+                    setData(currentPC, insert(Dispatch2Node.create(getContext().aboutToReturnSelector)));
                 }
-                ((Dispatch2NodeGen) getData(currentPC)).execute(frame, getOrCreateContext(frame, currentPC), result, firstMarkedContext);
+                ((Dispatch2Node) getData(currentPC)).execute(frame, getOrCreateContext(frame, currentPC), result, firstMarkedContext);
             }
         }
         throw cannotReturn(frame, pc, sp, result);
@@ -459,7 +492,7 @@ public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrum
     /*
      * Handling of forwarding pointers
      */
-    private Object followForwarded(final int currentPC, final Object value) {
+    protected final Object followForwarded(final int currentPC, final Object value) {
         final byte profile = getProfile(currentPC);
         if (value instanceof final AbstractSqueakObjectWithClassAndHash object) {
             enter(currentPC, profile, BRANCH6);
@@ -546,7 +579,8 @@ public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrum
             if (data[i] instanceof AbstractDispatchNode) {
                 final int bytecode = getUnsignedInt(bc, i);
                 if (isFastPathedMessageSend(bytecode)) {
-                    // The interpreter could handle this directly and might not check for interrupts.
+                    // The interpreter could handle this directly and might not check for
+                    // interrupts.
                     continue;
                 }
                 return null;

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterSistaV1Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterSistaV1Node.java
@@ -48,11 +48,10 @@ import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectAtPut0Node;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectAtPut0NodeGen;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectClassNodeGen;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectIdentityNodeGen;
-import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector0NodeFactory.Dispatch0NodeGen;
-import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector1NodeFactory.Dispatch1NodeGen;
-import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector2NodeFactory.Dispatch2NodeGen;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector0Node.Dispatch0Node;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector1Node.Dispatch1Node;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector2Node.Dispatch2Node;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNodeFactory.DispatchDirectedSuperNaryNodeGen;
-import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNodeFactory.DispatchNaryNodeGen;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNodeFactory.DispatchSuperNaryNodeGen;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchValueNodeGen;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchValueWithArgNodeGen;
@@ -227,7 +226,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                     vstate.resetExtAB();
                     break;
                 case BC.BYTECODE_PRIM_SIZE, BC.BYTECODE_PRIM_NEXT, BC.BYTECODE_PRIM_AT_END, BC.BYTECODE_PRIM_NEW, BC.BYTECODE_PRIM_POINT_X, BC.BYTECODE_PRIM_POINT_Y: {
-                    setData(currentPC, insert(Dispatch0NodeGen.create(image.getSpecialSelector(b - BC.BYTECODE_PRIM_ADD))));
+                    setData(currentPC, insert(Dispatch0Node.create(image.getSpecialSelector(b - BC.BYTECODE_PRIM_ADD))));
                     break;
                 }
                 case BC.BYTECODE_PRIM_CLASS: {
@@ -241,7 +240,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                 case BC.BYTECODE_PRIM_ADD, BC.BYTECODE_PRIM_SUBTRACT, BC.BYTECODE_PRIM_LESS_THAN, BC.BYTECODE_PRIM_GREATER_THAN, BC.BYTECODE_PRIM_LESS_OR_EQUAL, BC.BYTECODE_PRIM_GREATER_OR_EQUAL, //
                     BC.BYTECODE_PRIM_EQUAL, BC.BYTECODE_PRIM_NOT_EQUAL, BC.BYTECODE_PRIM_MULTIPLY, BC.BYTECODE_PRIM_DIVIDE, BC.BYTECODE_PRIM_MOD, BC.BYTECODE_PRIM_MAKE_POINT, BC.BYTECODE_PRIM_BIT_SHIFT, BC.BYTECODE_PRIM_DIV, //
                     BC.BYTECODE_PRIM_BIT_AND, BC.BYTECODE_PRIM_BIT_OR, BC.BYTECODE_PRIM_AT, BC.BYTECODE_PRIM_NEXT_PUT, BC.BYTECODE_PRIM_DO, BC.BYTECODE_PRIM_NEW_WITH_ARG: {
-                    setData(currentPC, insert(Dispatch1NodeGen.create(image.getSpecialSelector(b - BC.BYTECODE_PRIM_ADD))));
+                    setData(currentPC, insert(Dispatch1Node.create(image.getSpecialSelector(b - BC.BYTECODE_PRIM_ADD))));
                     break;
                 }
                 case BC.BYTECODE_PRIM_IDENTICAL, BC.BYTECODE_PRIM_NOT_IDENTICAL: {
@@ -253,25 +252,25 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                     break;
                 }
                 case BC.BYTECODE_PRIM_AT_PUT: {
-                    setData(currentPC, insert(Dispatch2NodeGen.create(image.getSpecialSelector(b - BC.BYTECODE_PRIM_ADD))));
+                    setData(currentPC, insert(Dispatch2Node.create(image.getSpecialSelector(b - BC.BYTECODE_PRIM_ADD))));
                     break;
                 }
                 case BC.SEND_LIT_SEL0_0, BC.SEND_LIT_SEL0_1, BC.SEND_LIT_SEL0_2, BC.SEND_LIT_SEL0_3, BC.SEND_LIT_SEL0_4, BC.SEND_LIT_SEL0_5, BC.SEND_LIT_SEL0_6, BC.SEND_LIT_SEL0_7, //
                     BC.SEND_LIT_SEL0_8, BC.SEND_LIT_SEL0_9, BC.SEND_LIT_SEL0_A, BC.SEND_LIT_SEL0_B, BC.SEND_LIT_SEL0_C, BC.SEND_LIT_SEL0_D, BC.SEND_LIT_SEL0_E, BC.SEND_LIT_SEL0_F: {
                     final NativeObject selector = (NativeObject) code.getAndResolveLiteral(b & 0xF);
-                    setData(currentPC, insert(Dispatch0NodeGen.create(selector)));
+                    setData(currentPC, insert(Dispatch0Node.create(selector)));
                     break;
                 }
                 case BC.SEND_LIT_SEL1_0, BC.SEND_LIT_SEL1_1, BC.SEND_LIT_SEL1_2, BC.SEND_LIT_SEL1_3, BC.SEND_LIT_SEL1_4, BC.SEND_LIT_SEL1_5, BC.SEND_LIT_SEL1_6, BC.SEND_LIT_SEL1_7, //
                     BC.SEND_LIT_SEL1_8, BC.SEND_LIT_SEL1_9, BC.SEND_LIT_SEL1_A, BC.SEND_LIT_SEL1_B, BC.SEND_LIT_SEL1_C, BC.SEND_LIT_SEL1_D, BC.SEND_LIT_SEL1_E, BC.SEND_LIT_SEL1_F: {
                     final NativeObject selector = (NativeObject) code.getAndResolveLiteral(b & 0xF);
-                    setData(currentPC, insert(Dispatch1NodeGen.create(selector)));
+                    setData(currentPC, insert(Dispatch1Node.create(selector)));
                     break;
                 }
                 case BC.SEND_LIT_SEL2_0, BC.SEND_LIT_SEL2_1, BC.SEND_LIT_SEL2_2, BC.SEND_LIT_SEL2_3, BC.SEND_LIT_SEL2_4, BC.SEND_LIT_SEL2_5, BC.SEND_LIT_SEL2_6, BC.SEND_LIT_SEL2_7, //
                     BC.SEND_LIT_SEL2_8, BC.SEND_LIT_SEL2_9, BC.SEND_LIT_SEL2_A, BC.SEND_LIT_SEL2_B, BC.SEND_LIT_SEL2_C, BC.SEND_LIT_SEL2_D, BC.SEND_LIT_SEL2_E, BC.SEND_LIT_SEL2_F: {
                     final NativeObject selector = (NativeObject) code.getAndResolveLiteral(b & 0xF);
-                    setData(currentPC, insert(Dispatch2NodeGen.create(selector)));
+                    setData(currentPC, insert(Dispatch2Node.create(selector)));
                     break;
                 }
                 case BC.SHORT_UJUMP_0, BC.SHORT_UJUMP_1, BC.SHORT_UJUMP_2, BC.SHORT_UJUMP_3, BC.SHORT_UJUMP_4, BC.SHORT_UJUMP_5, BC.SHORT_UJUMP_6, BC.SHORT_UJUMP_7: {
@@ -314,7 +313,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                     vstate.resetExtAB();
                     break;
                 }
-                case BC.EXT_PUSH_LITERAL, BC.EXT_PUSH_CHARACTER: {
+                case BC.EXT_PUSH_LITERAL, BC.EXT_PUSH_INTEGER, BC.EXT_PUSH_CHARACTER: {
                     pc++;
                     vstate.resetExtAB();
                     break;
@@ -323,16 +322,12 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                     pc++;
                     break;
                 }
-                case BC.EXT_PUSH_INTEGER: {
-                    pc++;
-                    vstate.resetExtAB();
-                    break;
-                }
                 case BC.EXT_SEND: {
                     final int byte1 = getUnsignedInt(bc, pc++);
                     final int literalIndex = (byte1 >> 3) + (vstate.getExtA() << 5);
                     final NativeObject selector = (NativeObject) code.getAndResolveLiteral(literalIndex);
-                    setData(currentPC, insert(DispatchNaryNodeGen.create(selector)));
+                    final int numArgs = (byte1 & 7) + (vstate.getExtB() << 3);
+                    setData(currentPC, insert(createDispatchNode(numArgs, selector)));
                     vstate.resetExtAB();
                     break;
                 }
@@ -2518,11 +2513,60 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
         final int byte1 = getUnsignedInt(state.bytecode, pc + 1);
         final int numArgs = (byte1 & 7) + (vstate.getExtB() << 3);
         CompilerAsserts.partialEvaluationConstant(numArgs);
-        final Object[] arguments = popN(frame, vstate.sp, numArgs);
-        vstate.sp -= numArgs;
-        final Object receiver = pop(frame, --vstate.sp);
-        FrameAccess.externalizePCAndSP(frame, nextPC, vstate.sp);
-        push(frame, vstate.sp++, sendNary(frame, pc, receiver, arguments));
+        FrameAccess.externalizePCAndSP(frame, nextPC, vstate.sp - 1 - numArgs);
+        Object result;
+        try {
+            result = switch (numArgs) {
+                case 0 -> {
+                    final Object receiver = pop(frame, --vstate.sp);
+                    yield dispatch(frame, pc, receiver);
+                }
+                case 1 -> {
+                    final Object arg1 = pop(frame, --vstate.sp);
+                    final Object receiver = pop(frame, --vstate.sp);
+                    yield dispatch(frame, pc, receiver, arg1);
+                }
+                case 2 -> {
+                    final Object arg2 = pop(frame, --vstate.sp);
+                    final Object arg1 = pop(frame, --vstate.sp);
+                    final Object receiver = pop(frame, --vstate.sp);
+                    yield dispatch(frame, pc, receiver, arg1, arg2);
+                }
+                case 3 -> {
+                    final Object arg3 = pop(frame, --vstate.sp);
+                    final Object arg2 = pop(frame, --vstate.sp);
+                    final Object arg1 = pop(frame, --vstate.sp);
+                    final Object receiver = pop(frame, --vstate.sp);
+                    yield dispatch(frame, pc, receiver, arg1, arg2, arg3);
+                }
+                case 4 -> {
+                    final Object arg4 = pop(frame, --vstate.sp);
+                    final Object arg3 = pop(frame, --vstate.sp);
+                    final Object arg2 = pop(frame, --vstate.sp);
+                    final Object arg1 = pop(frame, --vstate.sp);
+                    final Object receiver = pop(frame, --vstate.sp);
+                    yield dispatch(frame, pc, receiver, arg1, arg2, arg3, arg4);
+                }
+                case 5 -> {
+                    final Object arg5 = pop(frame, --vstate.sp);
+                    final Object arg4 = pop(frame, --vstate.sp);
+                    final Object arg3 = pop(frame, --vstate.sp);
+                    final Object arg2 = pop(frame, --vstate.sp);
+                    final Object arg1 = pop(frame, --vstate.sp);
+                    final Object receiver = pop(frame, --vstate.sp);
+                    yield dispatch(frame, pc, receiver, arg1, arg2, arg3, arg4, arg5);
+                }
+                default -> {
+                    final Object[] arguments = popN(frame, vstate.sp, numArgs);
+                    vstate.sp -= numArgs;
+                    final Object receiver = pop(frame, --vstate.sp);
+                    yield dispatchNary(frame, pc, receiver, arguments);
+                }
+            };
+        } catch (final AbstractStandardSendReturn r) {
+            result = handleReturnException(frame, pc, r);
+        }
+        push(frame, vstate.sp++, followForwarded(pc, result));
         vstate.resetExtAB();
         return nextPC;
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterV3PlusClosuresNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterV3PlusClosuresNode.java
@@ -33,10 +33,9 @@ import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectAtPut0Node;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectAtPut0NodeGen;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectClassNodeGen;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectIdentityNodeGen;
-import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector0NodeFactory.Dispatch0NodeGen;
-import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector1NodeFactory.Dispatch1NodeGen;
-import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector2NodeFactory.Dispatch2NodeGen;
-import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNodeFactory.DispatchNaryNodeGen;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector0Node.Dispatch0Node;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector1Node.Dispatch1Node;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector2Node.Dispatch2Node;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNodeFactory.DispatchSuperNaryNodeGen;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchValueNodeGen;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchValueWithArgNodeGen;
@@ -158,8 +157,9 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                     break;
                 }
                 case BC.SINGLE_EXTENDED_SEND: {
+                    final int numArgs = getUnsignedInt(bc, pc) >> 5;
                     final NativeObject selector = (NativeObject) code.getLiteral(getByte(bc, pc++) & 0x1F);
-                    setData(currentPC, insert(DispatchNaryNodeGen.create(selector)));
+                    setData(currentPC, insert(createDispatchNode(numArgs, selector)));
                     break;
                 }
                 case BC.DOUBLE_EXTENDED_DO_ANYTHING: {
@@ -167,8 +167,9 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                     final int byte3 = getUnsignedInt(bc, pc++);
                     switch (byte2 >> 5) {
                         case 0: {
+                            final int numArgs = byte2 & 0x1F;
                             final NativeObject selector = (NativeObject) code.getLiteral(byte3);
-                            setData(currentPC, insert(DispatchNaryNodeGen.create(selector)));
+                            setData(currentPC, insert(createDispatchNode(numArgs, selector)));
                             break;
                         }
                         case 1: {
@@ -210,8 +211,9 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                     break;
                 }
                 case BC.SECOND_EXTENDED_SEND: {
+                    final int numArgs = getUnsignedInt(bc, pc) >> 6;
                     final NativeObject selector = (NativeObject) code.getLiteral(getByte(bc, pc++) & 0x3F);
-                    setData(currentPC, insert(DispatchNaryNodeGen.create(selector)));
+                    setData(currentPC, insert(createDispatchNode(numArgs, selector)));
                     break;
                 }
                 case BC.PUSH_NEW_ARRAY: {
@@ -267,7 +269,7 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                     break;
                 }
                 case BC.BYTECODE_PRIM_SIZE, BC.BYTECODE_PRIM_NEXT, BC.BYTECODE_PRIM_AT_END, BC.BYTECODE_PRIM_NEW, BC.BYTECODE_PRIM_POINT_X, BC.BYTECODE_PRIM_POINT_Y: {
-                    setData(currentPC, insert(Dispatch0NodeGen.create(image.getSpecialSelector(b - BC.BYTECODE_PRIM_ADD))));
+                    setData(currentPC, insert(Dispatch0Node.create(image.getSpecialSelector(b - BC.BYTECODE_PRIM_ADD))));
                     break;
                 }
                 case BC.BYTECODE_PRIM_CLASS: {
@@ -277,7 +279,7 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                 case BC.BYTECODE_PRIM_ADD, BC.BYTECODE_PRIM_SUBTRACT, BC.BYTECODE_PRIM_LESS_THAN, BC.BYTECODE_PRIM_GREATER_THAN, BC.BYTECODE_PRIM_LESS_OR_EQUAL, BC.BYTECODE_PRIM_GREATER_OR_EQUAL, //
                     BC.BYTECODE_PRIM_EQUAL, BC.BYTECODE_PRIM_NOT_EQUAL, BC.BYTECODE_PRIM_MULTIPLY, BC.BYTECODE_PRIM_DIVIDE, BC.BYTECODE_PRIM_MOD, BC.BYTECODE_PRIM_MAKE_POINT, BC.BYTECODE_PRIM_BIT_SHIFT, BC.BYTECODE_PRIM_DIV, //
                     BC.BYTECODE_PRIM_BIT_AND, BC.BYTECODE_PRIM_BIT_OR, BC.BYTECODE_PRIM_AT, BC.BYTECODE_PRIM_NEXT_PUT, BC.BYTECODE_PRIM_DO, BC.BYTECODE_PRIM_NEW_WITH_ARG: {
-                    setData(currentPC, insert(Dispatch1NodeGen.create(image.getSpecialSelector(b - BC.BYTECODE_PRIM_ADD))));
+                    setData(currentPC, insert(Dispatch1Node.create(image.getSpecialSelector(b - BC.BYTECODE_PRIM_ADD))));
                     break;
                 }
                 case BC.BYTECODE_PRIM_IDENTICAL, BC.BYTECODE_PRIM_NOT_IDENTICAL: {
@@ -293,25 +295,25 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                     break;
                 }
                 case BC.BYTECODE_PRIM_AT_PUT: {
-                    setData(currentPC, insert(Dispatch2NodeGen.create(image.getSpecialSelector(b - BC.BYTECODE_PRIM_ADD))));
+                    setData(currentPC, insert(Dispatch2Node.create(image.getSpecialSelector(b - BC.BYTECODE_PRIM_ADD))));
                     break;
                 }
                 case BC.SEND_LIT_SEL0_0, BC.SEND_LIT_SEL0_1, BC.SEND_LIT_SEL0_2, BC.SEND_LIT_SEL0_3, BC.SEND_LIT_SEL0_4, BC.SEND_LIT_SEL0_5, BC.SEND_LIT_SEL0_6, BC.SEND_LIT_SEL0_7, //
                     BC.SEND_LIT_SEL0_8, BC.SEND_LIT_SEL0_9, BC.SEND_LIT_SEL0_A, BC.SEND_LIT_SEL0_B, BC.SEND_LIT_SEL0_C, BC.SEND_LIT_SEL0_D, BC.SEND_LIT_SEL0_E, BC.SEND_LIT_SEL0_F: {
                     final NativeObject selector = (NativeObject) code.getAndResolveLiteral(b & 0xF);
-                    setData(currentPC, insert(Dispatch0NodeGen.create(selector)));
+                    setData(currentPC, insert(Dispatch0Node.create(selector)));
                     break;
                 }
                 case BC.SEND_LIT_SEL1_0, BC.SEND_LIT_SEL1_1, BC.SEND_LIT_SEL1_2, BC.SEND_LIT_SEL1_3, BC.SEND_LIT_SEL1_4, BC.SEND_LIT_SEL1_5, BC.SEND_LIT_SEL1_6, BC.SEND_LIT_SEL1_7, //
                     BC.SEND_LIT_SEL1_8, BC.SEND_LIT_SEL1_9, BC.SEND_LIT_SEL1_A, BC.SEND_LIT_SEL1_B, BC.SEND_LIT_SEL1_C, BC.SEND_LIT_SEL1_D, BC.SEND_LIT_SEL1_E, BC.SEND_LIT_SEL1_F: {
                     final NativeObject selector = (NativeObject) code.getAndResolveLiteral(b & 0xF);
-                    setData(currentPC, insert(Dispatch1NodeGen.create(selector)));
+                    setData(currentPC, insert(Dispatch1Node.create(selector)));
                     break;
                 }
                 case BC.SEND_LIT_SEL2_0, BC.SEND_LIT_SEL2_1, BC.SEND_LIT_SEL2_2, BC.SEND_LIT_SEL2_3, BC.SEND_LIT_SEL2_4, BC.SEND_LIT_SEL2_5, BC.SEND_LIT_SEL2_6, BC.SEND_LIT_SEL2_7, //
                     BC.SEND_LIT_SEL2_8, BC.SEND_LIT_SEL2_9, BC.SEND_LIT_SEL2_A, BC.SEND_LIT_SEL2_B, BC.SEND_LIT_SEL2_C, BC.SEND_LIT_SEL2_D, BC.SEND_LIT_SEL2_E, BC.SEND_LIT_SEL2_F: {
                     final NativeObject selector = (NativeObject) code.getAndResolveLiteral(b & 0xF);
-                    setData(currentPC, insert(Dispatch2NodeGen.create(selector)));
+                    setData(currentPC, insert(Dispatch2Node.create(selector)));
                     break;
                 }
                 default: {
@@ -529,11 +531,7 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                     }
                     case BC.SINGLE_EXTENDED_SEND: {
                         final int numArgs = getUnsignedInt(bc, pc++) >> 5;
-                        final Object[] arguments = popN(frame, sp, numArgs);
-                        sp -= numArgs;
-                        final Object receiver = pop(frame, --sp);
-                        FrameAccess.externalizePCAndSP(frame, pc, sp);
-                        push(frame, sp++, sendNary(frame, currentPC, receiver, arguments));
+                        sp = handleExtendedSend(frame, currentPC, pc, sp, numArgs);
                         break;
                     }
                     case BC.DOUBLE_EXTENDED_DO_ANYTHING: {
@@ -544,11 +542,7 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                         switch (opType) {
                             case 0: {
                                 final int numArgs = byte2 & 31;
-                                final Object[] arguments = popN(frame, sp, numArgs);
-                                sp -= numArgs;
-                                final Object receiver = pop(frame, --sp);
-                                FrameAccess.externalizePCAndSP(frame, pc, sp);
-                                push(frame, sp++, sendNary(frame, currentPC, receiver, arguments));
+                                sp = handleExtendedSend(frame, currentPC, pc, sp, numArgs);
                                 break;
                             }
                             case 1: {
@@ -601,11 +595,7 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                     }
                     case BC.SECOND_EXTENDED_SEND: {
                         final int numArgs = getUnsignedInt(bc, pc++) >> 6;
-                        final Object[] arguments = popN(frame, sp, numArgs);
-                        sp -= numArgs;
-                        final Object receiver = pop(frame, --sp);
-                        FrameAccess.externalizePCAndSP(frame, pc, sp);
-                        push(frame, sp++, sendNary(frame, currentPC, receiver, arguments));
+                        sp = handleExtendedSend(frame, currentPC, pc, sp, numArgs);
                         break;
                     }
                     case BC.POP_STACK: {
@@ -1027,6 +1017,73 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
         } catch (final AbstractStandardSendReturn r) {
             return handleReturnException(frame, currentPC, r);
         }
+    }
+
+    @EarlyInline
+    private int handleExtendedSend(final VirtualFrame frame, final int currentPC, final int pc, final int initialSP, final int numArgs) {
+        int sp = initialSP;
+        CompilerAsserts.partialEvaluationConstant(numArgs);
+        Object result;
+        try {
+            result = switch (numArgs) {
+                case 0 -> {
+                    final Object receiver = pop(frame, --sp);
+                    FrameAccess.externalizePCAndSP(frame, pc, sp);
+                    yield dispatch(frame, currentPC, receiver);
+                }
+                case 1 -> {
+                    final Object arg1 = pop(frame, --sp);
+                    final Object receiver = pop(frame, --sp);
+                    FrameAccess.externalizePCAndSP(frame, pc, sp);
+                    yield dispatch(frame, currentPC, receiver, arg1);
+                }
+                case 2 -> {
+                    final Object arg2 = pop(frame, --sp);
+                    final Object arg1 = pop(frame, --sp);
+                    final Object receiver = pop(frame, --sp);
+                    FrameAccess.externalizePCAndSP(frame, pc, sp);
+                    yield dispatch(frame, currentPC, receiver, arg1, arg2);
+                }
+                case 3 -> {
+                    final Object arg3 = pop(frame, --sp);
+                    final Object arg2 = pop(frame, --sp);
+                    final Object arg1 = pop(frame, --sp);
+                    final Object receiver = pop(frame, --sp);
+                    FrameAccess.externalizePCAndSP(frame, pc, sp);
+                    yield dispatch(frame, currentPC, receiver, arg1, arg2, arg3);
+                }
+                case 4 -> {
+                    final Object arg4 = pop(frame, --sp);
+                    final Object arg3 = pop(frame, --sp);
+                    final Object arg2 = pop(frame, --sp);
+                    final Object arg1 = pop(frame, --sp);
+                    final Object receiver = pop(frame, --sp);
+                    FrameAccess.externalizePCAndSP(frame, pc, sp);
+                    yield dispatch(frame, currentPC, receiver, arg1, arg2, arg3, arg4);
+                }
+                case 5 -> {
+                    final Object arg5 = pop(frame, --sp);
+                    final Object arg4 = pop(frame, --sp);
+                    final Object arg3 = pop(frame, --sp);
+                    final Object arg2 = pop(frame, --sp);
+                    final Object arg1 = pop(frame, --sp);
+                    final Object receiver = pop(frame, --sp);
+                    FrameAccess.externalizePCAndSP(frame, pc, sp);
+                    yield dispatch(frame, currentPC, receiver, arg1, arg2, arg3, arg4, arg5);
+                }
+                default -> {
+                    final Object[] arguments = popN(frame, sp, numArgs);
+                    sp -= numArgs;
+                    final Object receiver = pop(frame, --sp);
+                    FrameAccess.externalizePCAndSP(frame, pc, sp);
+                    yield dispatchNary(frame, currentPC, receiver, arguments);
+                }
+            };
+        } catch (final AbstractStandardSendReturn r) {
+            result = handleReturnException(frame, currentPC, r);
+        }
+        push(frame, sp++, followForwarded(currentPC, result));
+        return sp;
     }
 
     @EarlyInline

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/TruffleSqueakPlugin.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/TruffleSqueakPlugin.java
@@ -11,15 +11,22 @@ import java.util.List;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.Truffle;
+import com.oracle.truffle.api.dsl.Bind;
+import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.DirectCallNode;
+import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.RootNode;
 
 import de.hpi.swa.trufflesqueak.exceptions.PrimitiveFailed;
+import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
 import de.hpi.swa.trufflesqueak.interop.JavaObjectWrapper;
+import de.hpi.swa.trufflesqueak.model.ArrayObject;
 import de.hpi.swa.trufflesqueak.model.NativeObject;
+import de.hpi.swa.trufflesqueak.model.NilObject;
+import de.hpi.swa.trufflesqueak.nodes.accessing.ArrayObjectNodes;
 import de.hpi.swa.trufflesqueak.nodes.interpreter.AbstractInterpreterNode;
 import de.hpi.swa.trufflesqueak.nodes.primitives.AbstractPrimitiveFactoryHolder;
 import de.hpi.swa.trufflesqueak.nodes.primitives.AbstractPrimitiveNode;
@@ -103,6 +110,42 @@ public final class TruffleSqueakPlugin extends AbstractPrimitiveFactoryHolder {
             } else {
                 throw PrimitiveFailed.andTransferToInterpreter();
             }
+        }
+    }
+
+    @GenerateNodeFactory
+    @SqueakPrimitive(names = "primitiveSetDNUShortcutSelectors")
+    protected abstract static class PrimSetDNUShortcutSelectorsNode extends AbstractPrimitiveNode implements Primitive1WithFallback {
+        @Specialization
+        protected final Object doSet(final Object receiver, final ArrayObject array,
+                        @Bind final Node node,
+                        @Cached final ArrayObjectNodes.ArrayObjectToObjectArrayCopyNode toObjectArrayNode) {
+
+            final Object[] elements = toObjectArrayNode.execute(node, array);
+            final int arraySize = elements.length;
+
+            if (arraySize > SqueakImageContext.MAX_DNU_SHORTCUT_ARITY + 1) {
+                CompilerDirectives.transferToInterpreter();
+                throw PrimitiveFailed.BAD_ARGUMENT;
+            }
+
+            final NativeObject[] isolatedSelectors = new NativeObject[arraySize];
+
+            for (int i = 0; i < arraySize; i++) {
+                final Object element = elements[i];
+
+                if (element instanceof final NativeObject nativeObject && getContext().isByteSymbol(nativeObject)) {
+                    isolatedSelectors[i] = nativeObject;
+                } else if (element == NilObject.SINGLETON) {
+                    isolatedSelectors[i] = null;
+                } else {
+                    CompilerDirectives.transferToInterpreter();
+                    throw PrimitiveFailed.BAD_ARGUMENT;
+                }
+            }
+
+            getContext().setDNUShortcutSelectors(isolatedSelectors);
+            return receiver;
         }
     }
 }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/TruffleSqueakPlugin.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/TruffleSqueakPlugin.java
@@ -124,7 +124,10 @@ public final class TruffleSqueakPlugin extends AbstractPrimitiveFactoryHolder {
             final Object[] elements = toObjectArrayNode.execute(node, array);
             final int arraySize = elements.length;
 
-            if (arraySize > SqueakImageContext.MAX_DNU_SHORTCUT_ARITY + 1) {
+            if (arraySize == 0) {
+                getContext().setDNUShortcutSelectors(null);
+                return receiver;
+            } else if (arraySize > SqueakImageContext.MAX_DNU_SHORTCUT_ARITY + 1) {
                 CompilerDirectives.transferToInterpreter();
                 throw PrimitiveFailed.BAD_ARGUMENT;
             }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ControlPrimitives.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ControlPrimitives.java
@@ -271,12 +271,16 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
     @SqueakPrimitive(indices = 84)
     protected abstract static class PrimPerformWithArguments2Node extends AbstractPrimitiveWithFrameNode implements Primitive2 {
         @SuppressWarnings("unused")
-        @Specialization(guards = {"selector == cachedSelector", "guard.check(receiver)"}, assumptions = "dispatchDirectNode.getAssumptions()", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
+        @Specialization(guards = {"selector == cachedSelector", "guard.check(receiver)",
+                        "arity == cachedArity"}, assumptions = "dispatchDirectNode.getAssumptions()", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
         protected static final Object performCached(final VirtualFrame frame, final Object receiver, final NativeObject selector, final ArrayObject argumentsArray,
                         @Bind final Node node,
                         @Cached("selector") final NativeObject cachedSelector,
                         @Cached("create(receiver)") final LookupClassGuard guard,
-                        @Cached("create(cachedSelector, guard)") final DispatchDirectNaryNode dispatchDirectNode,
+                        @Cached final ArrayObjectSizeNode sizeNode,
+                        @Bind("sizeNode.execute(node, argumentsArray)") final int arity,
+                        @Cached("arity") final int cachedArity,
+                        @Cached("create(cachedSelector, guard, cachedArity)") final DispatchDirectNaryNode dispatchDirectNode,
                         @Exclusive @Cached final ArrayObjectToObjectArrayCopyNode getObjectArrayNode) {
             final Object[] arguments = getObjectArrayNode.execute(node, argumentsArray);
             return dispatchDirectNode.executeWithCheckedArguments(frame, receiver, arguments);
@@ -507,11 +511,12 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
 
         protected abstract Object execute(VirtualFrame frame, ClassObject lookupClass, Object receiver, Object[] arguments);
 
-        @Specialization(guards = "lookupClass == cachedLookupClass", assumptions = {"cachedLookupClass.getClassHierarchyAndMethodDictStable()",
+        @Specialization(guards = {"lookupClass == cachedLookupClass", "arguments.length == cachedArity"}, assumptions = {"cachedLookupClass.getClassHierarchyAndMethodDictStable()",
                         "dispatchDirectNode.getAssumptions()"}, limit = "3")
         protected static final Object doCached(final VirtualFrame frame, @SuppressWarnings("unused") final ClassObject lookupClass, final Object receiver, final Object[] arguments,
                         @SuppressWarnings("unused") @Cached("lookupClass") final ClassObject cachedLookupClass,
-                        @Cached("create(selector, cachedLookupClass)") final DispatchDirectNaryNode dispatchDirectNode) {
+                        @SuppressWarnings("unused") @Cached("arguments.length") final int cachedArity,
+                        @Cached("create(selector, cachedLookupClass, cachedArity)") final DispatchDirectNaryNode dispatchDirectNode) {
             return dispatchDirectNode.executeWithCheckedArguments(frame, receiver, arguments);
         }
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ControlPrimitives.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ControlPrimitives.java
@@ -140,7 +140,7 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
         @Specialization(guards = "selector == cachedSelector", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
         protected static final Object perform0Cached(final VirtualFrame frame, final Object receiver, final NativeObject selector,
                         @Cached("selector") final NativeObject cachedSelector,
-                        @Cached("create(cachedSelector)") final Dispatch0Node dispatchNode) {
+                        @Cached("create(cachedSelector, true)") final Dispatch0Node dispatchNode) {
             return dispatchNode.execute(frame, receiver);
         }
 
@@ -160,7 +160,7 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
         @Specialization(guards = "selector == cachedSelector", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
         protected static final Object perform1Cached(final VirtualFrame frame, final Object receiver, final NativeObject selector, final Object arg1,
                         @Cached("selector") final NativeObject cachedSelector,
-                        @Cached("create(cachedSelector)") final Dispatch1Node dispatchNode) {
+                        @Cached("create(cachedSelector, true)") final Dispatch1Node dispatchNode) {
             return dispatchNode.execute(frame, receiver, arg1);
         }
 
@@ -180,7 +180,7 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
         @Specialization(guards = "selector == cachedSelector", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
         protected static final Object perform2Cached(final VirtualFrame frame, final Object receiver, final NativeObject selector, final Object arg1, final Object arg2,
                         @Cached("selector") final NativeObject cachedSelector,
-                        @Cached("create(cachedSelector)") final Dispatch2Node dispatchNode) {
+                        @Cached("create(cachedSelector, true)") final Dispatch2Node dispatchNode) {
             return dispatchNode.execute(frame, receiver, arg1, arg2);
         }
 
@@ -200,7 +200,7 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
         @Specialization(guards = "selector == cachedSelector", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
         protected static final Object perform3Cached(final VirtualFrame frame, final Object receiver, final NativeObject selector, final Object arg1, final Object arg2, final Object arg3,
                         @Cached("selector") final NativeObject cachedSelector,
-                        @Cached("create(cachedSelector)") final Dispatch3Node dispatchNode) {
+                        @Cached("create(cachedSelector, true)") final Dispatch3Node dispatchNode) {
             return dispatchNode.execute(frame, receiver, arg1, arg2, arg3);
         }
 
@@ -221,7 +221,7 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
         protected static final Object perform4Cached(final VirtualFrame frame, final Object receiver, final NativeObject selector, final Object arg1, final Object arg2, final Object arg3,
                         final Object arg4,
                         @Cached("selector") final NativeObject cachedSelector,
-                        @Cached("create(cachedSelector)") final Dispatch4Node dispatchNode) {
+                        @Cached("create(cachedSelector, true)") final Dispatch4Node dispatchNode) {
             return dispatchNode.execute(frame, receiver, arg1, arg2, arg3, arg4);
         }
 
@@ -243,7 +243,7 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
         protected static final Object perform5Cached(final VirtualFrame frame, final Object receiver, final NativeObject selector, final Object arg1, final Object arg2, final Object arg3,
                         final Object arg4, final Object arg5,
                         @Cached("selector") final NativeObject cachedSelector,
-                        @Cached("create(cachedSelector)") final Dispatch5Node dispatchNode) {
+                        @Cached("create(cachedSelector, true)") final Dispatch5Node dispatchNode) {
             return dispatchNode.execute(frame, receiver, arg1, arg2, arg3, arg4, arg5);
         }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ControlPrimitives.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ControlPrimitives.java
@@ -74,22 +74,28 @@ import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectChangeClassOfToNode;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectClassNode;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectIdentityNode;
 import de.hpi.swa.trufflesqueak.nodes.context.GetOrCreateContextWithoutFrameNode;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector0Node.Dispatch0Node;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector0Node.DispatchDirect0Node;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector0Node.DispatchIndirect0Node;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector1Node.Dispatch1Node;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector1Node.DispatchDirect1Node;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector1Node.DispatchIndirect1Node;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector2Node.Dispatch2Node;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector2Node.DispatchDirect2Node;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector2Node.DispatchIndirect2Node;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector3Node.Dispatch3Node;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector3Node.DispatchDirect3Node;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector3Node.DispatchIndirect3Node;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector4Node.Dispatch4Node;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector4Node.DispatchDirect4Node;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector4Node.DispatchIndirect4Node;
-import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector5Node.DispatchDirect5Node;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector5Node.Dispatch5Node;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector5Node.DispatchIndirect5Node;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNode.DispatchDirectNaryNode;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNode.DispatchIndirectNaryNode;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNode.DispatchIndirectNaryNode.CreateFrameArgumentsForIndirectCallNaryNode;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNode.DispatchIndirectNaryNode.TryPrimitiveNaryNode;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNode.DispatchPerformNaryNode;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNode.DispatchPrimitiveNode;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.LookupClassGuard;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.ResolveMethodNode;
@@ -131,12 +137,11 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
     @SqueakPrimitive(indices = 83)
     protected abstract static class PrimPerform0Node extends AbstractPrimitiveWithFrameNode implements Primitive1WithFallback {
         @SuppressWarnings("unused")
-        @Specialization(guards = {"selector == cachedSelector", "guard.check(receiver)"}, assumptions = "dispatchDirectNode.getAssumptions()", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
+        @Specialization(guards = "selector == cachedSelector", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
         protected static final Object perform0Cached(final VirtualFrame frame, final Object receiver, final NativeObject selector,
                         @Cached("selector") final NativeObject cachedSelector,
-                        @Cached("create(receiver)") final LookupClassGuard guard,
-                        @Cached("create(cachedSelector, guard, true)") final DispatchDirect0Node dispatchDirectNode) {
-            return dispatchDirectNode.execute(frame, receiver);
+                        @Cached("create(cachedSelector)") final Dispatch0Node dispatchNode) {
+            return dispatchNode.execute(frame, receiver);
         }
 
         @SuppressWarnings("unused")
@@ -152,12 +157,11 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
     @SqueakPrimitive(indices = 83)
     protected abstract static class PrimPerform1Node extends AbstractPrimitiveWithFrameNode implements Primitive2WithFallback {
         @SuppressWarnings("unused")
-        @Specialization(guards = {"selector == cachedSelector", "guard.check(receiver)"}, assumptions = "dispatchDirectNode.getAssumptions()", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
+        @Specialization(guards = "selector == cachedSelector", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
         protected static final Object perform1Cached(final VirtualFrame frame, final Object receiver, final NativeObject selector, final Object arg1,
                         @Cached("selector") final NativeObject cachedSelector,
-                        @Cached("create(receiver)") final LookupClassGuard guard,
-                        @Cached("create(cachedSelector, guard, true)") final DispatchDirect1Node dispatchDirectNode) {
-            return dispatchDirectNode.execute(frame, receiver, arg1);
+                        @Cached("create(cachedSelector)") final Dispatch1Node dispatchNode) {
+            return dispatchNode.execute(frame, receiver, arg1);
         }
 
         @SuppressWarnings("unused")
@@ -173,12 +177,11 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
     @SqueakPrimitive(indices = 83)
     protected abstract static class PrimPerform2Node extends AbstractPrimitiveWithFrameNode implements Primitive3WithFallback {
         @SuppressWarnings("unused")
-        @Specialization(guards = {"selector == cachedSelector", "guard.check(receiver)"}, assumptions = "dispatchDirectNode.getAssumptions()", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
+        @Specialization(guards = "selector == cachedSelector", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
         protected static final Object perform2Cached(final VirtualFrame frame, final Object receiver, final NativeObject selector, final Object arg1, final Object arg2,
                         @Cached("selector") final NativeObject cachedSelector,
-                        @Cached("create(receiver)") final LookupClassGuard guard,
-                        @Cached("create(cachedSelector, guard, true)") final DispatchDirect2Node dispatchDirectNode) {
-            return dispatchDirectNode.execute(frame, receiver, arg1, arg2);
+                        @Cached("create(cachedSelector)") final Dispatch2Node dispatchNode) {
+            return dispatchNode.execute(frame, receiver, arg1, arg2);
         }
 
         @SuppressWarnings("unused")
@@ -194,12 +197,11 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
     @SqueakPrimitive(indices = 83)
     protected abstract static class PrimPerform3Node extends AbstractPrimitiveWithFrameNode implements Primitive4WithFallback {
         @SuppressWarnings("unused")
-        @Specialization(guards = {"selector == cachedSelector", "guard.check(receiver)"}, assumptions = "dispatchDirectNode.getAssumptions()", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
+        @Specialization(guards = "selector == cachedSelector", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
         protected static final Object perform3Cached(final VirtualFrame frame, final Object receiver, final NativeObject selector, final Object arg1, final Object arg2, final Object arg3,
                         @Cached("selector") final NativeObject cachedSelector,
-                        @Cached("create(receiver)") final LookupClassGuard guard,
-                        @Cached("create(cachedSelector, guard, true)") final DispatchDirect3Node dispatchDirectNode) {
-            return dispatchDirectNode.execute(frame, receiver, arg1, arg2, arg3);
+                        @Cached("create(cachedSelector)") final Dispatch3Node dispatchNode) {
+            return dispatchNode.execute(frame, receiver, arg1, arg2, arg3);
         }
 
         @SuppressWarnings("unused")
@@ -215,13 +217,12 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
     @SqueakPrimitive(indices = 83)
     protected abstract static class PrimPerform4Node extends AbstractPrimitiveWithFrameNode implements Primitive5WithFallback {
         @SuppressWarnings("unused")
-        @Specialization(guards = {"selector == cachedSelector", "guard.check(receiver)"}, assumptions = "dispatchDirectNode.getAssumptions()", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
+        @Specialization(guards = "selector == cachedSelector", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
         protected static final Object perform4Cached(final VirtualFrame frame, final Object receiver, final NativeObject selector, final Object arg1, final Object arg2, final Object arg3,
                         final Object arg4,
                         @Cached("selector") final NativeObject cachedSelector,
-                        @Cached("create(receiver)") final LookupClassGuard guard,
-                        @Cached("create(cachedSelector, guard, true)") final DispatchDirect4Node dispatchDirectNode) {
-            return dispatchDirectNode.execute(frame, receiver, arg1, arg2, arg3, arg4);
+                        @Cached("create(cachedSelector)") final Dispatch4Node dispatchNode) {
+            return dispatchNode.execute(frame, receiver, arg1, arg2, arg3, arg4);
         }
 
         @SuppressWarnings("unused")
@@ -238,13 +239,12 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
     @SqueakPrimitive(indices = 83)
     protected abstract static class PrimPerform5Node extends AbstractPrimitiveWithFrameNode implements Primitive6WithFallback {
         @SuppressWarnings("unused")
-        @Specialization(guards = {"selector == cachedSelector", "guard.check(receiver)"}, assumptions = "dispatchDirectNode.getAssumptions()", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
+        @Specialization(guards = "selector == cachedSelector", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
         protected static final Object perform5Cached(final VirtualFrame frame, final Object receiver, final NativeObject selector, final Object arg1, final Object arg2, final Object arg3,
                         final Object arg4, final Object arg5,
                         @Cached("selector") final NativeObject cachedSelector,
-                        @Cached("create(receiver)") final LookupClassGuard guard,
-                        @Cached("create(cachedSelector, guard, true)") final DispatchDirect5Node dispatchDirectNode) {
-            return dispatchDirectNode.execute(frame, receiver, arg1, arg2, arg3, arg4, arg5);
+                        @Cached("create(cachedSelector)") final Dispatch5Node dispatchNode) {
+            return dispatchNode.execute(frame, receiver, arg1, arg2, arg3, arg4, arg5);
         }
 
         @SuppressWarnings("unused")
@@ -271,19 +271,14 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
     @SqueakPrimitive(indices = 84)
     protected abstract static class PrimPerformWithArguments2Node extends AbstractPrimitiveWithFrameNode implements Primitive2 {
         @SuppressWarnings("unused")
-        @Specialization(guards = {"selector == cachedSelector", "guard.check(receiver)",
-                        "arity == cachedArity"}, assumptions = "dispatchDirectNode.getAssumptions()", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
+        @Specialization(guards = "selector == cachedSelector", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
         protected static final Object performCached(final VirtualFrame frame, final Object receiver, final NativeObject selector, final ArrayObject argumentsArray,
                         @Bind final Node node,
                         @Cached("selector") final NativeObject cachedSelector,
-                        @Cached("create(receiver)") final LookupClassGuard guard,
-                        @Cached final ArrayObjectSizeNode sizeNode,
-                        @Bind("sizeNode.execute(node, argumentsArray)") final int arity,
-                        @Cached("arity") final int cachedArity,
-                        @Cached("create(cachedSelector, guard, cachedArity)") final DispatchDirectNaryNode dispatchDirectNode,
+                        @Cached("create(cachedSelector)") final DispatchPerformNaryNode dispatchNode,
                         @Exclusive @Cached final ArrayObjectToObjectArrayCopyNode getObjectArrayNode) {
             final Object[] arguments = getObjectArrayNode.execute(node, argumentsArray);
-            return dispatchDirectNode.executeWithCheckedArguments(frame, receiver, arguments);
+            return dispatchNode.execute(frame, receiver, arguments);
         }
 
         @Megamorphic

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/ArrayUtils.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/ArrayUtils.java
@@ -10,9 +10,11 @@ import java.util.Arrays;
 
 import org.graalvm.collections.UnmodifiableEconomicMap;
 
+import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.nodes.ExplodeLoop;
 
 public final class ArrayUtils {
     @CompilationFinal(dimensions = 1) public static final Object[] EMPTY_ARRAY = new Object[0];
@@ -92,6 +94,14 @@ public final class ArrayUtils {
             }
         }
         return false;
+    }
+
+    @ExplodeLoop
+    public static void copyExploded(final Object[] source, final Object[] dest, final int length) {
+        CompilerAsserts.partialEvaluationConstant(length);
+        for (int i = 0; i < length; i++) {
+            dest[i] = source[i];
+        }
     }
 
     public static byte[] copyOf(final byte[] original, final int newLength) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/FrameAccess.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/FrameAccess.java
@@ -21,8 +21,8 @@ import com.oracle.truffle.api.frame.FrameInstance;
 import com.oracle.truffle.api.frame.FrameSlotKind;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
-
 import com.oracle.truffle.api.nodes.ExplodeLoop;
+
 import de.hpi.swa.trufflesqueak.exceptions.SqueakExceptions.SqueakException;
 import de.hpi.swa.trufflesqueak.model.AbstractSqueakObject;
 import de.hpi.swa.trufflesqueak.model.ArrayObject;
@@ -78,6 +78,11 @@ public final class FrameAccess {
         private static final int CLOSURE_OR_NULL = 1;
         private static final int RECEIVER = 2;
         private static final int ARGUMENTS_START = 3;
+        private static final int ARGUMENT_1 = ARGUMENTS_START;
+        private static final int ARGUMENT_2 = ARGUMENT_1 + 1;
+        private static final int ARGUMENT_3 = ARGUMENT_2 + 1;
+        private static final int ARGUMENT_4 = ARGUMENT_3 + 1;
+        private static final int ARGUMENT_5 = ARGUMENT_4 + 1;
     }
 
     private static final class SlotIndices {
@@ -167,7 +172,7 @@ public final class FrameAccess {
     }
 
     public static int getNumArguments(final Frame frame) {
-        return frame.getArguments().length - getArgumentStartIndex();
+        return frame.getArguments().length - ArgumentIndices.ARGUMENTS_START;
     }
 
     public static Object[] getReceiverAndArguments(final Frame frame) {
@@ -405,7 +410,7 @@ public final class FrameAccess {
         frameArguments[ArgumentIndices.SENDER] = sender;
         frameArguments[ArgumentIndices.CLOSURE_OR_NULL] = closure;
         frameArguments[ArgumentIndices.RECEIVER] = receiver;
-        frameArguments[ArgumentIndices.ARGUMENTS_START] = arg1;
+        frameArguments[ArgumentIndices.ARGUMENT_1] = arg1;
         return frameArguments;
     }
 
@@ -415,8 +420,8 @@ public final class FrameAccess {
         frameArguments[ArgumentIndices.SENDER] = sender;
         frameArguments[ArgumentIndices.CLOSURE_OR_NULL] = closure;
         frameArguments[ArgumentIndices.RECEIVER] = receiver;
-        frameArguments[ArgumentIndices.ARGUMENTS_START] = arg1;
-        frameArguments[ArgumentIndices.ARGUMENTS_START + 1] = arg2;
+        frameArguments[ArgumentIndices.ARGUMENT_1] = arg1;
+        frameArguments[ArgumentIndices.ARGUMENT_2] = arg2;
         return frameArguments;
     }
 
@@ -426,9 +431,9 @@ public final class FrameAccess {
         frameArguments[ArgumentIndices.SENDER] = sender;
         frameArguments[ArgumentIndices.CLOSURE_OR_NULL] = closure;
         frameArguments[ArgumentIndices.RECEIVER] = receiver;
-        frameArguments[ArgumentIndices.ARGUMENTS_START] = arg1;
-        frameArguments[ArgumentIndices.ARGUMENTS_START + 1] = arg2;
-        frameArguments[ArgumentIndices.ARGUMENTS_START + 2] = arg3;
+        frameArguments[ArgumentIndices.ARGUMENT_1] = arg1;
+        frameArguments[ArgumentIndices.ARGUMENT_2] = arg2;
+        frameArguments[ArgumentIndices.ARGUMENT_3] = arg3;
         return frameArguments;
     }
 
@@ -439,10 +444,10 @@ public final class FrameAccess {
         frameArguments[ArgumentIndices.SENDER] = sender;
         frameArguments[ArgumentIndices.CLOSURE_OR_NULL] = closure;
         frameArguments[ArgumentIndices.RECEIVER] = receiver;
-        frameArguments[ArgumentIndices.ARGUMENTS_START] = arg1;
-        frameArguments[ArgumentIndices.ARGUMENTS_START + 1] = arg2;
-        frameArguments[ArgumentIndices.ARGUMENTS_START + 2] = arg3;
-        frameArguments[ArgumentIndices.ARGUMENTS_START + 3] = arg4;
+        frameArguments[ArgumentIndices.ARGUMENT_1] = arg1;
+        frameArguments[ArgumentIndices.ARGUMENT_2] = arg2;
+        frameArguments[ArgumentIndices.ARGUMENT_3] = arg3;
+        frameArguments[ArgumentIndices.ARGUMENT_4] = arg4;
         return frameArguments;
     }
 
@@ -453,11 +458,11 @@ public final class FrameAccess {
         frameArguments[ArgumentIndices.SENDER] = sender;
         frameArguments[ArgumentIndices.CLOSURE_OR_NULL] = closure;
         frameArguments[ArgumentIndices.RECEIVER] = receiver;
-        frameArguments[ArgumentIndices.ARGUMENTS_START] = arg1;
-        frameArguments[ArgumentIndices.ARGUMENTS_START + 1] = arg2;
-        frameArguments[ArgumentIndices.ARGUMENTS_START + 2] = arg3;
-        frameArguments[ArgumentIndices.ARGUMENTS_START + 3] = arg4;
-        frameArguments[ArgumentIndices.ARGUMENTS_START + 4] = arg5;
+        frameArguments[ArgumentIndices.ARGUMENT_1] = arg1;
+        frameArguments[ArgumentIndices.ARGUMENT_2] = arg2;
+        frameArguments[ArgumentIndices.ARGUMENT_3] = arg3;
+        frameArguments[ArgumentIndices.ARGUMENT_4] = arg4;
+        frameArguments[ArgumentIndices.ARGUMENT_5] = arg5;
         return frameArguments;
     }
 
@@ -520,33 +525,33 @@ public final class FrameAccess {
     }
 
     public static void fillClosureTemplateWith(final Object[] template, final Object arg1) {
-        template[ArgumentIndices.ARGUMENTS_START + 0] = arg1;
+        template[ArgumentIndices.ARGUMENT_1] = arg1;
     }
 
     public static void fillClosureTemplateWith(final Object[] template, final Object arg1, final Object arg2) {
-        template[ArgumentIndices.ARGUMENTS_START + 0] = arg1;
-        template[ArgumentIndices.ARGUMENTS_START + 1] = arg2;
+        template[ArgumentIndices.ARGUMENT_1] = arg1;
+        template[ArgumentIndices.ARGUMENT_2] = arg2;
     }
 
     public static void fillClosureTemplateWith(final Object[] template, final Object arg1, final Object arg2, final Object arg3) {
-        template[ArgumentIndices.ARGUMENTS_START + 0] = arg1;
-        template[ArgumentIndices.ARGUMENTS_START + 1] = arg2;
-        template[ArgumentIndices.ARGUMENTS_START + 2] = arg3;
+        template[ArgumentIndices.ARGUMENT_1] = arg1;
+        template[ArgumentIndices.ARGUMENT_2] = arg2;
+        template[ArgumentIndices.ARGUMENT_3] = arg3;
     }
 
     public static void fillClosureTemplateWith(final Object[] template, final Object arg1, final Object arg2, final Object arg3, final Object arg4) {
-        template[ArgumentIndices.ARGUMENTS_START + 0] = arg1;
-        template[ArgumentIndices.ARGUMENTS_START + 1] = arg2;
-        template[ArgumentIndices.ARGUMENTS_START + 2] = arg3;
-        template[ArgumentIndices.ARGUMENTS_START + 3] = arg4;
+        template[ArgumentIndices.ARGUMENT_1] = arg1;
+        template[ArgumentIndices.ARGUMENT_2] = arg2;
+        template[ArgumentIndices.ARGUMENT_3] = arg3;
+        template[ArgumentIndices.ARGUMENT_4] = arg4;
     }
 
     public static void fillClosureTemplateWith(final Object[] template, final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5) {
-        template[ArgumentIndices.ARGUMENTS_START + 0] = arg1;
-        template[ArgumentIndices.ARGUMENTS_START + 1] = arg2;
-        template[ArgumentIndices.ARGUMENTS_START + 2] = arg3;
-        template[ArgumentIndices.ARGUMENTS_START + 3] = arg4;
-        template[ArgumentIndices.ARGUMENTS_START + 4] = arg5;
+        template[ArgumentIndices.ARGUMENT_1] = arg1;
+        template[ArgumentIndices.ARGUMENT_2] = arg2;
+        template[ArgumentIndices.ARGUMENT_3] = arg3;
+        template[ArgumentIndices.ARGUMENT_4] = arg4;
+        template[ArgumentIndices.ARGUMENT_5] = arg5;
     }
 
     public static int expectedArgumentSize(final int numArgsAndCopied) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/MethodCacheEntry.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/MethodCacheEntry.java
@@ -10,14 +10,13 @@ import com.oracle.truffle.api.CompilerAsserts;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import de.hpi.swa.trufflesqueak.model.ClassObject;
-import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
 import de.hpi.swa.trufflesqueak.model.NativeObject;
 
 public final class MethodCacheEntry {
     private ClassObject classObject;
     private NativeObject selector;
     private Object result;
-    private CompiledCodeObject fallbackMethod;
+    private ClassObject.DispatchFailureResult dispatchFailure;
 
     public ClassObject getClassObject() {
         return classObject;
@@ -31,34 +30,34 @@ public final class MethodCacheEntry {
         return result;
     }
 
-    public CompiledCodeObject getOrCreateFallbackMethod() {
-        if (fallbackMethod == null) {
-            fallbackMethod = createFallbackMethod();
+    public ClassObject.DispatchFailureResult getOrCreateDispatchFailureResult(final int arity) {
+        if (dispatchFailure == null || dispatchFailure.arity() != arity) {
+            dispatchFailure = createDispatchFailureResult(arity);
         }
-        return fallbackMethod;
+        return dispatchFailure;
     }
 
     @CompilerDirectives.TruffleBoundary
-    private CompiledCodeObject createFallbackMethod() {
-        return classObject.resolveDispatchFailure(selector);
+    private ClassObject.DispatchFailureResult createDispatchFailureResult(final int arity) {
+        return classObject.resolveDispatchFailure(selector, arity);
     }
 
     public void setResult(final Object object) {
         result = object;
-        fallbackMethod = null;
+        dispatchFailure = null;
     }
 
     public void freeAndRelease() {
         selector = null; /* Mark it free. */
         result = null; /* Release the method. */
-        fallbackMethod = null;
+        dispatchFailure = null;
     }
 
     public MethodCacheEntry reuseFor(final ClassObject lookupClass, final NativeObject lookupSelector) {
         classObject = lookupClass;
         selector = lookupSelector;
         result = null;
-        fallbackMethod = null;
+        dispatchFailure = null;
         return this;
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/MethodCacheEntry.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/MethodCacheEntry.java
@@ -7,8 +7,8 @@
 package de.hpi.swa.trufflesqueak.util;
 
 import com.oracle.truffle.api.CompilerAsserts;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 
-import com.oracle.truffle.api.CompilerDirectives;
 import de.hpi.swa.trufflesqueak.model.ClassObject;
 import de.hpi.swa.trufflesqueak.model.NativeObject;
 
@@ -37,7 +37,7 @@ public final class MethodCacheEntry {
         return dispatchFailure;
     }
 
-    @CompilerDirectives.TruffleBoundary
+    @TruffleBoundary
     private ClassObject.DispatchFailureResult createDispatchFailureResult(final int arity) {
         return classObject.resolveDispatchFailure(selector, arity);
     }


### PR DESCRIPTION
This is a fresh PR to replace the previous drafts (#252 and #275) with a much cleaner, two-commit history. I've set aside the multi-level dispatch implementation for now and focused this PR on the fallback paths.

Here are the main improvements:

**Allocation-Free DNU Shortcuts**: For missing methods with 3 or fewer arguments, we can now skip allocating a temporary `Array` and `Message` object. If configured (via `primitiveSetDNUShortcutSelectors`), a failed send transforms directly into a call to a shortcut selector, simply tacking the original selector on as the final argument.

**Zero-Overhead when Disabled**: We introduced a Truffle Assumption (`dnuShortcutsAbsent`) to ensure that if an image doesn't configure these DNU shortcuts, the VM incurs zero overhead checking for them.

**Nested `#cannotInterpret:`**: We now gracefully handle cascading dispatch failures. If a method dictionary is `nil` and `#cannotInterpret:` itself fails, we build nested `Message` objects to preserve the exact context of the original failure all the way down the chain.

**Smarter Cache Invalidation**: DNU fallback nodes now track an image-global "absent selector" assumption. If a developer compiles a method that was previously missing, the AST instantly invalidates the old DNU fallback nodes so they can link to the newly compiled method.

**Unrolled Extended Sends**: We unrolled the extended send bytecodes for arities 0–5 in the interpreters (`InterpreterSistaV1Node` and `InterpreterV3PlusClosuresNode`). This eliminates expensive `popN()` array allocations when running heavily on the interpreter path.

**`perform:` Cache Fix**: Cleaned up the `PrimPerform` primitives by stripping out duplicate receiver guards. Caching is now fully delegated down to the dispatch nodes, which prevents an AST cache explosion for highly polymorphic reflective calls.

### Testing

Verified that DNU shortcuts for arities 0-3 successfully bypass standard `Message` allocations.

Verified that corrupting multiple method dictionaries correctly triggers the nested #cannotInterpret: logic.

[TruffleSqueakDispatchFallbackTests.st.zip](https://github.com/user-attachments/files/30918871/TruffleSqueakDispatchFallbackTests.st.zip)

(Note: Replaces draft PRs #252 and #275)