### PR TITLE
Force Context mutations to the heap

### DIFF
--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/CompiledCodeObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/CompiledCodeObject.java
@@ -677,7 +677,7 @@ public final class CompiledCodeObject extends AbstractSqueakObjectWithClassAndHa
     }
 
     /** CompiledMethod>>#methodClassAssociation. */
-    private AbstractPointersObject getMethodClassAssociation() {
+    private Object getMethodClassAssociation() {
         /*
          * From the CompiledMethod class description:
          *
@@ -687,7 +687,7 @@ public final class CompiledCodeObject extends AbstractSqueakObjectWithClassAndHa
          * may be nil (as would be the case for example of methods providing a pool of inst var
          * accessors).
          */
-        return (AbstractPointersObject) literals[getNumLiterals() - 1];
+        return literals[getNumLiterals() - 1];
     }
 
     public boolean hasMethodClass(final AbstractPointersObjectReadNode readNode) {
@@ -718,7 +718,7 @@ public final class CompiledCodeObject extends AbstractSqueakObjectWithClassAndHa
                 return methodClass;
             } else {
                 final ClassObject forwardedMethodClass = (ClassObject) methodClass.getForwardingPointer();
-                AbstractPointersObjectWriteNode.executeUncached(getMethodClassAssociation(), CLASS_BINDING.VALUE, forwardedMethodClass);
+                AbstractPointersObjectWriteNode.executeUncached((AbstractPointersObject) getMethodClassAssociation(), CLASS_BINDING.VALUE, forwardedMethodClass);
                 return forwardedMethodClass;
             }
         }
@@ -727,7 +727,7 @@ public final class CompiledCodeObject extends AbstractSqueakObjectWithClassAndHa
 
     /** CompiledMethod>>#methodClass. */
     private ClassObject getMethodClass(final AbstractPointersObjectReadNode readNode) {
-        return (ClassObject) readNode.execute(getMethodClassAssociation(), CLASS_BINDING.VALUE);
+        return (ClassObject) readNode.execute((AbstractPointersObject) getMethodClassAssociation(), CLASS_BINDING.VALUE);
     }
 
     public long getHeader() {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
@@ -273,7 +273,7 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
 
     /**
      * Returns true if the Context might be currently executing on the Truffle stack. This acts as a
-     * fast-path flag to avoid expensive {@link #isActiveOnTruffleStackSlow()} checks. Returns false
+     * fast-path flag to avoid expensive {@link #isActuallyActiveOnTruffleStackSlow()} checks. Returns false
      * if it is guaranteed to have been forced to the heap or suspended.
      * <p>
      * Note: We use inverted bit logic (0 = potentially active, 1 = inactive) to take advantage of
@@ -406,7 +406,7 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
         return truffleFrame;
     }
 
-    public boolean isActiveOnTruffleStackSlow() {
+    public boolean isActuallyActiveOnTruffleStackSlow() {
         if (!hasTruffleFrame()) {
             return false; // No Truffle frame means the receiver is not yet executing.
         }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
@@ -273,7 +273,7 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
 
     /**
      * Returns true if the Context might be currently executing on the Truffle stack. This acts as a
-     * fast-path flag to avoid expensive {@link #isActuallyActiveOnTruffleStackSlow()} checks. Returns false
+     * fast-path flag to avoid expensive {@link #isActuallyActiveOnTruffleStack()} checks. Returns false
      * if it is guaranteed to have been forced to the heap or suspended.
      * <p>
      * Note: We use inverted bit logic (0 = potentially active, 1 = inactive) to take advantage of
@@ -406,18 +406,18 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
         return truffleFrame;
     }
 
-    public boolean isActuallyActiveOnTruffleStackSlow() {
+    public boolean isActuallyActiveOnTruffleStack() {
         if (!hasTruffleFrame()) {
             return false; // No Truffle frame means the receiver is not yet executing.
         }
         final Object result = Truffle.getRuntime().iterateFrames(frameInstance -> {
             final Frame current = frameInstance.getFrame(FrameInstance.FrameAccess.READ_ONLY);
             if (current != null && FrameAccess.isTruffleSqueakFrame(current) && this == FrameAccess.getContext(current)) {
-                return true;
+                return this;
             }
             return null;
         });
-        return result != null;
+        return result == this;
     }
 
     public BlockClosureObject getClosure() {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ResumeContextRootNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/ResumeContextRootNode.java
@@ -45,7 +45,7 @@ public final class ResumeContextRootNode extends AbstractRootNode {
         /*
          * Reset the fast-path flag to indicate this Context has resumed execution. Future external
          * modifications to this Context's instruction pointer will now trigger a proper stack
-         * check. See AbstractInterpreterNode#checkForAndHandlePCModification
+         * check. See AbstractInterpreterNode#ensureContextReceiverIsNotActive
          */
         activeContext.markAsPotentiallyActiveOnTruffleStack();
         activeContext.clearModifiedSender();

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractInterpreterNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractInterpreterNode.java
@@ -37,6 +37,7 @@ import de.hpi.swa.trufflesqueak.model.AbstractSqueakObject;
 import de.hpi.swa.trufflesqueak.model.AbstractSqueakObjectWithClassAndHash;
 import de.hpi.swa.trufflesqueak.model.ArrayObject;
 import de.hpi.swa.trufflesqueak.model.BlockClosureObject;
+import de.hpi.swa.trufflesqueak.model.ClassObject;
 import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
 import de.hpi.swa.trufflesqueak.model.ContextObject;
 import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.ASSOCIATION;
@@ -76,6 +77,7 @@ public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrum
 
     protected final CompiledCodeObject code;
     protected final boolean isBlock;
+    protected final boolean modifiesContext;
 
     @CompilationFinal(dimensions = 1) private final Object[] data;
     @CompilationFinal(dimensions = 1) private final byte[] profiles;
@@ -89,7 +91,8 @@ public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrum
         final int endPC = code.getMaxPCZeroBased();
         data = new Object[endPC];
         profiles = new byte[endPC];
-        processBytecode(startPC, endPC);
+        final boolean hasPotentialContextIVStore = processBytecode(startPC, endPC);
+        modifiesContext = couldMutateContextVariables(hasPotentialContextIVStore);
     }
 
     @SuppressWarnings("this-escape")
@@ -102,14 +105,55 @@ public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrum
         final int endPC = code.getMaxPCZeroBased();
         data = new Object[endPC];
         profiles = new byte[endPC];
-        processBytecode(startPC, endPC);
+        final boolean hasPotentialContextIVStore = processBytecode(startPC, endPC);
+        modifiesContext = couldMutateContextVariables(hasPotentialContextIVStore);
         osrMetadata = null;
     }
 
-    protected abstract void processBytecode(int startPC, int endPC);
+    protected abstract boolean processBytecode(int startPC, int endPC);
 
     @Override
     public abstract Object execute(VirtualFrame frame, int startPC, int startSP);
+
+    /**
+     * The following Smalltalk snippet evaluates to true, proving that all methods
+     * possess a valid methodClass. This allows us to reliably use
+     * getMethodClassOrNullSlow() for hierarchy checks, falling back to true only
+     * for edge cases like interop or polyglot messages.
+     * <p>
+     *  | methods |
+     *  methods := OrderedCollection new.
+     *  Behavior allInstances do: [ :cls |
+     *      cls methodsDo: [ :meth |
+     *          meth methodClass == cls ifFalse: [
+     *              methods add: meth]]].
+     *  methods isEmpty
+     */
+    private boolean couldMutateContextVariables(final boolean hasPotentialContextIVStore) {
+        if (hasPotentialContextIVStore) {
+            final ClassObject methodClass = code.getMethod().getMethodClassOrNullSlow();
+            if (methodClass == null) {
+                // Cannot prove the receiver is not a Context method.
+                return true;
+            }
+
+            // Fast-path rejection: must have between 1 and Context's number of instance variables
+            final ClassObject contextClass = getContext().methodContextClass;
+            final int methodClassInstSize = methodClass.getBasicInstanceSize();
+
+            if (methodClassInstSize > 0 && methodClassInstSize <= contextClass.getBasicInstanceSize()) {
+                // Walk the superclass chain until we hit a class with 0 instance variables (e.g., Object)
+                ClassObject current = contextClass;
+                do {
+                    if (methodClass == current) {
+                        return true;
+                    }
+                    current = current.getSuperclassOrNull();
+                } while (current != null && current.getBasicInstanceSize() > 0);
+            }
+        }
+        return false;
+    }
 
     static final class ReadLiteralVariableNode extends AbstractNode {
         private final SqueakObjectAt0NodeGen at0Node = insert((SqueakObjectAt0NodeGen) SqueakObjectAt0NodeGen.create());
@@ -397,24 +441,18 @@ public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrum
         throw new CannotReturnToTarget(returnValue, GetOrCreateContextWithFrameNode.executeUncached(frame));
     }
 
-    protected final void checkForAndHandlePCModification(final VirtualFrame frame, final int pc, final int sp, final int index, final Object receiver, final int nextPC) {
-        if (index == CONTEXT.INSTRUCTION_POINTER && receiver instanceof ContextObject context) {
-            enter(pc, getProfile(pc), BRANCH1);
-            if (context.isPotentiallyActiveOnTruffleStack()) {
-                // Fast-path optimization: Preemptively mark the Context as inactive.
-                // If the PC is modified multiple times while suspended, we avoid paying
-                // the expensive cost of iterateFrames() on subsequent modifications.
-                context.markAsInactiveOnTruffleStack();
-                if (context.isActiveOnTruffleStackSlow()) {
-                    // The context was actually active. Throwing ProcessSwitch will unwind the
-                    // Truffle stack and force all contexts to the heap. This renders our
-                    // preemptive "inactive" mark factually correct.
-                    CompilerDirectives.transferToInterpreter();
-                    FrameAccess.externalizePCAndSP(frame, nextPC, sp);
-                    final ContextObject activeContext = GetOrCreateContextWithFrameNode.executeUncached(frame);
-                    AbstractPointersObjectWriteNode.executeUncached(getContext().getActiveProcessSlow(), PROCESS.SUSPENDED_CONTEXT, activeContext);
-                    throw ProcessSwitch.SINGLETON;
-                }
+    protected final void ensureContextIsNotActive(final VirtualFrame frame, final ContextObject context, final int pc, final int sp) {
+        if (context.isPotentiallyActiveOnTruffleStack()) {
+            // Fast-path optimization: Preemptively mark the Context as inactive.
+            context.markAsInactiveOnTruffleStack();
+            if (context.isActuallyActiveOnTruffleStackSlow()) {
+                // The context was actually active. Throwing ProcessSwitch will unwind the
+                // Truffle stack and force all contexts to the heap.
+                CompilerDirectives.transferToInterpreter();
+                FrameAccess.externalizePCAndSP(frame, pc, sp);
+                final ContextObject activeContext = GetOrCreateContextWithFrameNode.executeUncached(frame);
+                AbstractPointersObjectWriteNode.executeUncached(getContext().getActiveProcessSlow(), PROCESS.SUSPENDED_CONTEXT, activeContext);
+                throw ProcessSwitch.SINGLETON;
             }
         }
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractInterpreterNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractInterpreterNode.java
@@ -41,7 +41,6 @@ import de.hpi.swa.trufflesqueak.model.ClassObject;
 import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
 import de.hpi.swa.trufflesqueak.model.ContextObject;
 import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.ASSOCIATION;
-import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.CONTEXT;
 import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.PROCESS;
 import de.hpi.swa.trufflesqueak.nodes.AbstractNode;
 import de.hpi.swa.trufflesqueak.nodes.accessing.AbstractPointersObjectNodes.AbstractPointersObjectWriteNode;
@@ -77,7 +76,7 @@ public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrum
 
     protected final CompiledCodeObject code;
     protected final boolean isBlock;
-    protected final boolean modifiesContext;
+    private final boolean modifiesContext;
 
     @CompilationFinal(dimensions = 1) private final Object[] data;
     @CompilationFinal(dimensions = 1) private final byte[] profiles;
@@ -441,11 +440,11 @@ public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrum
         throw new CannotReturnToTarget(returnValue, GetOrCreateContextWithFrameNode.executeUncached(frame));
     }
 
-    protected final void ensureContextIsNotActive(final VirtualFrame frame, final ContextObject context, final int pc, final int sp) {
-        if (context.isPotentiallyActiveOnTruffleStack()) {
+    protected final void ensureContextReceiverIsNotActive(final VirtualFrame frame, final int pc, final int sp) {
+        if (modifiesContext && FrameAccess.getReceiver(frame) instanceof final ContextObject context && context.isPotentiallyActiveOnTruffleStack()) {
             // Fast-path optimization: Preemptively mark the Context as inactive.
             context.markAsInactiveOnTruffleStack();
-            if (context.isActuallyActiveOnTruffleStackSlow()) {
+            if (context.isActuallyActiveOnTruffleStack()) {
                 // The context was actually active. Throwing ProcessSwitch will unwind the
                 // Truffle stack and force all contexts to the heap.
                 CompilerDirectives.transferToInterpreter();

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterSistaV1Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterSistaV1Node.java
@@ -42,6 +42,7 @@ import de.hpi.swa.trufflesqueak.model.ContextObject;
 import de.hpi.swa.trufflesqueak.model.NativeObject;
 import de.hpi.swa.trufflesqueak.model.NilObject;
 import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.ASSOCIATION;
+import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.CONTEXT;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectAt0NodeGen;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectAtPut0Node;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectAtPut0NodeGen;
@@ -178,9 +179,10 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
     }
 
     @Override
-    protected void processBytecode(final int startPC, final int endPC) {
+    protected boolean processBytecode(final int startPC, final int endPC) {
         final byte[] bc = code.getBytes();
         final SqueakImageContext image = SqueakImageContext.getSlow();
+        boolean hasPotentialContextIVStore = false;
 
         int pc = startPC;
         assert pc < endPC;
@@ -286,6 +288,9 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                 }
                 case BC.POP_INTO_RCVR_VAR_0, BC.POP_INTO_RCVR_VAR_1, BC.POP_INTO_RCVR_VAR_2, BC.POP_INTO_RCVR_VAR_3, BC.POP_INTO_RCVR_VAR_4, BC.POP_INTO_RCVR_VAR_5, BC.POP_INTO_RCVR_VAR_6, BC.POP_INTO_RCVR_VAR_7: {
                     setData(currentPC, insert(SqueakObjectAtPut0NodeGen.create()));
+                    if (b - BC.POP_INTO_RCVR_VAR_0 < CONTEXT.INST_SIZE) {
+                        hasPotentialContextIVStore = true;
+                    }
                     break;
                 }
                 /* 2 byte bytecodes */
@@ -360,7 +365,16 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                     vstate.resetExtAB();
                     break;
                 }
-                case BC.EXT_STORE_AND_POP_RECEIVER_VARIABLE, BC.EXT_STORE_AND_POP_LITERAL_VARIABLE, BC.EXT_STORE_RECEIVER_VARIABLE, BC.EXT_STORE_LITERAL_VARIABLE: {
+                case BC.EXT_STORE_AND_POP_RECEIVER_VARIABLE, BC.EXT_STORE_RECEIVER_VARIABLE: {
+                    setData(currentPC, insert(SqueakObjectAtPut0NodeGen.create()));
+                    final int index = getByteExtended(bc, pc++, vstate.getExtA());
+                    if (index < CONTEXT.INST_SIZE) {
+                        hasPotentialContextIVStore = true;
+                    }
+                    vstate.resetExtAB();
+                    break;
+                }
+                case BC.EXT_STORE_AND_POP_LITERAL_VARIABLE, BC.EXT_STORE_LITERAL_VARIABLE: {
                     setData(currentPC, insert(SqueakObjectAtPut0NodeGen.create()));
                     pc++;
                     vstate.resetExtAB();
@@ -402,6 +416,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                 }
             }
         }
+        return hasPotentialContextIVStore;
     }
 
     @Override
@@ -423,6 +438,13 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
         final FrameWithoutBoxing frame = ACCESS.uncheckedCast(frame_, FrameWithoutBoxing.class);
         final byte[] bc = ACCESS.uncheckedCast(code.getBytes(), byte[].class);
         assert isBlock == FrameAccess.hasClosure(frame);
+
+        if (modifiesContext) {
+            final Object receiver = FrameAccess.getReceiver(frame);
+            if (receiver instanceof ContextObject context) {
+                ensureContextIsNotActive(frame, context, startPC, startSP);
+            }
+        }
 
         final LoopCounter loopCounter = CompilerDirectives.inCompiledCode() && CompilerDirectives.hasNextTier() ? new LoopCounter() : null;
         int pc = startPC;
@@ -1891,7 +1913,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
     @BytecodeInterpreterHandler(value = BC.POP_INTO_RCVR_VAR_1, safepoint = false)
     private int handlePopIntoReceiverVariable1(final VirtualFrame frame, final int pc, final VirtualState vstate, @SuppressWarnings("unused") final State state) {
         // assert CONTEXT.INSTRUCTION_POINTER == 1;
-        return doStoreIntoReceiverVariable(frame, pc, vstate, 1, pop(frame, --vstate.sp), pc + 1);
+        return handlePopIntoReceiverVariable(frame, pc, vstate, 1);
     }
 
     @EarlyInline
@@ -1937,10 +1959,9 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
     }
 
     @EarlyInline
-    private int doStoreIntoReceiverVariable(final VirtualFrame frame, final int pc, final VirtualState vstate, final int index, final Object value, final int nextPC) {
+    private int doStoreIntoReceiverVariable(final VirtualFrame frame, final int pc, final int index, final Object value, final int nextPC) {
         final Object receiver = FrameAccess.getReceiver(frame);
         ACCESS.uncheckedCast(getData(pc), SqueakObjectAtPut0Node.class).execute(this, receiver, index, value);
-        checkForAndHandlePCModification(frame, pc, vstate.sp, index, receiver, nextPC);
         return nextPC;
     }
 
@@ -2015,7 +2036,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
     @BytecodeInterpreterHandler(value = BC.EXT_STORE_AND_POP_RECEIVER_VARIABLE, safepoint = false)
     private int handleExtendedStoreAndPopReceiverVariable(final VirtualFrame frame, final int pc, final VirtualState vstate, final State state) {
         final int index = getByteExtendedWithExtA(pc, vstate, state);
-        return doStoreIntoReceiverVariable(frame, pc, vstate, index, pop(frame, --vstate.sp), pc + 2);
+        return doStoreIntoReceiverVariable(frame, pc, index, pop(frame, --vstate.sp), pc + 2);
     }
 
     @EarlyInline
@@ -2038,7 +2059,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
     @BytecodeInterpreterHandler(value = BC.EXT_STORE_RECEIVER_VARIABLE, safepoint = false)
     private int handleExtendedStoreReceiverVariable(final VirtualFrame frame, final int pc, final VirtualState vstate, final State state) {
         final int index = getByteExtendedWithExtA(pc, vstate, state);
-        return doStoreIntoReceiverVariable(frame, pc, vstate, index, top(frame, vstate.sp), pc + 2);
+        return doStoreIntoReceiverVariable(frame, pc, index, top(frame, vstate.sp), pc + 2);
     }
 
     @EarlyInline

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterSistaV1Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterSistaV1Node.java
@@ -439,12 +439,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
         final byte[] bc = ACCESS.uncheckedCast(code.getBytes(), byte[].class);
         assert isBlock == FrameAccess.hasClosure(frame);
 
-        if (modifiesContext) {
-            final Object receiver = FrameAccess.getReceiver(frame);
-            if (receiver instanceof ContextObject context) {
-                ensureContextIsNotActive(frame, context, startPC, startSP);
-            }
-        }
+        ensureContextReceiverIsNotActive(frame, startPC, startSP);
 
         final LoopCounter loopCounter = CompilerDirectives.inCompiledCode() && CompilerDirectives.hasNextTier() ? new LoopCounter() : null;
         int pc = startPC;

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterV3PlusClosuresNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterV3PlusClosuresNode.java
@@ -24,9 +24,11 @@ import de.hpi.swa.trufflesqueak.model.AbstractSqueakObjectWithClassAndHash;
 import de.hpi.swa.trufflesqueak.model.ArrayObject;
 import de.hpi.swa.trufflesqueak.model.BooleanObject;
 import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
+import de.hpi.swa.trufflesqueak.model.ContextObject;
 import de.hpi.swa.trufflesqueak.model.NativeObject;
 import de.hpi.swa.trufflesqueak.model.NilObject;
 import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.ASSOCIATION;
+import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.CONTEXT;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectAt0NodeGen;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectAtPut0Node;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectAtPut0NodeGen;
@@ -70,9 +72,10 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
     }
 
     @Override
-    protected void processBytecode(final int startPC, final int endPC) {
+    protected boolean processBytecode(final int startPC, final int endPC) {
         final byte[] bc = code.getBytes();
         final SqueakImageContext image = SqueakImageContext.getSlow();
+        boolean hasPotentialContextIVStore = false;
 
         int pc = startPC;
 
@@ -106,6 +109,9 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                 }
                 case BC.POP_INTO_RCVR_VAR_0, BC.POP_INTO_RCVR_VAR_1, BC.POP_INTO_RCVR_VAR_2, BC.POP_INTO_RCVR_VAR_3, BC.POP_INTO_RCVR_VAR_4, BC.POP_INTO_RCVR_VAR_5, BC.POP_INTO_RCVR_VAR_6, BC.POP_INTO_RCVR_VAR_7: {
                     setData(currentPC, insert(SqueakObjectAtPut0NodeGen.create()));
+                    if (b - BC.POP_INTO_RCVR_VAR_0 < CONTEXT.INST_SIZE) {
+                        hasPotentialContextIVStore = true;
+                    }
                     break;
                 }
                 case BC.EXTENDED_PUSH: {
@@ -114,6 +120,9 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                     switch (variableType(descriptor)) {
                         case 0: {
                             setData(currentPC, insert(SqueakObjectAt0NodeGen.create()));
+                            if (variableIndex < CONTEXT.INST_SIZE) {
+                                hasPotentialContextIVStore = true;
+                            }
                             break;
                         }
                         case 1, 2: {
@@ -132,8 +141,11 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                 case BC.EXTENDED_STORE, BC.EXTENDED_POP: {
                     final byte descriptor = getByte(bc, pc++);
                     switch (variableType(descriptor)) {
-                        case 0, 3: {
+                        case 0: {
                             setData(currentPC, insert(SqueakObjectAtPut0NodeGen.create()));
+                            if (variableIndex(descriptor) < CONTEXT.INST_SIZE) {
+                                hasPotentialContextIVStore = true;
+                            }
                             break;
                         }
                         case 1: {
@@ -141,6 +153,10 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                         }
                         case 2: {
                             throw unknownBytecode();
+                        }
+                        case 3: {
+                            setData(currentPC, insert(SqueakObjectAtPut0NodeGen.create()));
+                            break;
                         }
                     }
                     break;
@@ -175,7 +191,14 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                             setData(currentPC, getLiteralVariableOrCreateLiteralNode(code.getAndResolveLiteral(byte3)));
                             break;
                         }
-                        case 5, 6, 7: {
+                        case 5, 6: {
+                            setData(currentPC, insert(SqueakObjectAtPut0NodeGen.create()));
+                            if (byte3 < CONTEXT.INST_SIZE) {
+                                hasPotentialContextIVStore = true;
+                            }
+                            break;
+                        }
+                        case 7: {
                             setData(currentPC, insert(SqueakObjectAtPut0NodeGen.create()));
                             break;
                         }
@@ -300,6 +323,7 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                 }
             }
         }
+        return hasPotentialContextIVStore;
     }
 
     @Override
@@ -307,6 +331,13 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
     @ExplodeLoop(kind = ExplodeLoop.LoopExplosionKind.MERGE_EXPLODE)
     public Object execute(final VirtualFrame frame, final int startPC, final int startSP) {
         assert isBlock == FrameAccess.hasClosure(frame);
+
+        if (modifiesContext) {
+            final Object receiver = FrameAccess.getReceiver(frame);
+            if (receiver instanceof ContextObject context) {
+                ensureContextIsNotActive(frame, context, startPC, startSP);
+            }
+        }
 
         final SqueakImageContext image = getContext();
         final byte[] bc = ACCESS.uncheckedCast(code.getBytes(), byte[].class);
@@ -328,7 +359,6 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                 switch (HostCompilerDirectives.markThreadedSwitch(b)) {
                     case BC.PUSH_RCVR_VAR_0, BC.PUSH_RCVR_VAR_1, BC.PUSH_RCVR_VAR_2, BC.PUSH_RCVR_VAR_3, BC.PUSH_RCVR_VAR_4, BC.PUSH_RCVR_VAR_5, BC.PUSH_RCVR_VAR_6, BC.PUSH_RCVR_VAR_7, //
                         BC.PUSH_RCVR_VAR_8, BC.PUSH_RCVR_VAR_9, BC.PUSH_RCVR_VAR_A, BC.PUSH_RCVR_VAR_B, BC.PUSH_RCVR_VAR_C, BC.PUSH_RCVR_VAR_D, BC.PUSH_RCVR_VAR_E, BC.PUSH_RCVR_VAR_F: {
-                        FrameAccess.externalizePCAndSP(frame, pc, sp); // for ContextObject access
                         pushFollowed(frame, currentPC, sp++, ACCESS.uncheckedCast(getData(currentPC), SqueakObjectAt0NodeGen.class).execute(this, FrameAccess.getReceiver(frame), b & 0xF));
                         break;
                     }
@@ -351,12 +381,8 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                         push(frame, sp++, readLiteralVariable(currentPC, b & 0x1F));
                         break;
                     }
-                    case BC.POP_INTO_RCVR_VAR_0, BC.POP_INTO_RCVR_VAR_2, BC.POP_INTO_RCVR_VAR_3, BC.POP_INTO_RCVR_VAR_4, BC.POP_INTO_RCVR_VAR_5, BC.POP_INTO_RCVR_VAR_6, BC.POP_INTO_RCVR_VAR_7: {
+                    case BC.POP_INTO_RCVR_VAR_0, BC.POP_INTO_RCVR_VAR_1, BC.POP_INTO_RCVR_VAR_2, BC.POP_INTO_RCVR_VAR_3, BC.POP_INTO_RCVR_VAR_4, BC.POP_INTO_RCVR_VAR_5, BC.POP_INTO_RCVR_VAR_6, BC.POP_INTO_RCVR_VAR_7: {
                         ACCESS.uncheckedCast(getData(currentPC), SqueakObjectAtPut0Node.class).execute(this, FrameAccess.getReceiver(frame), b & 7, pop(frame, --sp));
-                        break;
-                    }
-                    case BC.POP_INTO_RCVR_VAR_1: {
-                        doStoreIntoReceiverVariable(frame, currentPC, pc, sp, 1, pop(frame, --sp));
                         break;
                     }
                     case BC.POP_INTO_TEMP_VAR_0, BC.POP_INTO_TEMP_VAR_1, BC.POP_INTO_TEMP_VAR_2, BC.POP_INTO_TEMP_VAR_3, BC.POP_INTO_TEMP_VAR_4, BC.POP_INTO_TEMP_VAR_5, BC.POP_INTO_TEMP_VAR_6, BC.POP_INTO_TEMP_VAR_7: {
@@ -438,8 +464,6 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                         CompilerAsserts.partialEvaluationConstant(variableType);
                         switch (variableType) {
                             case 0: {
-                                // for ContextObject access
-                                FrameAccess.externalizePCAndSP(frame, pc, sp);
                                 pushFollowed(frame, currentPC, sp++,
                                                 ACCESS.uncheckedCast(getData(currentPC), SqueakObjectAt0NodeGen.class).execute(this, FrameAccess.getReceiver(frame), variableIndex));
                                 break;
@@ -470,7 +494,7 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                         CompilerAsserts.partialEvaluationConstant(variableType);
                         switch (variableType) {
                             case 0: {
-                                doStoreIntoReceiverVariable(frame, currentPC, pc, sp, variableIndex, stackTop);
+                                doStoreIntoReceiverVariable(frame, currentPC, variableIndex, stackTop);
                                 break;
                             }
                             case 1: {
@@ -495,7 +519,7 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                         CompilerAsserts.partialEvaluationConstant(variableType);
                         switch (variableType) {
                             case 0: {
-                                doStoreIntoReceiverVariable(frame, currentPC, pc, sp, variableIndex, stackValue);
+                                doStoreIntoReceiverVariable(frame, currentPC, variableIndex, stackValue);
                                 break;
                             }
                             case 1: {
@@ -546,8 +570,6 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                                 break;
                             }
                             case 2: {
-                                // for ContextObject access
-                                FrameAccess.externalizePCAndSP(frame, pc, sp);
                                 pushFollowed(frame, currentPC, sp++, ACCESS.uncheckedCast(getData(currentPC), SqueakObjectAt0NodeGen.class).execute(this, FrameAccess.getReceiver(frame), byte3));
                                 break;
                             }
@@ -560,11 +582,11 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                                 break;
                             }
                             case 5: {
-                                doStoreIntoReceiverVariable(frame, currentPC, pc, sp, byte3, top(frame, sp));
+                                doStoreIntoReceiverVariable(frame, currentPC, byte3, top(frame, sp));
                                 break;
                             }
                             case 6: {
-                                doStoreIntoReceiverVariable(frame, currentPC, pc, sp, byte3, pop(frame, --sp));
+                                doStoreIntoReceiverVariable(frame, currentPC, byte3, pop(frame, --sp));
                                 break;
                             }
                             case 7: {
@@ -1017,10 +1039,9 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
     }
 
     @EarlyInline
-    private void doStoreIntoReceiverVariable(final VirtualFrame frame, final int pc, final int nextPC, final int sp, final int index, final Object value) {
+    private void doStoreIntoReceiverVariable(final VirtualFrame frame, final int pc, final int index, final Object value) {
         final Object receiver = FrameAccess.getReceiver(frame);
         ACCESS.uncheckedCast(getData(pc), SqueakObjectAtPut0Node.class).execute(this, receiver, index, value);
-        checkForAndHandlePCModification(frame, pc, sp, index, receiver, nextPC);
     }
 
     static int longJump(final int b, final int nextByte) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterV3PlusClosuresNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterV3PlusClosuresNode.java
@@ -24,7 +24,6 @@ import de.hpi.swa.trufflesqueak.model.AbstractSqueakObjectWithClassAndHash;
 import de.hpi.swa.trufflesqueak.model.ArrayObject;
 import de.hpi.swa.trufflesqueak.model.BooleanObject;
 import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
-import de.hpi.swa.trufflesqueak.model.ContextObject;
 import de.hpi.swa.trufflesqueak.model.NativeObject;
 import de.hpi.swa.trufflesqueak.model.NilObject;
 import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.ASSOCIATION;
@@ -120,9 +119,6 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                     switch (variableType(descriptor)) {
                         case 0: {
                             setData(currentPC, insert(SqueakObjectAt0NodeGen.create()));
-                            if (variableIndex < CONTEXT.INST_SIZE) {
-                                hasPotentialContextIVStore = true;
-                            }
                             break;
                         }
                         case 1, 2: {
@@ -332,12 +328,7 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
     public Object execute(final VirtualFrame frame, final int startPC, final int startSP) {
         assert isBlock == FrameAccess.hasClosure(frame);
 
-        if (modifiesContext) {
-            final Object receiver = FrameAccess.getReceiver(frame);
-            if (receiver instanceof ContextObject context) {
-                ensureContextIsNotActive(frame, context, startPC, startSP);
-            }
-        }
+        ensureContextReceiverIsNotActive(frame, startPC, startSP);
 
         final SqueakImageContext image = getContext();
         final byte[] bc = ACCESS.uncheckedCast(code.getBytes(), byte[].class);


### PR DESCRIPTION
This PR is the first step towards addressing issue #163. It updates the interpreter to ensure that any modification to a `Context`'s instance variables strictly occurs on the heap. By moving the context safety checks out of individual variable store nodes and into a centralized execution boundary, the VM preemptively protects active execution states without incurring per-store overhead.

### **Key Changes**

* **Static Context Store Detection:** The `processBytecode` method now analyzes bytecodes to detect potential stores to context instance variables (targeting indices smaller than `CONTEXT.INST_SIZE`). This sets a new `modifiesContext` flag on `AbstractInterpreterNode`.
* **Context Class Validation:** A new `couldMutateContextVariables` method confirms whether the executing method belongs to the `Context` class hierarchy.
* **Preemptive Heap Flushing:** When an interpreter node begins execution, if `modifiesContext` is true and the receiver is a `ContextObject`, the VM explicitly triggers `ensureContextIsNotActive` to ensure the receiver is on the heap.
* **Code Cleanup:** Redundant `checkForAndHandlePCModification` and `FrameAccess.externalizePCAndSP` calls have been removed from individual store bytecodes.
* **Casting Fixes:** Minor adjustments were made to `getMethodClassAssociation` and its callers to remove overly strict `AbstractPointersObject` casts.