### PR TITLE
Fix race condition in squeakHashAndBits

### DIFF
--- a/src/de.hpi.swa.trufflesqueak.test/src/de/hpi/swa/trufflesqueak/test/AbstractSqueakTestCaseWithDummyImage.java
+++ b/src/de.hpi.swa.trufflesqueak.test/src/de/hpi/swa/trufflesqueak/test/AbstractSqueakTestCaseWithDummyImage.java
@@ -6,6 +6,8 @@
  */
 package de.hpi.swa.trufflesqueak.test;
 
+import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectNewNode;
+import de.hpi.swa.trufflesqueak.util.ArrayUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
@@ -135,6 +137,17 @@ public abstract class AbstractSqueakTestCaseWithDummyImage extends AbstractSquea
 
     private static NativeObject asByteSymbol(final String value) {
         return NativeObject.newNativeBytes(image.getByteSymbolClass(), MiscUtils.stringToBytes(value));
+    }
+
+    protected static ClassObject createFreshTestClass() {
+        final ClassObject dummyClass = new ClassObject(image);
+        dummyClass.setFormat(65542L /* `Morph format` */ | 24 /* + 24 slot = 30 slots in total. */);
+        dummyClass.setOtherPointers(ArrayUtils.EMPTY_ARRAY);
+        return dummyClass;
+    }
+
+    protected static PointersObject instantiate(final ClassObject dummyClass) {
+        return (PointersObject) SqueakObjectNewNode.executeUncached(dummyClass);
     }
 
     @AfterClass

--- a/src/de.hpi.swa.trufflesqueak.test/src/de/hpi/swa/trufflesqueak/test/MarkBitsConcurrencyTest.java
+++ b/src/de.hpi.swa.trufflesqueak.test/src/de/hpi/swa/trufflesqueak/test/MarkBitsConcurrencyTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2026 Software Architecture Group, Hasso Plattner Institute
+ * Copyright (c) 2026 Oracle and/or its affiliates
+ *
+ * Licensed under the MIT License.
+ */
+package de.hpi.swa.trufflesqueak.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.Test;
+
+import de.hpi.swa.trufflesqueak.model.AbstractSqueakObjectWithHash;
+import de.hpi.swa.trufflesqueak.model.ClassObject;
+import de.hpi.swa.trufflesqueak.model.PointersObject;
+
+@SuppressWarnings("static-method")
+public final class MarkBitsConcurrencyTest extends AbstractSqueakTestCaseWithDummyImage {
+    private static final long FLAG_ITERATIONS = 10_000_000;
+    private static final int MARK_OBJECT_COUNT = 20_000;
+    private static final int MARK_THREAD_COUNT = 4;
+
+    /**
+     * Verifies that concurrent bit-field updates (boolean flags vs. GC mark bits) are thread-safe.
+     * One thread toggles boolean flags while another marks/unmarks the object; neither may lose
+     * updates or mutate the identity hash.
+     */
+    @Test
+    public void testFlagAndMarkingBitsDoNotLoseUpdates() throws InterruptedException {
+        final PointersObject object = instantiate(createFreshTestClass());
+        final int hash = 0x2A2A2A;
+        object.setSqueakHash(hash);
+        object.setBooleanDBit(); /* Set once, must never be observed unset again. */
+
+        final Queue<String> failures = new ConcurrentLinkedQueue<>();
+        final CountDownLatch start = new CountDownLatch(1);
+
+        final Thread booleanBitsThread = new Thread(() -> {
+            try {
+                start.await();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            for (long i = 0; i < FLAG_ITERATIONS; i++) {
+                object.setBooleanABit();
+                if (!object.isBooleanASet()) {
+                    failures.add("Lost setBooleanABit in iteration " + i);
+                    return;
+                }
+                object.clearBooleanABit();
+                if (object.isBooleanASet()) {
+                    failures.add("Lost clearBooleanABit in iteration " + i);
+                    return;
+                }
+                if (!object.isBooleanDSet()) {
+                    failures.add("Lost the untouched boolean D bit in iteration " + i);
+                    return;
+                }
+                if (object.getSqueakHashInt() != hash) {
+                    failures.add("Hash changed to " + object.getSqueakHashInt() + " in iteration " + i);
+                    return;
+                }
+            }
+        }, "booleanBitsThread");
+
+        final Thread markingBitsThread = new Thread(() -> {
+            try {
+                start.await();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            for (long i = 0; i < FLAG_ITERATIONS; i++) {
+                if (!object.tryToMarkWith(true)) {
+                    failures.add("Could not mark in iteration " + i);
+                    return;
+                }
+                if (!object.isMarkedWith(true)) {
+                    failures.add("Lost the mark in iteration " + i);
+                    return;
+                }
+                object.unmarkWith(true);
+                if (object.isMarkedWith(true)) {
+                    failures.add("Lost the unmark in iteration " + i);
+                    return;
+                }
+            }
+        }, "markingBitsThread");
+
+        booleanBitsThread.start();
+        markingBitsThread.start();
+        start.countDown();
+        booleanBitsThread.join();
+        markingBitsThread.join();
+
+        assertEquals("Lost updates: " + failures, 0, failures.size());
+        assertEquals("Hash survived", hash, object.getSqueakHashInt());
+        assertTrue("Boolean D bit survived", object.isBooleanDSet());
+    }
+
+    /**
+     * Verifies that marking objects is atomic across concurrent threads.
+     * When multiple threads race to mark the same object, {@code tryToMarkWith(true)} must return
+     * {@code true} for exactly 1 thread and {@code false} for all others. Across N objects,
+     * the total number of successful marks across all threads must equal N.
+     */
+    @Test
+    public void testConcurrentMarkingMarksEachObjectExactlyOnce() throws InterruptedException {
+        final ClassObject testClass = createFreshTestClass();
+        final List<AbstractSqueakObjectWithHash> objects = new ArrayList<>(MARK_OBJECT_COUNT);
+        for (int i = 0; i < MARK_OBJECT_COUNT; i++) {
+            objects.add(instantiate(testClass));
+        }
+
+        final AtomicLong marked = new AtomicLong();
+        final CountDownLatch start = new CountDownLatch(1);
+        final Thread[] threads = new Thread[MARK_THREAD_COUNT];
+        for (int t = 0; t < threads.length; t++) {
+            /* Walk in opposite directions to widen the window in which two threads meet. */
+            final boolean forwards = t % 2 == 0;
+            threads[t] = new Thread(() -> {
+                try {
+                    start.await();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                long count = 0;
+                for (int i = 0; i < MARK_OBJECT_COUNT; i++) {
+                    final AbstractSqueakObjectWithHash object = objects.get(forwards ? i : MARK_OBJECT_COUNT - 1 - i);
+                    if (object.tryToMarkWith(true)) {
+                        count++;
+                    }
+                }
+                marked.addAndGet(count);
+            }, "graphWalkerThread" + t);
+        }
+        for (final Thread thread : threads) {
+            thread.start();
+        }
+        start.countDown();
+        for (final Thread thread : threads) {
+            thread.join();
+        }
+
+        assertEquals("Every object marked exactly once", MARK_OBJECT_COUNT, marked.get());
+        for (final AbstractSqueakObjectWithHash object : objects) {
+            assertTrue(object.isMarkedWith(true));
+            object.unmarkWith(true);
+            assertFalse(object.isMarkedWith(true));
+        }
+    }
+}

--- a/src/de.hpi.swa.trufflesqueak.test/src/de/hpi/swa/trufflesqueak/test/MarkBitsConcurrencyTest.java
+++ b/src/de.hpi.swa.trufflesqueak.test/src/de/hpi/swa/trufflesqueak/test/MarkBitsConcurrencyTest.java
@@ -28,6 +28,7 @@ public final class MarkBitsConcurrencyTest extends AbstractSqueakTestCaseWithDum
     private static final long FLAG_ITERATIONS = 10_000_000;
     private static final int MARK_OBJECT_COUNT = 20_000;
     private static final int MARK_THREAD_COUNT = 4;
+    private static final int HASH = 0x2A2A2A;
 
     /**
      * Verifies that concurrent bit-field updates (boolean flags vs. GC mark bits) are thread-safe.
@@ -37,63 +38,19 @@ public final class MarkBitsConcurrencyTest extends AbstractSqueakTestCaseWithDum
     @Test
     public void testFlagAndMarkingBitsDoNotLoseUpdates() throws InterruptedException {
         final PointersObject object = instantiate(createFreshTestClass());
-        final int hash = 0x2A2A2A;
-        object.setSqueakHash(hash);
+        object.setSqueakHash(HASH);
         object.setBooleanDBit(); /* Set once, must never be observed unset again. */
 
         final Queue<String> failures = new ConcurrentLinkedQueue<>();
         final CountDownLatch start = new CountDownLatch(1);
 
-        final Thread booleanBitsThread = new Thread(() -> {
-            try {
-                start.await();
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-            }
-            for (long i = 0; i < FLAG_ITERATIONS; i++) {
-                object.setBooleanABit();
-                if (!object.isBooleanASet()) {
-                    failures.add("Lost setBooleanABit in iteration " + i);
-                    return;
-                }
-                object.clearBooleanABit();
-                if (object.isBooleanASet()) {
-                    failures.add("Lost clearBooleanABit in iteration " + i);
-                    return;
-                }
-                if (!object.isBooleanDSet()) {
-                    failures.add("Lost the untouched boolean D bit in iteration " + i);
-                    return;
-                }
-                if (object.getSqueakHashInt() != hash) {
-                    failures.add("Hash changed to " + object.getSqueakHashInt() + " in iteration " + i);
-                    return;
-                }
-            }
-        }, "booleanBitsThread");
+        final Thread booleanBitsThread = new Thread(
+                        () -> runBooleanBitsWorker(object, failures, start),
+                        "booleanBitsThread");
 
-        final Thread markingBitsThread = new Thread(() -> {
-            try {
-                start.await();
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-            }
-            for (long i = 0; i < FLAG_ITERATIONS; i++) {
-                if (!object.tryToMarkWith(true)) {
-                    failures.add("Could not mark in iteration " + i);
-                    return;
-                }
-                if (!object.isMarkedWith(true)) {
-                    failures.add("Lost the mark in iteration " + i);
-                    return;
-                }
-                object.unmarkWith(true);
-                if (object.isMarkedWith(true)) {
-                    failures.add("Lost the unmark in iteration " + i);
-                    return;
-                }
-            }
-        }, "markingBitsThread");
+        final Thread markingBitsThread = new Thread(
+                        () -> runMarkingBitsWorker(object, failures, start),
+                        "markingBitsThread");
 
         booleanBitsThread.start();
         markingBitsThread.start();
@@ -102,7 +59,7 @@ public final class MarkBitsConcurrencyTest extends AbstractSqueakTestCaseWithDum
         markingBitsThread.join();
 
         assertEquals("Lost updates: " + failures, 0, failures.size());
-        assertEquals("Hash survived", hash, object.getSqueakHashInt());
+        assertEquals("Hash survived", HASH, object.getSqueakHashInt());
         assertTrue("Boolean D bit survived", object.isBooleanDSet());
     }
 
@@ -126,21 +83,9 @@ public final class MarkBitsConcurrencyTest extends AbstractSqueakTestCaseWithDum
         for (int t = 0; t < threads.length; t++) {
             /* Walk in opposite directions to widen the window in which two threads meet. */
             final boolean forwards = t % 2 == 0;
-            threads[t] = new Thread(() -> {
-                try {
-                    start.await();
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
-                long count = 0;
-                for (int i = 0; i < MARK_OBJECT_COUNT; i++) {
-                    final AbstractSqueakObjectWithHash object = objects.get(forwards ? i : MARK_OBJECT_COUNT - 1 - i);
-                    if (object.tryToMarkWith(true)) {
-                        count++;
-                    }
-                }
-                marked.addAndGet(count);
-            }, "graphWalkerThread" + t);
+            threads[t] = new Thread(
+                            () -> runGraphWalkerWorker(objects, forwards, marked, start),
+                            "graphWalkerThread" + t);
         }
         for (final Thread thread : threads) {
             thread.start();
@@ -155,6 +100,70 @@ public final class MarkBitsConcurrencyTest extends AbstractSqueakTestCaseWithDum
             assertTrue(object.isMarkedWith(true));
             object.unmarkWith(true);
             assertFalse(object.isMarkedWith(true));
+        }
+    }
+
+    private static void runBooleanBitsWorker(final PointersObject object, final Queue<String> failures, final CountDownLatch start) {
+        awaitLatch(start);
+        for (long i = 0; i < FLAG_ITERATIONS; i++) {
+            object.setBooleanABit();
+            if (!object.isBooleanASet()) {
+                failures.add("Lost setBooleanABit in iteration " + i);
+                return;
+            }
+            object.clearBooleanABit();
+            if (object.isBooleanASet()) {
+                failures.add("Lost clearBooleanABit in iteration " + i);
+                return;
+            }
+            if (!object.isBooleanDSet()) {
+                failures.add("Lost the untouched boolean D bit in iteration " + i);
+                return;
+            }
+            if (object.getSqueakHashInt() != HASH) {
+                failures.add("Hash changed to " + object.getSqueakHashInt() + " in iteration " + i);
+                return;
+            }
+        }
+    }
+
+    private static void runMarkingBitsWorker(final PointersObject object, final Queue<String> failures, final CountDownLatch start) {
+        awaitLatch(start);
+        for (long i = 0; i < FLAG_ITERATIONS; i++) {
+            if (!object.tryToMarkWith(true)) {
+                failures.add("Could not mark in iteration " + i);
+                return;
+            }
+            if (!object.isMarkedWith(true)) {
+                failures.add("Lost the mark in iteration " + i);
+                return;
+            }
+            object.unmarkWith(true);
+            if (object.isMarkedWith(true)) {
+                failures.add("Lost the unmark in iteration " + i);
+                return;
+            }
+        }
+    }
+
+    private static void runGraphWalkerWorker(final List<AbstractSqueakObjectWithHash> objects, final boolean forwards, final AtomicLong marked, final CountDownLatch start) {
+        awaitLatch(start);
+        long count = 0;
+        for (int i = 0; i < MARK_OBJECT_COUNT; i++) {
+            final AbstractSqueakObjectWithHash object = objects.get(forwards ? i : MARK_OBJECT_COUNT - 1 - i);
+            if (object.tryToMarkWith(true)) {
+                count++;
+            }
+        }
+        marked.addAndGet(count);
+    }
+
+    private static void awaitLatch(final CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError("Thread interrupted while awaiting latch", e);
         }
     }
 }

--- a/src/de.hpi.swa.trufflesqueak.test/src/de/hpi/swa/trufflesqueak/test/ObjectLayoutTest.java
+++ b/src/de.hpi.swa.trufflesqueak.test/src/de/hpi/swa/trufflesqueak/test/ObjectLayoutTest.java
@@ -22,8 +22,6 @@ import de.hpi.swa.trufflesqueak.model.PointersObject;
 import de.hpi.swa.trufflesqueak.model.layout.SlotLocation;
 import de.hpi.swa.trufflesqueak.nodes.accessing.AbstractPointersObjectNodes.AbstractPointersObjectReadNode;
 import de.hpi.swa.trufflesqueak.nodes.accessing.AbstractPointersObjectNodes.AbstractPointersObjectWriteNode;
-import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectNewNode;
-import de.hpi.swa.trufflesqueak.util.ArrayUtils;
 
 @SuppressWarnings("static-method")
 public final class ObjectLayoutTest extends AbstractSqueakTestCaseWithDummyImage {
@@ -177,17 +175,6 @@ public final class ObjectLayoutTest extends AbstractSqueakTestCaseWithDummyImage
         assertSame(NilObject.SINGLETON, obj.object1);
         assertSame(NilObject.SINGLETON, obj.object2);
         assertNull(obj.objectExtension);
-    }
-
-    private static ClassObject createFreshTestClass() {
-        final ClassObject dummyClass = new ClassObject(image);
-        dummyClass.setFormat(65542L /* `Morph format` */ | 24 /* + 24 slot = 30 slots in total. */);
-        dummyClass.setOtherPointers(ArrayUtils.EMPTY_ARRAY);
-        return dummyClass;
-    }
-
-    private static PointersObject instantiate(final ClassObject dummyClass) {
-        return (PointersObject) SqueakObjectNewNode.executeUncached(dummyClass);
     }
 
     private static void writeAndValidate(final AbstractPointersObject obj, final int index, final Object value) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/AbstractSqueakObjectWithHash.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/AbstractSqueakObjectWithHash.java
@@ -9,6 +9,8 @@ package de.hpi.swa.trufflesqueak.model;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 
+import de.hpi.swa.trufflesqueak.util.ThreadAccess;
+import de.hpi.swa.trufflesqueak.util.ThreadAccess.Mode;
 import org.graalvm.collections.UnmodifiableEconomicMap;
 
 import com.oracle.truffle.api.CompilerAsserts;
@@ -63,7 +65,7 @@ public abstract class AbstractSqueakObjectWithHash extends AbstractSqueakObject 
     /* Generate new hash if hash is 0 (see SpurMemoryManager>>#hashBitsOf:). */
     protected static final int HASH_UNINITIALIZED = 0;
 
-    private int squeakHashAndBits;
+    @ThreadAccess(value = Mode.CAS, orderedBy = "HASH_AND_BITS_HANDLE") private int squeakHashAndBits;
 
     /**
      * Support for atomically accessing the flags contained within squeakHashAndBits.
@@ -89,8 +91,10 @@ public abstract class AbstractSqueakObjectWithHash extends AbstractSqueakObject 
 
     @SuppressWarnings("this-escape")
     protected AbstractSqueakObjectWithHash(final AbstractSqueakObjectWithHash original) {
-        /* Preserves flags and resets hash. */
-        squeakHashAndBits = original.squeakHashAndBits & SQUEAK_HASH_FLAGS_MASK;
+        /*
+         * Preserves flags and resets hash and mark bits.
+         */
+        squeakHashAndBits = original.squeakHashAndBits & SQUEAK_HASH_FLAGS_MASK & ~MARKING_MASK;
     }
 
     protected void initializeFrom(final SqueakImageChunk chunk) {
@@ -136,7 +140,7 @@ public abstract class AbstractSqueakObjectWithHash extends AbstractSqueakObject 
 
     public final int getSqueakHashInt() {
         assert assertNotForwarded();
-        return squeakHashAndBits >>> SQUEAK_HASH_SHIFT;
+        return ((int) HASH_AND_BITS_HANDLE.getAcquire(this)) >>> SQUEAK_HASH_SHIFT;
     }
 
     public final boolean needsSqueakHash() {
@@ -147,7 +151,11 @@ public abstract class AbstractSqueakObjectWithHash extends AbstractSqueakObject 
     public final void setSqueakHash(final int newHash) {
         assert assertNotForwarded();
         assert (newHash & SqueakImageConstants.IDENTITY_HASH_HALF_WORD_MASK) == newHash : "Invalid hash: " + newHash;
-        squeakHashAndBits = (newHash << SQUEAK_HASH_SHIFT) | (squeakHashAndBits & SQUEAK_HASH_FLAGS_MASK);
+
+        int oldValue;
+        do {
+            oldValue = (int) HASH_AND_BITS_HANDLE.getAcquire(this);
+        } while (!HASH_AND_BITS_HANDLE.compareAndSet(this, oldValue, (newHash << SQUEAK_HASH_SHIFT) | (oldValue & SQUEAK_HASH_FLAGS_MASK)));
     }
 
     /**
@@ -156,8 +164,11 @@ public abstract class AbstractSqueakObjectWithHash extends AbstractSqueakObject 
      */
     public final boolean isMarkedWith(final boolean currentMarkingFlag) {
         final int currentBits = ((int) HASH_AND_BITS_HANDLE.getAcquire(this)) & MARKING_MASK;
-        final int desiredBits = VALID_MARK_BIT | (currentMarkingFlag ? MARK_BIT : 0);
-        return currentBits == desiredBits;
+        return currentBits == desiredMarkBits(currentMarkingFlag);
+    }
+
+    private static int desiredMarkBits(final boolean currentMarkingFlag) {
+        return VALID_MARK_BIT | (currentMarkingFlag ? MARK_BIT : 0);
     }
 
     /**
@@ -174,7 +185,7 @@ public abstract class AbstractSqueakObjectWithHash extends AbstractSqueakObject 
          */
         do {
             oldValue = (int) HASH_AND_BITS_HANDLE.getAcquire(this);
-            final int desiredBits = VALID_MARK_BIT | (currentMarkingFlag ? MARK_BIT : 0);
+            final int desiredBits = desiredMarkBits(currentMarkingFlag);
             if ((oldValue & MARKING_MASK) == desiredBits) {
                 return false; // Already marked
             } else {
@@ -192,11 +203,11 @@ public abstract class AbstractSqueakObjectWithHash extends AbstractSqueakObject 
     }
 
     protected final void setForwardedBit() {
-        squeakHashAndBits |= FORWARDED_BIT;
+        HASH_AND_BITS_HANDLE.getAndBitwiseOrRelease(this, FORWARDED_BIT);
     }
 
     public final boolean isNotForwarded() {
-        return (squeakHashAndBits & FORWARDED_BIT) == 0;
+        return ((int) HASH_AND_BITS_HANDLE.getAcquire(this) & FORWARDED_BIT) == 0;
     }
 
     @SuppressWarnings("this-escape")
@@ -216,59 +227,62 @@ public abstract class AbstractSqueakObjectWithHash extends AbstractSqueakObject 
     /* General purpose boolean flags. */
 
     public final void setBooleanABit() {
-        squeakHashAndBits |= BOOLEAN_A_BIT;
+        HASH_AND_BITS_HANDLE.getAndBitwiseOrRelease(this, BOOLEAN_A_BIT);
     }
 
     public final void setBooleanBBit() {
-        squeakHashAndBits |= BOOLEAN_B_BIT;
+        HASH_AND_BITS_HANDLE.getAndBitwiseOrRelease(this, BOOLEAN_B_BIT);
     }
 
     public final void setBooleanCBit() {
-        squeakHashAndBits |= BOOLEAN_C_BIT;
+        HASH_AND_BITS_HANDLE.getAndBitwiseOrRelease(this, BOOLEAN_C_BIT);
     }
 
     public final void setBooleanDBit() {
-        squeakHashAndBits |= BOOLEAN_D_BIT;
+        HASH_AND_BITS_HANDLE.getAndBitwiseOrRelease(this, BOOLEAN_D_BIT);
     }
 
     public final void clearBooleanABit() {
-        squeakHashAndBits &= ~BOOLEAN_A_BIT;
+        HASH_AND_BITS_HANDLE.getAndBitwiseAndRelease(this, ~BOOLEAN_A_BIT);
     }
 
     public final void clearBooleanBBit() {
-        squeakHashAndBits &= ~BOOLEAN_B_BIT;
+        HASH_AND_BITS_HANDLE.getAndBitwiseAndRelease(this, ~BOOLEAN_B_BIT);
     }
 
     public final void clearBooleanCBit() {
-        squeakHashAndBits &= ~BOOLEAN_C_BIT;
+        HASH_AND_BITS_HANDLE.getAndBitwiseAndRelease(this, ~BOOLEAN_C_BIT);
     }
 
     public final void clearBooleanDBit() {
-        squeakHashAndBits &= ~BOOLEAN_D_BIT;
+        HASH_AND_BITS_HANDLE.getAndBitwiseAndRelease(this, ~BOOLEAN_D_BIT);
     }
 
     public final boolean isBooleanASet() {
-        return (squeakHashAndBits & BOOLEAN_A_BIT) != 0;
+        return ((int) HASH_AND_BITS_HANDLE.getAcquire(this) & BOOLEAN_A_BIT) != 0;
     }
 
     public final boolean isBooleanBSet() {
-        return (squeakHashAndBits & BOOLEAN_B_BIT) != 0;
+        return ((int) HASH_AND_BITS_HANDLE.getAcquire(this) & BOOLEAN_B_BIT) != 0;
     }
 
     public final boolean isBooleanCSet() {
-        return (squeakHashAndBits & BOOLEAN_C_BIT) != 0;
+        return ((int) HASH_AND_BITS_HANDLE.getAcquire(this) & BOOLEAN_C_BIT) != 0;
     }
 
     public final boolean isBooleanDSet() {
-        return (squeakHashAndBits & BOOLEAN_D_BIT) != 0;
+        return ((int) HASH_AND_BITS_HANDLE.getAcquire(this) & BOOLEAN_D_BIT) != 0;
     }
 
     public final int getAllBooleanBits() {
-        return squeakHashAndBits & BOOLEAN_BIT_MASK;
+        return ((int) HASH_AND_BITS_HANDLE.getAcquire(this) & BOOLEAN_BIT_MASK);
     }
 
     public final void setAllBooleanBits(final int bits) {
-        squeakHashAndBits = (squeakHashAndBits & ~BOOLEAN_BIT_MASK) | bits;
+        int oldValue;
+        do {
+            oldValue = (int) HASH_AND_BITS_HANDLE.getAcquire(this);
+        } while (!HASH_AND_BITS_HANDLE.compareAndSet(this, oldValue, (oldValue & ~BOOLEAN_BIT_MASK) | bits));
     }
 
     @Override

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/ThreadAccess.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/ThreadAccess.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Software Architecture Group, Hasso Plattner Institute
+ * Copyright (c) 2026 Oracle and/or its affiliates
+ *
+ * Licensed under the MIT License.
+ */
+package de.hpi.swa.trufflesqueak.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Declares the thread-safety access contract for a field shared across multiple threads.
+ * This annotation documents intended synchronization rules and provides guidelines
+ * on how shared fields must be safely accessed and mutated.
+ * Specify the weakest access mode that guarantees correctness,
+ * rather than defaulting to the strongest available mechanism.
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.FIELD)
+public @interface ThreadAccess {
+    Mode value();
+
+    /**
+     * Identifies the synchronization mechanism enforcing ordering or atomicity for this field
+     * (e.g. the name of a {@code VarHandle}, {@code AtomicReferenceFieldUpdater}, guarding lock,
+     * or VM-level operation).
+     */
+    String orderedBy() default "";
+
+    enum Mode {
+        // TODO: Add more modes if needed.
+        /**
+         * Updated only by {@code compareAndSet}, typically in a retry loop.
+         */
+        CAS,
+    }
+}


### PR DESCRIPTION
This PR fixes a race-condition in the usage of squeakHashAndBits. Even with the existence of HASH_AND_BITS_HANDLE for atomic accesses, it was not used everywhere.

MarkBitsConcurrencyTest will mostly fail without those changes
