### PR TITLE
add Squeak 6.1 image; fix image read of non-integer Context stack pointers

### DIFF
--- a/src/de.hpi.swa.trufflesqueak.shared/src/de/hpi/swa/trufflesqueak/shared/SqueakLanguageConfig.java
+++ b/src/de.hpi.swa.trufflesqueak.shared/src/de/hpi/swa/trufflesqueak/shared/SqueakLanguageConfig.java
@@ -43,6 +43,7 @@ public final class SqueakLanguageConfig {
                                     "https://github.com/hpi-swa/trufflesqueak/releases/download/22.3.0/TruffleSqueakTestImage-6.0-22104-64bit.zip"),
                     new SupportedImage("cuis-7.5-test", "Cuis Smalltalk test image (7.5-7708)", "https://github.com/hpi-swa/trufflesqueak/releases/download/25.0.1/CuisTestImage-7.5-7708.zip"),
                     new SupportedImage("cuis-7.3-test", "Cuis Smalltalk test image (7.3-7036)", "https://github.com/hpi-swa/trufflesqueak/releases/download/24.1.2/CuisTestImage-7.3-7036.zip"),
+                    new SupportedImage("squeak-6.1", "Squeak/Smalltalk (6.1-23976)", "https://files.squeak.org/6.1/Squeak6.1-23976-64bit/Squeak6.1-23976-64bit.zip"),
                     new SupportedImage("squeak-6.0", "Squeak/Smalltalk (6.0-22148)", "https://files.squeak.org/6.0/Squeak6.0-22148-64bit/Squeak6.0-22148-64bit.zip"),
     };
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
@@ -124,7 +124,9 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
         } else {
             setInstructionPointer(MiscUtils.toIntExact((long) pc) - methodOrBlock.getInitialPC());
         }
-        final int stackPointer = MiscUtils.toIntExact((long) chunk.getPointer(CONTEXT.STACKPOINTER));
+        // OSVM interprets non-integers as zero: see Interpreter>>fetchStackPointerOf:
+        final Object sp = chunk.getPointer(CONTEXT.STACKPOINTER);
+        final int stackPointer = sp instanceof Long spLong ? MiscUtils.toIntExact(spLong) : 0;
         setStackPointer(stackPointer);
         for (int i = 0; i < stackPointer; i++) {
             atTempPut(i, chunk.getPointer(CONTEXT.TEMP_FRAME_START + i));


### PR DESCRIPTION
OSVM internally tolerates non-integer stack pointers in `Contexts`, returning `0` for non-integer values. However, Squeak 6.1 images contain `Context` instances with `nil` stack pointers when read from disk.

Since Smalltalk can only read or write integers from/to the stack pointer, converting `nil` or non-integer stack pointers to `0` during the image read phase preserves expected semantics and prevents downstream runtime issues.

Changes in this PR:

- Converts non-integer stack pointer values to 0 when reading the image file.
- Adds the Squeak 6.1 image to the list of run-time selectable images.

_Note: Squeak 6.1 images do not have the high-DPI bit set, so the display will look quantized on high-DPI monitors. See #301 _