### PR TITLE
Introduce ContextProxy

### DIFF
--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
@@ -428,8 +428,8 @@ public final class SqueakImageContext {
         final CompiledCodeObject doItMethod = (CompiledCodeObject) methodNode.send(this, "generate");
 
         final ContextObject doItContext = new ContextObject(doItMethod.getSqueakContextSize());
-        doItContext.setReceiver(NilObject.SINGLETON);
         doItContext.setCodeObject(doItMethod);
+        doItContext.setReceiver(NilObject.SINGLETON);
         doItContext.setInstructionPointer(0);
         doItContext.setStackPointer(doItMethod.getNumTemps());
         doItContext.setSenderUnsafe(NilObject.SINGLETON);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
@@ -428,6 +428,8 @@ public final class SqueakImageContext {
         final CompiledCodeObject doItMethod = (CompiledCodeObject) methodNode.send(this, "generate");
 
         final ContextObject doItContext = new ContextObject(doItMethod.getSqueakContextSize());
+        // Code object must be set before any other field in a new Context to ensure the Truffle frame
+        // descriptor and initial frame state are allocated.
         doItContext.setCodeObject(doItMethod);
         doItContext.setReceiver(NilObject.SINGLETON);
         doItContext.setInstructionPointer(0);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
@@ -8,6 +8,7 @@ package de.hpi.swa.trufflesqueak.model;
 
 import java.util.Arrays;
 
+import de.hpi.swa.trufflesqueak.util.ArrayUtils;
 import org.graalvm.collections.UnmodifiableEconomicMap;
 
 import com.oracle.truffle.api.CallTarget;
@@ -46,31 +47,79 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
         SCRUB
     }
 
-    private Object senderOrFrameOrSize;
+    private static final class ContextProxy {
+        private Object sender;
+        private Object instructionPointer;
+        private Object stackPointer;
+        private Object method;
+        private Object closureOrNil;
+        private Object receiver;
+        private Object stackOrSize;
+
+        private ContextProxy(final int size) {
+            stackOrSize = size;
+        }
+
+        private int getSize() {
+            if (stackOrSize instanceof Integer size) {
+                return size;
+            } else {
+                return ((Object[]) stackOrSize).length;
+            }
+        }
+
+        private Object[] getOrCreateStack() {
+            if (stackOrSize instanceof Integer size) {
+                final Object[] stack = ArrayUtils.withAll(size, NilObject.SINGLETON);
+                stackOrSize = stack;
+                return stack;
+            }
+            return (Object[]) stackOrSize;
+        }
+    }
+
+    /**
+     * To maximize GraalVM performance, this field acts as a union type transitioning between four
+     * distinct states:
+     * <p>
+     * 1. {@link AbstractSqueakObject} (Sender): The lightweight wrapper state. When a context is
+     *    actively executing in a {@link VirtualFrame}, we avoid allocating a MaterializedFrame.
+     *    Instead, we simply store its sender here until materialization is forced.
+     * <p>
+     * 2. {@link MaterializedFrame}: The fast-path execution state. Used for valid, suspended
+     *    contexts on the heap. This allows GraalVM to execute and resume them.
+     * <p>
+     * 3. {@link ContextProxy}: The slow-path fallback state. Used for newly allocated empty
+     *    contexts or contexts that have been reflectively mutated with incompatible values,
+     *    making them invalid Truffle frames.
+     * <p>
+     * 4. {@link SqueakImageChunk}: A transient bootstrap state used exclusively during image load.
+     */
+    private Object senderOrFrameOrProxy;
 
     public ContextObject(final SqueakImageChunk chunk) {
         super(chunk);
-        senderOrFrameOrSize = chunk;
+        senderOrFrameOrProxy = chunk;
     }
 
     public ContextObject(final int size) {
         super();
-        senderOrFrameOrSize = size;
+        senderOrFrameOrProxy = new ContextProxy(size);
         assert size == CONTEXT.SMALL_FRAMESIZE || size == CONTEXT.LARGE_FRAMESIZE || size == CONTEXT.HUGE_FRAMESIZE;
     }
 
     public ContextObject(final VirtualFrame frame) {
         super();
         FrameAccess.assertSenderNotNull(frame);
-        this.senderOrFrameOrSize = FrameAccess.getSender(frame);
+        senderOrFrameOrProxy = FrameAccess.getSender(frame);
         FrameAccess.setContext(frame, this);
     }
 
     public ContextObject(final MaterializedFrame frame) {
         super();
         FrameAccess.assertSenderNotNull(frame);
-        this.senderOrFrameOrSize = frame;
-        this.setMarkedCodeFlags();
+        senderOrFrameOrProxy = frame;
+        setMarkedCodeFlags();
         FrameAccess.setContext(frame, this);
     }
 
@@ -81,60 +130,54 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
         setAllBooleanBits(original.getAllBooleanBits());
         // Create shallow copy of Truffle frame
         final FrameDescriptor frameDescriptor = FrameAccess.getCodeObject(original.getTruffleFrame()).getFrameDescriptor();
-        senderOrFrameOrSize = Truffle.getRuntime().createMaterializedFrame(original.getTruffleFrame().getArguments().clone(), frameDescriptor);
+        senderOrFrameOrProxy = Truffle.getRuntime().createMaterializedFrame(original.getTruffleFrame().getArguments().clone(), frameDescriptor);
         FrameAccess.copyAllSlots(original.getTruffleFrame(), getTruffleFrame());
     }
 
     @Override
     public void fillin(final SqueakImageChunk chunk) {
         assert chunk.getWordSize() > CONTEXT.TEMP_FRAME_START;
-        final CompiledCodeObject code = (CompiledCodeObject) chunk.getPointer(CONTEXT.METHOD);
-        final AbstractSqueakObject sender = (AbstractSqueakObject) chunk.getPointer(CONTEXT.SENDER_OR_NIL);
-        assert sender != null : "sender should not be null";
-        final Object closureOrNil = chunk.getPointer(CONTEXT.CLOSURE_OR_NIL);
-        final BlockClosureObject closure;
-        final int numArgs;
-        final CompiledCodeObject methodOrBlock;
-        if (closureOrNil == NilObject.SINGLETON) {
-            closure = null;
-            methodOrBlock = code;
-            numArgs = code.getNumArgs();
-        } else {
-            closure = (BlockClosureObject) closureOrNil;
-            numArgs = closure.getNumArgs() + closure.getNumCopied();
-            if (code.isCompiledMethod()) {
+        fillinAsProxy(chunk);
+
+        // During image load, the closure shell must be explicitly filled in
+        // before materialization so we can access its CompiledBlock.
+        final ContextProxy proxy = getProxy();
+        if (proxy.closureOrNil instanceof BlockClosureObject closure) {
+            if (proxy.method instanceof CompiledCodeObject code && code.isCompiledMethod()) {
                 closure.fillin(chunk.getChunk(CONTEXT.CLOSURE_OR_NIL));
-                methodOrBlock = closure.getCompiledBlock();
-            } else {
-                assert closure.isAFullBlockClosure();
-                methodOrBlock = code;
             }
         }
-        final int endArguments = CONTEXT.TEMP_FRAME_START + numArgs;
-        final Object[] arguments = chunk.getPointers(CONTEXT.RECEIVER, endArguments);
-        final Object[] frameArguments = FrameAccess.newWith(sender, closure, arguments);
+
+        // ToDo: A Context that was a proxy because its stack pointer was not an integer,
+        // but was legal in all other ways, will lose the stack pointer value here.
+        materializeFromProxy(true);
+    }
+
+    private void fillinAsProxy(final SqueakImageChunk chunk) {
+        final int stackSize = chunk.getWordSize() - CONTEXT.TEMP_FRAME_START;
+        final ContextProxy proxy = new ContextProxy(stackSize);
+
+        // Read the exact object pointers directly from the chunk without casting
+        proxy.sender = chunk.getPointer(CONTEXT.SENDER_OR_NIL);
+        proxy.instructionPointer = chunk.getPointer(CONTEXT.INSTRUCTION_POINTER);
+        proxy.stackPointer = chunk.getPointer(CONTEXT.STACKPOINTER);
+        proxy.method = chunk.getPointer(CONTEXT.METHOD);
+        proxy.closureOrNil = chunk.getPointer(CONTEXT.CLOSURE_OR_NIL);
+        proxy.receiver = chunk.getPointer(CONTEXT.RECEIVER);
+
+        // Map every variable-length stack slot from the chunk into the proxy array
+        final Object[] stack = proxy.getOrCreateStack();
+        for (int i = 0; i < stackSize; i++) {
+            stack[i] = chunk.getPointer(CONTEXT.TEMP_FRAME_START + i);
+        }
+
         CompilerDirectives.transferToInterpreterAndInvalidate();
-        assert senderOrFrameOrSize == chunk;
-        senderOrFrameOrSize = Truffle.getRuntime().createMaterializedFrame(frameArguments, methodOrBlock.getFrameDescriptor());
-        setMarkedCodeFlags();
-        FrameAccess.setContext(getTruffleFrame(), this);
-        final Object pc = chunk.getPointer(CONTEXT.INSTRUCTION_POINTER);
-        if (pc == NilObject.SINGLETON) {
-            removeInstructionPointer();
-        } else {
-            setInstructionPointer(MiscUtils.toIntExact((long) pc) - methodOrBlock.getInitialPC());
-        }
-        // OSVM interprets non-integers as zero: see Interpreter>>fetchStackPointerOf:
-        final Object sp = chunk.getPointer(CONTEXT.STACKPOINTER);
-        final int stackPointer = sp instanceof Long spLong ? MiscUtils.toIntExact(spLong) : 0;
-        setStackPointer(stackPointer);
-        for (int i = 0; i < stackPointer; i++) {
-            atTempPut(i, chunk.getPointer(CONTEXT.TEMP_FRAME_START + i));
-        }
+        assert senderOrFrameOrProxy == chunk;
+        senderOrFrameOrProxy = proxy;
     }
 
     public CompiledCodeObject getMethodFromChunk() {
-        if (senderOrFrameOrSize instanceof final SqueakImageChunk chunk) {
+        if (senderOrFrameOrProxy instanceof final SqueakImageChunk chunk) {
             return (CompiledCodeObject) chunk.getPointer(CONTEXT.METHOD);
         } else {
             return getCodeObject();
@@ -171,7 +214,16 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
 
     private MaterializedFrame getOrCreateTruffleFrame() {
         if (!hasTruffleFrame()) {
-            senderOrFrameOrSize = createTruffleFrame(this);
+            if (hasContextProxy()) {
+                if (materializeFromProxy(true)) {
+                    return getTruffleFrame();
+                } else {
+                    CompilerDirectives.transferToInterpreter();
+                    throw SqueakException.create("Cannot materialize a structurally invalid ContextProxy!");
+                }
+            }
+            // Fallback for the lightweight sender state.
+            senderOrFrameOrProxy = createTruffleFrame(this);
             setMarkedCodeFlags();
         }
         return getTruffleFrame();
@@ -192,13 +244,32 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
     public AbstractSqueakObject getFrameSender() {
         if (hasTruffleFrame()) {
             return FrameAccess.getSender(getTruffleFrame());
+        } else if (senderOrFrameOrProxy instanceof AbstractSqueakObject o) {
+            return o;
         } else {
-            return (AbstractSqueakObject) senderOrFrameOrSize;
+            return getFrameSenderFallback();
         }
     }
 
+    @TruffleBoundary
+    private AbstractSqueakObject getFrameSenderFallback() {
+        if (hasContextProxy()) {
+            final Object proxySender = getProxy().sender;
+            return proxySender instanceof AbstractSqueakObject o ? o : NilObject.SINGLETON;
+        }
+        return (AbstractSqueakObject) senderOrFrameOrProxy;
+    }
+
     public AbstractSqueakObject getSender() {
-        final AbstractSqueakObject sender = getFrameSender();
+        final AbstractSqueakObject sender;
+        if (hasTruffleFrame()) {
+            sender = FrameAccess.getSender(getTruffleFrame());
+        } else if (senderOrFrameOrProxy instanceof ContextProxy proxy) {
+            sender = (AbstractSqueakObject) NilObject.nullToNil(proxy.sender);
+        } else {
+            sender = (AbstractSqueakObject) senderOrFrameOrProxy;
+        }
+
         if (sender instanceof final ContextObject senderContext && !senderContext.hasTruffleFrame()) {
             senderContext.materializeFromFrames();
         }
@@ -207,7 +278,7 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
 
     @TruffleBoundary
     public void materializeFromFrames() {
-        senderOrFrameOrSize = FrameAccess.findFrameForContext(this);
+        senderOrFrameOrProxy = FrameAccess.findFrameForContext(this);
         setMarkedCodeFlags();
         getCodeObject().getDoesNotNeedThisContextAssumption().invalidate();
     }
@@ -343,7 +414,14 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
     }
 
     public int getStackPointerOrZero() {
-        return hasTruffleFrame() ? FrameAccess.getStackPointer(getTruffleFrame()) : 0;
+        if (hasTruffleFrame()) {
+            return FrameAccess.getStackPointer(getTruffleFrame());
+        } else if (hasContextProxy()) {
+            final Object sp = getProxyStackPointer();
+            return sp instanceof Long l ? MiscUtils.toIntExact(l) : 0;
+        } else {
+            return 0;
+        }
     }
 
     public int getStackPointer() {
@@ -369,7 +447,7 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
     }
 
     public void setCodeObject(final CompiledCodeObject value) {
-        senderOrFrameOrSize = createTruffleFrame(value);
+        senderOrFrameOrProxy = createTruffleFrame(value);
         setMarkedCodeFlags();
     }
 
@@ -448,7 +526,7 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
         final FrameDescriptor frameDescriptor = value.getCompiledBlock().getFrameDescriptor();
         // Create and initialize new frame
         final MaterializedFrame frame = Truffle.getRuntime().createMaterializedFrame(arguments, frameDescriptor);
-        senderOrFrameOrSize = frame;
+        senderOrFrameOrProxy = frame;
         setMarkedCodeFlags();
         FrameAccess.assertSenderNotNull(frame);
         FrameAccess.assertReceiverNotNull(frame);
@@ -574,7 +652,7 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
 
     @Override
     public int getNumSlots() {
-        return CONTEXT.INST_SIZE + getCodeObject().getSqueakContextSize();
+        return CONTEXT.INST_SIZE + size();
     }
 
     @Override
@@ -584,23 +662,38 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
 
     @Override
     public int size() {
-        if (senderOrFrameOrSize instanceof final Integer size) {
-            return size;
+        if (senderOrFrameOrProxy instanceof final ContextProxy proxy) {
+            return proxy.getSize();
         } else {
             return getCodeObject().getSqueakContextSize();
         }
     }
 
+    public boolean isValidStackPointer(final long sp) {
+        if (hasTruffleFrame()) {
+            return sp >= 0 && sp <= FrameAccess.getNumStackSlots(getTruffleFrame());
+        }
+        // If it is a proxy, physical size limits apply.
+        return sp >= 0 && sp <= size();
+    }
+
+    public boolean isValidTempIndex(final int tempIndex) {
+        if (hasTruffleFrame()) {
+            return tempIndex >= 0 && tempIndex < FrameAccess.getNumStackSlots(getTruffleFrame());
+        }
+        return tempIndex >= 0 && tempIndex < size();
+    }
+
     public void become(final ContextObject other) {
-        final Object otherSenderOrFrame = other.senderOrFrameOrSize;
+        final Object otherSenderOrFrame = other.senderOrFrameOrProxy;
         final int otherBooleans = other.getAllBooleanBits();
-        other.setFields(senderOrFrameOrSize, getAllBooleanBits());
+        other.setFields(senderOrFrameOrProxy, getAllBooleanBits());
         setFields(otherSenderOrFrame, otherBooleans);
     }
 
     private void setFields(final Object otherSenderOrFrame, final int otherBooleanBits) {
         CompilerDirectives.transferToInterpreterAndInvalidate();
-        senderOrFrameOrSize = otherSenderOrFrame;
+        senderOrFrameOrProxy = otherSenderOrFrame;
         setAllBooleanBits(otherBooleanBits);
     }
 
@@ -626,16 +719,221 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
      * {@link CompilerDirectives#castExact(Object, Class)}.
      */
     public MaterializedFrame getTruffleFrame() {
-        return (MaterializedFrame) CompilerDirectives.castExact(senderOrFrameOrSize, CONCRETE_MATERIALIZED_FRAME_CLASS);
+        return (MaterializedFrame) CompilerDirectives.castExact(senderOrFrameOrProxy, CONCRETE_MATERIALIZED_FRAME_CLASS);
     }
 
     public boolean hasTruffleFrame() {
-        return senderOrFrameOrSize instanceof MaterializedFrame;
+        return senderOrFrameOrProxy instanceof MaterializedFrame;
     }
 
     public void setTruffleFrame(final MaterializedFrame frame) {
         assert !hasTruffleFrame();
-        senderOrFrameOrSize = frame;
+        senderOrFrameOrProxy = frame;
+    }
+
+    /**
+     *  Proxy Accessing.
+     */
+
+    public boolean hasContextProxy() {
+        return senderOrFrameOrProxy instanceof ContextProxy;
+    }
+
+    private ContextProxy getProxy() {
+        assert hasContextProxy();
+        return (ContextProxy) senderOrFrameOrProxy;
+    }
+
+    @TruffleBoundary
+    private boolean materializeFromProxy(final boolean forced) {
+        final ContextProxy proxy = (ContextProxy) senderOrFrameOrProxy;
+        if (!(proxy.method instanceof CompiledCodeObject code)) {
+            return false; // Cannot materialize without a structurally valid method
+        }
+
+        final Object closureOrNil = NilObject.nullToNil(proxy.closureOrNil);
+        if (closureOrNil != NilObject.SINGLETON && !(closureOrNil instanceof BlockClosureObject)) {
+            return false; // Structurally invalid closure
+        }
+
+        final Object pc = NilObject.nullToNil(proxy.instructionPointer);
+        if (pc != NilObject.SINGLETON && !(pc instanceof Long)) {
+            return false; // Structurally invalid instruction pointer
+        }
+
+        final Object sender = NilObject.nullToNil(proxy.sender);
+        if (!(sender instanceof AbstractSqueakObject)) {
+            return false; // Structurally invalid sender (e.g., primitive Long)
+        }
+
+        // Resolve method and closure
+        final BlockClosureObject closure;
+        final int numArgs;
+        final CompiledCodeObject methodOrBlock;
+
+        if (closureOrNil == NilObject.SINGLETON) {
+            closure = null;
+            methodOrBlock = code;
+            numArgs = code.getNumArgs();
+        } else {
+            closure = (BlockClosureObject) closureOrNil;
+            numArgs = closure.getNumArgs() + closure.getNumCopied();
+            methodOrBlock = closure.isAFullBlockClosure() ? code : closure.getCompiledBlock();
+        }
+
+        final Object receiver = NilObject.nullToNil(proxy.receiver);
+
+        // Gather receiver and arguments for FrameAccess
+        final Object[] proxyStack = proxy.getOrCreateStack();
+        final Object[] receiverAndArgs = new Object[1 + numArgs];
+        receiverAndArgs[0] = receiver;
+        for (int i = 0; i < numArgs; i++) {
+            final Object stackVal = i < proxyStack.length ? proxyStack[i] : null;
+            receiverAndArgs[1 + i] = NilObject.nullToNil(stackVal);
+        }
+
+        // Allocate the Truffle Frame first to query its physical bounds
+        final Object[] frameArguments = FrameAccess.newWith((AbstractSqueakObject) sender, closure, receiverAndArgs);
+        final MaterializedFrame frame = Truffle.getRuntime().createMaterializedFrame(frameArguments, methodOrBlock.getFrameDescriptor());
+
+        // Now evaluate the true physical SP bounds against the allocated frame
+        final int numStackSlots = FrameAccess.getNumStackSlots(frame);
+        final int sp;
+
+        if (proxy.stackPointer instanceof Long l) {
+            final int requestedSp = MiscUtils.toIntExact(l);
+            if (requestedSp < 0 || requestedSp > numStackSlots) {
+                // Refuse to materialize if SP out of bounds. If forced,
+                // this naturally falls through to getOrCreateTruffleFrame()
+                // which will throw the fatal SqueakException upon resumption.
+                // ToDo: Alternatively, we could force SP to zero when forced
+                return false;
+            } else {
+                sp = requestedSp;
+            }
+        } else if (forced) {
+            sp = 0; // OSVM interprets non-integers as zero for execution/loading
+        } else {
+            return false; // Stay a proxy
+        }
+
+        senderOrFrameOrProxy = frame;
+        setMarkedCodeFlags();
+        FrameAccess.setContext(frame, this);
+
+        // Restore pointers
+        if (pc == NilObject.SINGLETON) {
+            removeInstructionPointer();
+        } else if (pc instanceof Long l) {
+            setInstructionPointer(MiscUtils.toIntExact(l) - methodOrBlock.getInitialPC());
+        }
+
+        setStackPointer(sp);
+
+        // Restore stack temps and arguments
+        for (int i = 0; i < sp; i++) {
+            final Object stackVal = i < proxyStack.length ? proxyStack[i] : null;
+            atTempPut(i, NilObject.nullToNil(stackVal));
+        }
+        return true;
+    }
+
+    /**
+     * Gracefully degrades a MaterializedFrame into a ContextProxy.
+     * This is triggered when Squeak reflection attempts to write structurally
+     * invalid types (e.g., Strings instead of CompiledCodeObjects) into critical slots.
+     */
+    public void dematerializeToProxy() {
+        assert hasTruffleFrame();
+
+        // ToDo: Ensure primitives only operate on heap-based Contexts.
+        if (isPotentiallyActiveOnTruffleStack() && isActuallyActiveOnTruffleStackSlow()) {
+            CompilerDirectives.transferToInterpreter();
+            throw SqueakException.create("Fatal: Cannot structurally degrade a Context that is currently active on the Truffle execution stack.");
+        }
+
+        // Extract all state from the Truffle frame using the existing slow-path getters
+        final ContextProxy proxy = new ContextProxy(getCodeObject().getSqueakContextSize());
+        proxy.sender = getSender();
+        proxy.instructionPointer = getInstructionPointer(InlinedConditionProfile.getUncached(), null);
+        proxy.stackPointer = (long) getStackPointer();
+        proxy.method = getCodeObject();
+        proxy.closureOrNil = getClosure();
+        proxy.receiver = getReceiver();
+
+        // Populate the proxy's array with the Truffle frame's stack
+        final Object[] stack = proxy.getOrCreateStack();
+        for (int i = 0; i < stack.length; i++) {
+            stack[i] = atTemp(i);
+        }
+
+        // Sever the connection to the Truffle frame
+        senderOrFrameOrProxy = proxy;
+    }
+
+    public Object getProxySender() {
+        return NilObject.nullToNil(getProxy().sender);
+    }
+
+    public Object getProxyInstructionPointer() {
+        return NilObject.nullToNil(getProxy().instructionPointer);
+    }
+
+    public Object getProxyStackPointer() {
+        return NilObject.nullToNil(getProxy().stackPointer);
+    }
+
+    public Object getProxyMethod() {
+        return NilObject.nullToNil(getProxy().method);
+    }
+
+    public Object getProxyClosureOrNil() {
+        return NilObject.nullToNil(getProxy().closureOrNil);
+    }
+
+    public Object getProxyReceiver() {
+        return NilObject.nullToNil(getProxy().receiver);
+    }
+
+    public Object getProxyTemp(final int index) {
+        final Object[] stack = getProxy().getOrCreateStack();
+        return index >= 0 && index < stack.length ? NilObject.nullToNil(stack[index]) : NilObject.SINGLETON;
+    }
+
+    public void setProxySender(final Object value) {
+        getProxy().sender = value;
+        materializeFromProxy(false);
+    }
+
+    public void setProxyInstructionPointer(final Object value) {
+        getProxy().instructionPointer = value;
+        materializeFromProxy(false);
+    }
+
+    public void setProxyStackPointer(final Object value) {
+        getProxy().stackPointer = value;
+        materializeFromProxy(false);
+    }
+
+    public void setProxyMethod(final Object value) {
+        getProxy().method = value;
+        materializeFromProxy(false);
+    }
+
+    public void setProxyClosureOrNil(final Object value) {
+        getProxy().closureOrNil = value;
+        materializeFromProxy(false);
+    }
+
+    public void setProxyReceiver(final Object value) {
+        getProxy().receiver = value;
+    }
+
+    public void setProxyTemp(final int index, final Object value) {
+        final Object[] stack = getProxy().getOrCreateStack();
+        if (index >= 0 && index < stack.length) {
+            stack[index] = value;
+        }
     }
 
     @TruffleBoundary
@@ -653,6 +951,24 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
                     return true;
                 }
             }
+        } else if (hasContextProxy()) {
+            final ContextProxy proxy = getProxy();
+            if (proxy.sender == thang || thang.equals(proxy.instructionPointer) || thang.equals(proxy.stackPointer) || proxy.method == thang ||
+                            proxy.closureOrNil == thang ||
+                            proxy.receiver == thang) {
+                return true;
+            }
+            if (proxy.stackOrSize instanceof Object[] stack) {
+                final int sp = getStackPointerOrZero();
+                final int limit = Math.min(sp, stack.length);
+                for (int i = 0; i < limit; i++) {
+                    if (stack[i] == thang) {
+                        return true;
+                    }
+                }
+            }
+        } else if (senderOrFrameOrProxy == thang) {
+            return true; // Lightweight sender state
         }
         return false;
     }
@@ -690,6 +1006,61 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
                     return null;
                 }
             });
+        } else if (hasContextProxy()) {
+            final ContextProxy proxy = getProxy();
+            if (proxy.sender != null) {
+                final Object migrated = fromToMap.get(proxy.sender);
+                if (migrated != null) {
+                    proxy.sender = migrated;
+                }
+            }
+            if (proxy.instructionPointer != null) {
+                final Object migrated = fromToMap.get(proxy.instructionPointer);
+                if (migrated != null) {
+                    proxy.instructionPointer = migrated;
+                }
+            }
+            if (proxy.stackPointer != null) {
+                final Object migrated = fromToMap.get(proxy.stackPointer);
+                if (migrated != null) {
+                    proxy.stackPointer = migrated;
+                }
+            }
+            if (proxy.method != null) {
+                final Object migrated = fromToMap.get(proxy.method);
+                if (migrated != null) {
+                    proxy.method = migrated;
+                }
+            }
+            if (proxy.closureOrNil != null) {
+                final Object migrated = fromToMap.get(proxy.closureOrNil);
+                if (migrated != null) {
+                    proxy.closureOrNil = migrated;
+                }
+            }
+            if (proxy.receiver != null) {
+                final Object migrated = fromToMap.get(proxy.receiver);
+                if (migrated != null) {
+                    proxy.receiver = migrated;
+                }
+            }
+            if (proxy.stackOrSize instanceof Object[] stack) {
+                for (int i = 0; i < stack.length; i++) {
+                    final Object stackVal = stack[i];
+                    if (stackVal != null) {
+                        final Object migrated = fromToMap.get(stackVal);
+                        if (migrated != null) {
+                            stack[i] = migrated;
+                        }
+                    }
+                }
+            }
+        } else if (senderOrFrameOrProxy != null) {
+            // Migrate the lightweight sender state
+            final Object migrated = fromToMap.get(senderOrFrameOrProxy);
+            if (migrated != null) {
+                senderOrFrameOrProxy = migrated;
+            }
         }
     }
 
@@ -701,8 +1072,21 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
             tracer.addIfUnmarked(FrameAccess.getCodeObject(frame));
             tracer.addAllIfUnmarked(frame.getArguments());
             FrameAccess.iterateStackObjects(frame, tracer.frameHandling, tracer::addIfUnmarked);
+        } else if (hasContextProxy()) {
+            final ContextProxy proxy = getProxy();
+            tracer.addIfUnmarked(proxy.sender);
+            tracer.addIfUnmarked(proxy.instructionPointer);
+            tracer.addIfUnmarked(proxy.method);
+            tracer.addIfUnmarked(proxy.closureOrNil);
+            tracer.addIfUnmarked(proxy.receiver);
+            if (proxy.stackOrSize instanceof Object[] stack) {
+                final int sp = Math.min(getStackPointerOrZero(), stack.length);
+                for (int i = 0; i < sp; i++) {
+                    tracer.addIfUnmarked(stack[i]);
+                }
+            }
         } else {
-            tracer.addIfUnmarked(senderOrFrameOrSize);
+            tracer.addIfUnmarked(senderOrFrameOrProxy);
         }
     }
 
@@ -715,7 +1099,20 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
             writer.traceIfNecessary(FrameAccess.getCodeObject(frame));
             writer.traceAllIfNecessary(frame.getArguments());
             FrameAccess.iterateStackObjects(frame, FrameHandling.SCRUB, writer::traceIfNecessary);
-        } else if (senderOrFrameOrSize instanceof AbstractSqueakObject o) {
+        } else if (hasContextProxy()) {
+            final ContextProxy proxy = (ContextProxy) senderOrFrameOrProxy;
+            writer.traceIfNecessary(proxy.sender);
+            writer.traceIfNecessary(proxy.instructionPointer);
+            writer.traceIfNecessary(proxy.method);
+            writer.traceIfNecessary(proxy.closureOrNil);
+            writer.traceIfNecessary(proxy.receiver);
+            if (proxy.stackOrSize instanceof Object[] stack) {
+                final int sp = Math.min(getStackPointerOrZero(), stack.length);
+                for (int i = 0; i < sp; i++) {
+                    writer.traceIfNecessary(stack[i]);
+                }
+            }
+        } else if (senderOrFrameOrProxy instanceof AbstractSqueakObject o) {
             writer.traceIfNecessary(o);
         }
     }
@@ -725,32 +1122,65 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
         if (!writeHeader(writer)) {
             throw SqueakException.create("ContextObject must have slots:", this);
         }
-        writer.writeObject(getSender());
-        writer.writeObject(getInstructionPointer(InlinedConditionProfile.getUncached(), null));
-        writer.writeSmallInteger(getStackPointer());
-        writer.writeObject(getCodeObject());
-        writer.writeObject(NilObject.nullToNil(getClosure()));
-        final MaterializedFrame frame = getTruffleFrame();
-        final Object[] args = frame.getArguments();
-        final int numArgs = FrameAccess.getNumArguments(frame);
-        // Write receiver and arguments
-        for (int i = 0; i < 1 + numArgs; i++) {
-            writer.writeObject(args[FrameAccess.getReceiverStartIndex() + i]);
-        }
-        // Write stack values from frame slots
-        final int numSlots = FrameAccess.getNumStackSlots(frame);
-        for (int i = numArgs; i < numSlots; i++) {
-            final Object stackValue = FrameAccess.getStackValue(frame, i);
-            if (stackValue == null) {
-                writer.writeNil();
-            } else {
-                writer.writeObject(stackValue);
+
+        if (hasTruffleFrame()) {
+            writer.writeObject(getSender());
+            writer.writeObject(getInstructionPointer(InlinedConditionProfile.getUncached(), null));
+            writer.writeSmallInteger(getStackPointer());
+            writer.writeObject(getCodeObject());
+            writer.writeObject(NilObject.nullToNil(getClosure()));
+            final MaterializedFrame frame = getTruffleFrame();
+            final Object[] args = frame.getArguments();
+            final int numArgs = FrameAccess.getNumArguments(frame);
+            // Write receiver and arguments
+            for (int i = 0; i < 1 + numArgs; i++) {
+                writer.writeObject(args[FrameAccess.getReceiverStartIndex() + i]);
             }
-        }
-        // Write nil values for remaining stack values
-        final int contextSize = getCodeObject().getSqueakContextSize();
-        for (int i = numSlots; i < contextSize; i++) {
+            // Write stack values from frame slots
+            final int numSlots = FrameAccess.getNumStackSlots(frame);
+            for (int i = numArgs; i < numSlots; i++) {
+                final Object stackValue = FrameAccess.getStackValue(frame, i);
+                if (stackValue == null) {
+                    writer.writeNil();
+                } else {
+                    writer.writeObject(stackValue);
+                }
+            }
+            final int contextSize = getCodeObject().getSqueakContextSize();
+            for (int i = numSlots; i < contextSize; i++) {
+                writer.writeNil();
+            }
+        } else if (hasContextProxy()) {
+            final ContextProxy proxy = (ContextProxy) senderOrFrameOrProxy;
+            writer.writeObject(NilObject.nullToNil(proxy.sender));
+            writer.writeObject(NilObject.nullToNil(proxy.instructionPointer));
+            writer.writeObject(NilObject.nullToNil(proxy.stackPointer));
+            writer.writeObject(NilObject.nullToNil(proxy.method));
+            writer.writeObject(NilObject.nullToNil(proxy.closureOrNil));
+            writer.writeObject(NilObject.nullToNil(proxy.receiver));
+
+            final Object[] stack = proxy.stackOrSize instanceof Object[] s ? s : null;
+            final int contextSize = proxy.getSize();
+            final int sp = getStackPointerOrZero();
+
+            for (int i = 0; i < contextSize; i++) {
+                if (i < sp && stack != null && stack[i] != null) {
+                    writer.writeObject(stack[i]);
+                } else {
+                    writer.writeNil();
+                }
+            }
+        } else {
+            writer.writeObject(getSender());
             writer.writeNil();
+            writer.writeNil();
+            writer.writeNil();
+            writer.writeNil();
+            writer.writeNil();
+            final int contextSize = size();
+            for (int i = 0; i < contextSize; i++) {
+                writer.writeNil();
+            }
         }
     }
 }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
@@ -40,6 +40,25 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
 
     private static final Class<?> CONCRETE_MATERIALIZED_FRAME_CLASS = Truffle.getRuntime().createMaterializedFrame(new Object[0]).getClass();
 
+    /**
+     * To maximize GraalVM performance, this field acts as a union type transitioning between four
+     * distinct states:
+     * <p>
+     * 1. {@link AbstractSqueakObject} (Sender): The lightweight wrapper state. When a context is
+     *    actively executing in a {@link VirtualFrame}, we avoid allocating a MaterializedFrame.
+     *    Instead, we simply store its sender here until materialization is forced.
+     * <p>
+     * 2. {@link MaterializedFrame}: The fast-path execution state. Used for valid, suspended
+     *    contexts on the heap. This allows GraalVM to execute and resume them.
+     * <p>
+     * 3. {@link ContextProxy}: The slow-path fallback state. Used for newly allocated empty
+     *    contexts or contexts that have been reflectively mutated with incompatible values,
+     *    making them invalid Truffle frames.
+     * <p>
+     * 4. {@link SqueakImageChunk}: A transient bootstrap state used exclusively during image load.
+     */
+    private Object senderOrFrameOrProxy;
+
     public enum FrameHandling {
         /** Enumerate live objects in Truffle frames (Read-Only). */
         SCAN,
@@ -77,25 +96,6 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
             return (Object[]) stackOrSize;
         }
     }
-
-    /**
-     * To maximize GraalVM performance, this field acts as a union type transitioning between four
-     * distinct states:
-     * <p>
-     * 1. {@link AbstractSqueakObject} (Sender): The lightweight wrapper state. When a context is
-     *    actively executing in a {@link VirtualFrame}, we avoid allocating a MaterializedFrame.
-     *    Instead, we simply store its sender here until materialization is forced.
-     * <p>
-     * 2. {@link MaterializedFrame}: The fast-path execution state. Used for valid, suspended
-     *    contexts on the heap. This allows GraalVM to execute and resume them.
-     * <p>
-     * 3. {@link ContextProxy}: The slow-path fallback state. Used for newly allocated empty
-     *    contexts or contexts that have been reflectively mutated with incompatible values,
-     *    making them invalid Truffle frames.
-     * <p>
-     * 4. {@link SqueakImageChunk}: A transient bootstrap state used exclusively during image load.
-     */
-    private Object senderOrFrameOrProxy;
 
     public ContextObject(final SqueakImageChunk chunk) {
         super(chunk);
@@ -142,10 +142,10 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
         // During image load, the closure shell must be explicitly filled in
         // before materialization so we can access its CompiledBlock.
         final ContextProxy proxy = getProxy();
-        if (proxy.closureOrNil instanceof BlockClosureObject closure) {
-            if (proxy.method instanceof CompiledCodeObject code && code.isCompiledMethod()) {
-                closure.fillin(chunk.getChunk(CONTEXT.CLOSURE_OR_NIL));
-            }
+        if (proxy.closureOrNil instanceof BlockClosureObject closure &&
+                        proxy.method instanceof CompiledCodeObject code &&
+                        code.isCompiledMethod()) {
+            closure.fillin(chunk.getChunk(CONTEXT.CLOSURE_OR_NIL));
         }
 
         // ToDo: A Context that was a proxy because its stack pointer was not an integer,
@@ -747,29 +747,18 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
     @TruffleBoundary
     private boolean materializeFromProxy(final boolean forced) {
         final ContextProxy proxy = (ContextProxy) senderOrFrameOrProxy;
-        if (!(proxy.method instanceof CompiledCodeObject code)) {
-            return false; // Cannot materialize without a structurally valid method
+
+        if (!hasValidProxyStructure(proxy)) {
+            return false;
         }
 
+        final CompiledCodeObject code = (CompiledCodeObject) proxy.method;
         final Object closureOrNil = NilObject.nullToNil(proxy.closureOrNil);
-        if (closureOrNil != NilObject.SINGLETON && !(closureOrNil instanceof BlockClosureObject)) {
-            return false; // Structurally invalid closure
-        }
-
-        final Object pc = NilObject.nullToNil(proxy.instructionPointer);
-        if (pc != NilObject.SINGLETON && !(pc instanceof Long)) {
-            return false; // Structurally invalid instruction pointer
-        }
-
-        final Object sender = NilObject.nullToNil(proxy.sender);
-        if (!(sender instanceof AbstractSqueakObject)) {
-            return false; // Structurally invalid sender (e.g., primitive Long)
-        }
 
         // Resolve method and closure
         final BlockClosureObject closure;
-        final int numArgs;
         final CompiledCodeObject methodOrBlock;
+        final int numArgs;
 
         if (closureOrNil == NilObject.SINGLETON) {
             closure = null;
@@ -777,51 +766,88 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
             numArgs = code.getNumArgs();
         } else {
             closure = (BlockClosureObject) closureOrNil;
-            numArgs = closure.getNumArgs() + closure.getNumCopied();
             methodOrBlock = closure.isAFullBlockClosure() ? code : closure.getCompiledBlock();
+            numArgs = closure.getNumArgs() + closure.getNumCopied();
         }
 
-        final Object receiver = NilObject.nullToNil(proxy.receiver);
-
-        // Gather receiver and arguments for FrameAccess
+        // Gather receiver and arguments
         final Object[] proxyStack = proxy.getOrCreateStack();
-        final Object[] receiverAndArgs = new Object[1 + numArgs];
-        receiverAndArgs[0] = receiver;
-        for (int i = 0; i < numArgs; i++) {
-            final Object stackVal = i < proxyStack.length ? proxyStack[i] : null;
-            receiverAndArgs[1 + i] = NilObject.nullToNil(stackVal);
-        }
+        final Object[] receiverAndArgs = gatherReceiverAndArgs(proxy, numArgs, proxyStack);
 
-        // Allocate the Truffle Frame first to query its physical bounds
-        final Object[] frameArguments = FrameAccess.newWith((AbstractSqueakObject) sender, closure, receiverAndArgs);
+        // Allocate Truffle Frame
+        final AbstractSqueakObject sender = (AbstractSqueakObject) NilObject.nullToNil(proxy.sender);
+        final Object[] frameArguments = FrameAccess.newWith(sender, closure, receiverAndArgs);
         final MaterializedFrame frame = Truffle.getRuntime().createMaterializedFrame(frameArguments, methodOrBlock.getFrameDescriptor());
 
-        // Now evaluate the true physical SP bounds against the allocated frame
-        final int numStackSlots = FrameAccess.getNumStackSlots(frame);
-        final int sp;
-
-        if (proxy.stackPointer instanceof Long l) {
-            final int requestedSp = MiscUtils.toIntExact(l);
-            if (requestedSp < 0 || requestedSp > numStackSlots) {
-                // Refuse to materialize if SP out of bounds. If forced,
-                // this naturally falls through to getOrCreateTruffleFrame()
-                // which will throw the fatal SqueakException upon resumption.
-                // ToDo: Alternatively, we could force SP to zero when forced
-                return false;
-            } else {
-                sp = requestedSp;
-            }
-        } else if (forced) {
-            sp = 0; // OSVM interprets non-integers as zero for execution/loading
-        } else {
-            return false; // Stay a proxy
+        // Evaluate bounds
+        final int sp = determineStackPointer(proxy, forced, FrameAccess.getNumStackSlots(frame));
+        if (sp < 0) {
+            return false;
         }
 
+        // Apply state
         senderOrFrameOrProxy = frame;
         setMarkedCodeFlags();
         FrameAccess.setContext(frame, this);
+        restorePointersAndStack(proxy, methodOrBlock, sp, proxyStack);
 
-        // Restore pointers
+        return true;
+    }
+
+    private static boolean hasValidProxyStructure(final ContextProxy proxy) {
+        if (!(proxy.method instanceof CompiledCodeObject)) {
+            return false; // Cannot materialize without a structurally valid method
+        }
+        final Object closureOrNil = NilObject.nullToNil(proxy.closureOrNil);
+        if (closureOrNil != NilObject.SINGLETON && !(closureOrNil instanceof BlockClosureObject)) {
+            return false; // Structurally invalid closure
+        }
+        final Object pc = NilObject.nullToNil(proxy.instructionPointer);
+        if (pc != NilObject.SINGLETON && !(pc instanceof Long)) {
+            return false; // Structurally invalid instruction pointer
+        }
+        final Object sender = NilObject.nullToNil(proxy.sender);
+        if (!(sender instanceof AbstractSqueakObject)) {
+            return false; // Structurally invalid sender (e.g., primitive Long)
+        }
+        return true;
+    }
+
+    private static Object[] gatherReceiverAndArgs(final ContextProxy proxy, final int numArgs, final Object[] proxyStack) {
+        final Object[] receiverAndArgs = new Object[1 + numArgs];
+        receiverAndArgs[0] = NilObject.nullToNil(proxy.receiver);
+
+        final int limit = Math.min(numArgs, proxyStack.length);
+
+        // Map values that exist within the proxyStack bounds
+        for (int i = 0; i < limit; i++) {
+            receiverAndArgs[1 + i] = NilObject.nullToNil(proxyStack[i]);
+        }
+
+        // Pad any remaining arguments with NilObject
+        for (int i = limit; i < numArgs; i++) {
+            receiverAndArgs[1 + i] = NilObject.SINGLETON;
+        }
+
+        return receiverAndArgs;
+    }
+
+    private static int determineStackPointer(final ContextProxy proxy, final boolean forced, final int numStackSlots) {
+        if (proxy.stackPointer instanceof Long l) {
+            final int sp = MiscUtils.toIntExact(l);
+            if (sp < 0 || sp > numStackSlots) {
+                // ToDo: Alternatively, we could force SP to zero when forced
+                return -1; // Refuse to materialize if SP out of bounds
+            }
+            return sp;
+        } else if (forced) {
+            return 0; // OSVM interprets non-integers as zero for execution/loading
+        }
+        return -1; // Stay a proxy
+    }
+
+    private void restorePointersAndStack(final ContextProxy proxy, final CompiledCodeObject methodOrBlock, final int sp, final Object[] proxyStack) {
+        final Object pc = NilObject.nullToNil(proxy.instructionPointer);
         if (pc == NilObject.SINGLETON) {
             removeInstructionPointer();
         } else if (pc instanceof Long l) {
@@ -830,12 +856,17 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
 
         setStackPointer(sp);
 
-        // Restore stack temps and arguments
-        for (int i = 0; i < sp; i++) {
-            final Object stackVal = i < proxyStack.length ? proxyStack[i] : null;
-            atTempPut(i, NilObject.nullToNil(stackVal));
+        final int limit = Math.min(sp, proxyStack.length);
+
+        // Restore stack temps that exist within the proxyStack bounds
+        for (int i = 0; i < limit; i++) {
+            atTempPut(i, NilObject.nullToNil(proxyStack[i]));
         }
-        return true;
+
+        // Pad any remaining stack pointers with NilObject
+        for (int i = limit; i < sp; i++) {
+            atTempPut(i, NilObject.SINGLETON);
+        }
     }
 
     /**

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
@@ -878,7 +878,7 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
         assert hasTruffleFrame();
 
         // ToDo: Ensure primitives only operate on heap-based Contexts.
-        if (isPotentiallyActiveOnTruffleStack() && isActuallyActiveOnTruffleStackSlow()) {
+        if (isPotentiallyActiveOnTruffleStack() && isActuallyActiveOnTruffleStack()) {
             CompilerDirectives.transferToInterpreter();
             throw SqueakException.create("Fatal: Cannot structurally degrade a Context that is currently active on the Truffle execution stack.");
         }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
@@ -8,7 +8,6 @@ package de.hpi.swa.trufflesqueak.model;
 
 import java.util.Arrays;
 
-import de.hpi.swa.trufflesqueak.util.ArrayUtils;
 import org.graalvm.collections.UnmodifiableEconomicMap;
 
 import com.oracle.truffle.api.CallTarget;
@@ -29,6 +28,7 @@ import de.hpi.swa.trufflesqueak.image.SqueakImageChunk;
 import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
 import de.hpi.swa.trufflesqueak.image.SqueakImageWriter;
 import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.CONTEXT;
+import de.hpi.swa.trufflesqueak.util.ArrayUtils;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
 import de.hpi.swa.trufflesqueak.util.MiscUtils;
 import de.hpi.swa.trufflesqueak.util.ObjectGraphUtils.ObjectTracer;
@@ -881,17 +881,18 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
         }
 
         // Extract all state from the Truffle frame using the existing slow-path getters
+        final int sp = getStackPointer();
         final ContextProxy proxy = new ContextProxy(getCodeObject().getSqueakContextSize());
         proxy.sender = getSender();
         proxy.instructionPointer = getInstructionPointer(InlinedConditionProfile.getUncached(), null);
-        proxy.stackPointer = (long) getStackPointer();
+        proxy.stackPointer = (long) sp;
         proxy.method = getCodeObject();
         proxy.closureOrNil = getClosure();
         proxy.receiver = getReceiver();
 
         // Populate the proxy's array with the Truffle frame's stack
         final Object[] stack = proxy.getOrCreateStack();
-        for (int i = 0; i < stack.length; i++) {
+        for (int i = 0; i < sp; i++) {
             stack[i] = atTemp(i);
         }
 
@@ -924,8 +925,9 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
     }
 
     public Object getProxyTemp(final int index) {
+        assert index >= 0 : "Temp index cannot be negative: " + index;
         final Object[] stack = getProxy().getOrCreateStack();
-        return index >= 0 && index < stack.length ? NilObject.nullToNil(stack[index]) : NilObject.SINGLETON;
+        return index < stack.length ? NilObject.nullToNil(stack[index]) : NilObject.SINGLETON;
     }
 
     public void setProxySender(final Object value) {
@@ -958,8 +960,9 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
     }
 
     public void setProxyTemp(final int index, final Object value) {
+        assert index >= 0 : "Temp index cannot be negative: " + index;
         final Object[] stack = getProxy().getOrCreateStack();
-        if (index >= 0 && index < stack.length) {
+        if (index < stack.length) {
             stack[index] = value;
         }
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ContextObject.java
@@ -807,10 +807,7 @@ public final class ContextObject extends AbstractSqueakObjectWithHash {
             return false; // Structurally invalid instruction pointer
         }
         final Object sender = NilObject.nullToNil(proxy.sender);
-        if (!(sender instanceof AbstractSqueakObject)) {
-            return false; // Structurally invalid sender (e.g., primitive Long)
-        }
-        return true;
+        return sender instanceof AbstractSqueakObject; // Structurally invalid sender (e.g., primitive Long)
     }
 
     private static Object[] gatherReceiverAndArgs(final ContextProxy proxy, final int numArgs, final Object[] proxyStack) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/accessing/ContextObjectNodes.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/accessing/ContextObjectNodes.java
@@ -16,12 +16,14 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.InlinedConditionProfile;
 
+import de.hpi.swa.trufflesqueak.model.AbstractSqueakObject;
 import de.hpi.swa.trufflesqueak.model.BlockClosureObject;
 import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
 import de.hpi.swa.trufflesqueak.model.ContextObject;
 import de.hpi.swa.trufflesqueak.model.NilObject;
 import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.CONTEXT;
 import de.hpi.swa.trufflesqueak.nodes.AbstractNode;
+import de.hpi.swa.trufflesqueak.nodes.SqueakGuards;
 
 public final class ContextObjectNodes {
     @GenerateInline
@@ -32,109 +34,232 @@ public final class ContextObjectNodes {
 
         public abstract Object execute(Node node, ContextObject context, long index);
 
+        // --- Sender ---
         @Specialization(guards = "index == SENDER_OR_NIL")
         protected static final Object doSender(final ContextObject context, @SuppressWarnings("unused") final long index) {
             return context.getSender();
         }
 
-        @Specialization(guards = {"index == INSTRUCTION_POINTER"})
+        // --- Instruction Pointer ---
+        @Specialization(guards = {"index == INSTRUCTION_POINTER", "context.hasTruffleFrame()"})
         protected static final Object doInstructionPointer(final Node node, final ContextObject context, @SuppressWarnings("unused") final long index,
                         @Exclusive @Cached final InlinedConditionProfile nilProfile) {
             return context.getInstructionPointer(nilProfile, node);
         }
 
-        @Specialization(guards = "index == STACKPOINTER")
-        protected static final long doStackPointer(final ContextObject context, @SuppressWarnings("unused") final long index) {
-            return context.getStackPointer(); // Must return a long.
+        @Specialization(guards = {"index == INSTRUCTION_POINTER", "context.hasContextProxy()"})
+        protected static final Object doProxyInstructionPointer(final ContextObject context, @SuppressWarnings("unused") final long index) {
+            return context.getProxyInstructionPointer();
         }
 
+        // --- Stack Pointer ---
+        @Specialization(guards = {"index == STACKPOINTER", "context.hasTruffleFrame()"})
+        protected static final long doStackPointer(final ContextObject context, @SuppressWarnings("unused") final long index) {
+            return context.getStackPointer();
+        }
+
+        @Specialization(guards = {"index == STACKPOINTER", "context.hasContextProxy()"})
+        protected static final Object doProxyStackPointer(final ContextObject context, @SuppressWarnings("unused") final long index) {
+            return context.getProxyStackPointer();
+        }
+
+        // --- Method ---
         @Specialization(guards = {"index == METHOD", "context.hasTruffleFrame()"})
         protected static final CompiledCodeObject doMethod(final ContextObject context, @SuppressWarnings("unused") final long index) {
             return context.getCodeObject();
         }
 
-        @SuppressWarnings("unused")
-        @Specialization(guards = {"index == METHOD", "!context.hasTruffleFrame()"})
-        protected static final NilObject doNilMethod(final ContextObject context, final long index) {
-            return NilObject.SINGLETON;
+        @Specialization(guards = {"index == METHOD", "context.hasContextProxy()"})
+        protected static final Object doProxyMethod(final ContextObject context, @SuppressWarnings("unused") final long index) {
+            return context.getProxyMethod();
         }
 
-        @Specialization(guards = {"index == CLOSURE_OR_NIL"})
+        // --- Closure ---
+        @Specialization(guards = {"index == CLOSURE_OR_NIL", "context.hasTruffleFrame()"})
         protected static final Object doClosure(final Node node, final ContextObject context, @SuppressWarnings("unused") final long index,
                         @Exclusive @Cached final InlinedConditionProfile nilProfile) {
             return NilObject.nullToNil(context.getClosure(), nilProfile, node);
         }
 
-        @Specialization(guards = "index == RECEIVER")
+        @Specialization(guards = {"index == CLOSURE_OR_NIL", "context.hasContextProxy()"})
+        protected static final Object doProxyClosure(final ContextObject context, @SuppressWarnings("unused") final long index) {
+            return context.getProxyClosureOrNil();
+        }
+
+        // --- Receiver ---
+        @Specialization(guards = {"index == RECEIVER", "context.hasTruffleFrame()"})
         protected static final Object doReceiver(final ContextObject context, @SuppressWarnings("unused") final long index) {
             return context.getReceiver();
         }
 
-        @Specialization(guards = "index >= TEMP_FRAME_START")
+        @Specialization(guards = {"index == RECEIVER", "context.hasContextProxy()"})
+        protected static final Object doProxyReceiver(final ContextObject context, @SuppressWarnings("unused") final long index) {
+            return context.getProxyReceiver();
+        }
+
+        // --- Temp / Stack ---
+        @Specialization(guards = {"index >= TEMP_FRAME_START", "context.hasTruffleFrame()", "isValidTempIndex(context, index)"})
         protected static final Object doTemp(final ContextObject context, final long index) {
             return context.atTemp((int) (index - CONTEXT.TEMP_FRAME_START));
+        }
+
+        @Specialization(guards = {"index >= TEMP_FRAME_START", "context.hasContextProxy()", "isValidTempIndex(context, index)"})
+        protected static final Object doProxyTemp(final ContextObject context, final long index) {
+            return context.getProxyTemp((int) (index - CONTEXT.TEMP_FRAME_START));
+        }
+
+        @Specialization(guards = {"index >= TEMP_FRAME_START", "!isValidTempIndex(context, index)"})
+        protected static final Object doTempOutOfBounds(@SuppressWarnings("unused") final ContextObject context, @SuppressWarnings("unused") final long index) {
+            return NilObject.SINGLETON;
+        }
+
+        protected static boolean isValidTempIndex(final ContextObject context, final long index) {
+            return context.isValidTempIndex((int) (index - CONTEXT.TEMP_FRAME_START));
         }
     }
 
     @GenerateInline
     @GenerateUncached
     @GenerateCached(false)
-    @ImportStatic(CONTEXT.class)
+    @ImportStatic({CONTEXT.class, SqueakGuards.class})
     public abstract static class ContextObjectWriteNode extends AbstractNode {
 
         public abstract void execute(Node node, ContextObject context, long index, Object value);
 
-        @Specialization(guards = "index == SENDER_OR_NIL")
-        protected static final void doSender(final ContextObject context, @SuppressWarnings("unused") final long index, final ContextObject value) {
-            context.setSender(value);
+        // --- Sender ---
+        @Specialization(guards = {"index == SENDER_OR_NIL", "context.hasTruffleFrame()"})
+        protected static final void doSenderFrame(final ContextObject context, @SuppressWarnings("unused") final long index, final AbstractSqueakObject value) {
+            context.setSender(value); // Note: NilObject is an AbstractSqueakObject, so this catches both!
         }
 
-        @SuppressWarnings("unused")
-        @Specialization(guards = "index == SENDER_OR_NIL")
-        protected static final void doSender(final ContextObject context, final long index, final NilObject value) {
-            context.setSender(NilObject.SINGLETON);
+        @Specialization(guards = {"index == SENDER_OR_NIL", "context.hasTruffleFrame()", "!isAbstractSqueakObject(value)"})
+        protected static final void doSenderDematerialize(final ContextObject context, @SuppressWarnings("unused") final long index, final Object value) {
+            context.dematerializeToProxy();
+            context.setProxySender(value);
         }
 
-        @Specialization(guards = {"index == INSTRUCTION_POINTER"})
-        protected static final void doInstructionPointer(final ContextObject context, @SuppressWarnings("unused") final long index, final long value) {
+        @Specialization(guards = {"index == SENDER_OR_NIL", "context.hasContextProxy()"})
+        protected static final void doProxySender(final ContextObject context, @SuppressWarnings("unused") final long index, final Object value) {
+            context.setProxySender(value);
+        }
+
+        // --- Instruction Pointer ---
+        @Specialization(guards = {"index == INSTRUCTION_POINTER", "context.hasTruffleFrame()"})
+        protected static final void doInstructionPointerFrame(final ContextObject context, @SuppressWarnings("unused") final long index, final long value) {
             context.setInstructionPointer((int) value - context.getCodeObject().getInitialPC());
         }
 
         @SuppressWarnings("unused")
-        @Specialization(guards = {"index == INSTRUCTION_POINTER"})
+        @Specialization(guards = {"index == INSTRUCTION_POINTER", "context.hasTruffleFrame()"})
         protected static final void doInstructionPointerTerminated(final ContextObject context, final long index, final NilObject value) {
             context.removeInstructionPointer();
         }
 
-        @Specialization(guards = "index == STACKPOINTER")
-        protected static final void doStackPointer(final ContextObject context, @SuppressWarnings("unused") final long index, final long value) {
+        @Specialization(guards = {"index == INSTRUCTION_POINTER", "context.hasTruffleFrame()", "!isLong(value)", "!isNil(value)"})
+        protected static final void doInstructionPointerDematerialize(final ContextObject context, @SuppressWarnings("unused") final long index, final Object value) {
+            context.dematerializeToProxy();
+            context.setProxyInstructionPointer(value);
+        }
+
+        @Specialization(guards = {"index == INSTRUCTION_POINTER", "context.hasContextProxy()"})
+        protected static final void doProxyInstructionPointer(final ContextObject context, @SuppressWarnings("unused") final long index, final Object value) {
+            context.setProxyInstructionPointer(value);
+        }
+
+        // --- Stack Pointer ---
+        @Specialization(guards = {"index == STACKPOINTER", "context.hasTruffleFrame()", "isValidStackPointer(context, value)"})
+        protected static final void doStackPointerFrame(final ContextObject context, @SuppressWarnings("unused") final long index, final long value) {
             context.setStackPointer((int) value);
         }
 
-        @Specialization(guards = "index == METHOD")
-        protected static final void doMethod(final ContextObject context, @SuppressWarnings("unused") final long index, final CompiledCodeObject value) {
+        @Specialization(guards = {"index == STACKPOINTER", "context.hasTruffleFrame()", "!isValidStackPointer(context, value)"})
+        protected static final void doStackPointerDematerialize(final ContextObject context, @SuppressWarnings("unused") final long index, final Object value) {
+            context.dematerializeToProxy();
+            context.setProxyStackPointer(value);
+        }
+
+        @Specialization(guards = {"index == STACKPOINTER", "context.hasContextProxy()"})
+        protected static final void doProxyStackPointer(final ContextObject context, @SuppressWarnings("unused") final long index, final Object value) {
+            context.setProxyStackPointer(value);
+        }
+
+        protected static boolean isValidStackPointer(final ContextObject context, final Object value) {
+            return value instanceof Long l && context.isValidStackPointer(l);
+        }
+
+        // --- Method ---
+        @Specialization(guards = {"index == METHOD", "context.hasTruffleFrame()"})
+        protected static final void doMethodFrame(final ContextObject context, @SuppressWarnings("unused") final long index, final CompiledCodeObject value) {
             context.overwriteCodeObject(value);
         }
 
-        @Specialization(guards = {"index == CLOSURE_OR_NIL"})
-        protected static final void doClosure(final ContextObject context, @SuppressWarnings("unused") final long index, final BlockClosureObject value) {
+        @Specialization(guards = {"index == METHOD", "context.hasTruffleFrame()", "!isCompiledCodeObject(value)"})
+        protected static final void doMethodDematerialize(final ContextObject context, @SuppressWarnings("unused") final long index, final Object value) {
+            context.dematerializeToProxy();
+            context.setProxyMethod(value);
+        }
+
+        @Specialization(guards = {"index == METHOD", "context.hasContextProxy()"})
+        protected static final void doProxyMethod(final ContextObject context, @SuppressWarnings("unused") final long index, final Object value) {
+            context.setProxyMethod(value);
+        }
+
+        // --- Closure ---
+        @Specialization(guards = {"index == CLOSURE_OR_NIL", "context.hasTruffleFrame()"})
+        protected static final void doClosureFrame(final ContextObject context, @SuppressWarnings("unused") final long index, final BlockClosureObject value) {
             context.setClosure(value);
         }
 
         @SuppressWarnings("unused")
-        @Specialization(guards = {"index == CLOSURE_OR_NIL"})
-        protected static final void doClosure(final ContextObject context, final long index, final NilObject value) {
+        @Specialization(guards = {"index == CLOSURE_OR_NIL", "context.hasTruffleFrame()"})
+        protected static final void doClosureTerminated(final ContextObject context, final long index, final NilObject value) {
             context.removeClosure();
         }
 
-        @Specialization(guards = "index == RECEIVER")
-        protected static final void doReceiver(final ContextObject context, @SuppressWarnings("unused") final long index, final Object value) {
+        @Specialization(guards = {"index == CLOSURE_OR_NIL", "context.hasTruffleFrame()", "!isBlockClosureObject(value)", "!isNil(value)"})
+        protected static final void doClosureDematerialize(final ContextObject context, @SuppressWarnings("unused") final long index, final Object value) {
+            context.dematerializeToProxy();
+            context.setProxyClosureOrNil(value);
+        }
+
+        @Specialization(guards = {"index == CLOSURE_OR_NIL", "context.hasContextProxy()"})
+        protected static final void doProxyClosure(final ContextObject context, @SuppressWarnings("unused") final long index, final Object value) {
+            context.setProxyClosureOrNil(value);
+        }
+
+        // --- Receiver & Temps (Naturally polymorphic arrays, no dematerialization needed) ---
+        @Specialization(guards = {"index == RECEIVER", "context.hasTruffleFrame()"})
+        protected static final void doReceiverFrame(final ContextObject context, @SuppressWarnings("unused") final long index, final Object value) {
             context.setReceiver(value);
         }
 
-        @Specialization(guards = "index >= TEMP_FRAME_START")
-        protected static final void doTemp(final ContextObject context, final long index, final Object value) {
+        @Specialization(guards = {"index == RECEIVER", "context.hasContextProxy()"})
+        protected static final void doProxyReceiver(final ContextObject context, @SuppressWarnings("unused") final long index, final Object value) {
+            context.setProxyReceiver(value);
+        }
+
+        // --- Temps ---
+        @Specialization(guards = {"index >= TEMP_FRAME_START", "context.hasTruffleFrame()", "isValidTempIndex(context, index)"})
+        protected static final void doTempFrame(final ContextObject context, final long index, final Object value) {
             context.atTempPut((int) (index - CONTEXT.TEMP_FRAME_START), value);
+        }
+
+        @Specialization(guards = {"index >= TEMP_FRAME_START", "context.hasContextProxy()", "isValidTempIndex(context, index)"})
+        protected static final void doProxyTemp(final ContextObject context, final long index, final Object value) {
+            context.setProxyTemp((int) (index - CONTEXT.TEMP_FRAME_START), value);
+        }
+
+        @Specialization(guards = {"index >= TEMP_FRAME_START", "!isValidTempIndex(context, index)"})
+        protected static final void doTempOutOfBounds(@SuppressWarnings("unused") final ContextObject context, @SuppressWarnings("unused") final long index,
+                        @SuppressWarnings("unused") final Object value) {
+            /*
+             * No-op. We safely ignore out-of-bounds writes to dead space.
+             * This prevents crashing on negative indices.
+             */
+        }
+
+        protected static boolean isValidTempIndex(final ContextObject context, final long index) {
+            return context.isValidTempIndex((int) (index - CONTEXT.TEMP_FRAME_START));
         }
     }
 }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ArrayStreamPrimitives.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ArrayStreamPrimitives.java
@@ -22,6 +22,7 @@ import de.hpi.swa.trufflesqueak.exceptions.PrimitiveFailed;
 import de.hpi.swa.trufflesqueak.exceptions.RespecializeException;
 import de.hpi.swa.trufflesqueak.model.AbstractSqueakObject;
 import de.hpi.swa.trufflesqueak.model.CharacterObject;
+import de.hpi.swa.trufflesqueak.model.ContextObject;
 import de.hpi.swa.trufflesqueak.model.NativeObject;
 import de.hpi.swa.trufflesqueak.nodes.SqueakGuards;
 import de.hpi.swa.trufflesqueak.nodes.accessing.FloatObjectNodes.FloatObjectNormalizeNode;
@@ -136,6 +137,11 @@ public final class ArrayStreamPrimitives extends AbstractPrimitiveFactoryHolder 
     @SqueakPrimitive(indices = 62)
     protected abstract static class PrimSize1Node extends AbstractPrimitiveNode implements Primitive0WithFallback {
         @Specialization
+        protected static final long doContext(final ContextObject receiver) {
+            return Math.min(receiver.size(), receiver.getStackPointerOrZero());
+        }
+
+        @Specialization
         protected static final long doSqueakObject(final AbstractSqueakObject receiver,
                         @Bind final Node node,
                         @Cached final SqueakObjectSizeNode sizeNode,
@@ -147,6 +153,11 @@ public final class ArrayStreamPrimitives extends AbstractPrimitiveFactoryHolder 
     @GenerateNodeFactory
     @SqueakPrimitive(indices = 62)
     protected abstract static class PrimSize2Node extends AbstractPrimitiveNode implements Primitive1WithFallback {
+        @Specialization
+        protected static final long doContext(@SuppressWarnings("unused") final Object receiver, final ContextObject target) {
+            return Math.min(target.size(), target.getStackPointerOrZero());
+        }
+
         @Specialization
         protected static final long doSqueakObject(@SuppressWarnings("unused") final Object receiver, final AbstractSqueakObject target,
                         @Bind final Node node,

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ContextPrimitives.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ContextPrimitives.java
@@ -28,6 +28,7 @@ import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive0WithFallbac
 import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive1WithFallback;
 import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive2WithFallback;
 import de.hpi.swa.trufflesqueak.nodes.primitives.SqueakPrimitive;
+import de.hpi.swa.trufflesqueak.util.MiscUtils;
 
 public class ContextPrimitives extends AbstractPrimitiveFactoryHolder {
 
@@ -35,8 +36,9 @@ public class ContextPrimitives extends AbstractPrimitiveFactoryHolder {
     @GenerateNodeFactory
     @SqueakPrimitive(indices = 76)
     protected abstract static class PrimStoreStackPointerNode extends AbstractPrimitiveNode implements Primitive1WithFallback {
-        @Specialization(guards = {"0 <= newStackPointerLong", "newStackPointerLong <= receiver.size()"})
-        protected static final ContextObject store(final ContextObject receiver, final long newStackPointerLong) {
+
+        @Specialization(guards = {"0 <= newStackPointerLong", "receiver.isValidStackPointer(newStackPointerLong)", "!receiver.hasContextProxy()"})
+        protected static final ContextObject storeTruffle(final ContextObject receiver, final long newStackPointerLong) {
             final int oldStackPointer = receiver.getStackPointerOrZero();
             final int newStackPointer = (int) newStackPointerLong;
 
@@ -45,6 +47,20 @@ public class ContextPrimitives extends AbstractPrimitiveFactoryHolder {
             }
 
             receiver.setStackPointer(newStackPointer);
+            return receiver;
+        }
+
+        @Specialization(guards = {"0 <= newStackPointerLong", "receiver.isValidStackPointer(newStackPointerLong)", "receiver.hasContextProxy()"})
+        protected static final ContextObject storeProxy(final ContextObject receiver, final long newStackPointerLong) {
+            final Object spObj = receiver.getProxyStackPointer();
+            final int oldStackPointer = spObj instanceof Long l ? MiscUtils.toIntExact(l) : 0;
+            final int newStackPointer = (int) newStackPointerLong;
+
+            for (int i = oldStackPointer; i < newStackPointer; i++) {
+                receiver.setProxyTemp(i, NilObject.SINGLETON);
+            }
+
+            receiver.setProxyStackPointer((long) newStackPointer);
             return receiver;
         }
     }
@@ -152,7 +168,7 @@ public class ContextPrimitives extends AbstractPrimitiveFactoryHolder {
     @GenerateNodeFactory
     @SqueakPrimitive(indices = 210)
     protected abstract static class PrimContextAtNode extends AbstractPrimitiveNode implements Primitive1WithFallback {
-        @Specialization(guards = {"1 <= index", "index <= receiver.getStackPointer()"})
+        @Specialization(guards = {"1 <= index", "index <= receiver.getStackPointerOrZero()"})
         protected static final Object doContextObject(final ContextObject receiver, final long index,
                         @Bind final Node node,
                         @Cached final ContextObjectReadNode readNode) {
@@ -163,7 +179,7 @@ public class ContextPrimitives extends AbstractPrimitiveFactoryHolder {
     @GenerateNodeFactory
     @SqueakPrimitive(indices = 211)
     protected abstract static class PrimContextAtPutNode extends AbstractPrimitiveNode implements Primitive2WithFallback {
-        @Specialization(guards = {"1 <= index", "index <= receiver.getStackPointer()"})
+        @Specialization(guards = {"1 <= index", "index <= receiver.getStackPointerOrZero()"})
         protected static final Object doContextObject(final ContextObject receiver, final long index, final Object value,
                         @Bind final Node node,
                         @Cached final ContextObjectWriteNode writeNode) {
@@ -181,14 +197,9 @@ public class ContextPrimitives extends AbstractPrimitiveFactoryHolder {
          * truly invisible even (and especially!) to the garbage collector. Any store into stackp
          * other than by the primitive method stackp: is potentially fatal."
          */
-        @Specialization(guards = "receiver.hasTruffleFrame()")
+        @Specialization
         protected static final long doSize(final ContextObject receiver) {
-            return receiver.getStackPointer();
-        }
-
-        @Specialization(guards = "!receiver.hasTruffleFrame()")
-        protected static final long doSizeWithoutFrame(@SuppressWarnings("unused") final ContextObject receiver) {
-            return 0;
+            return receiver.getStackPointerOrZero();
         }
     }
 


### PR DESCRIPTION
**Depends on #304** 

This PR builds on the recent heap-based `Context` changes by introducing `ContextProxy` to safely manage structurally invalid or reflectively mutated contexts.

Changes:

- Introduces the `ContextProxy` state, featuring automatic dematerialization of Truffle frames upon incompatible reflective writes, and dynamic materialization when a valid execution state resumes.
- Centralizes context boundary checks in `ContextObject`, enforcing physical Truffle frame capacity over logical Squeak limits.
- Consolidates out-of-bounds temporary variable and stack accesses into safe no-ops across frames and proxies, preventing indexing exceptions.
- Reorders `ContextObject` initialization in `SqueakImageContext.getDoItContextNode()` to properly establish code objects before receivers during image boot.

With these changes, all previously failing examples in #163 are correctly functioning (see image below).

<img width="1416" height="935" alt="ContextProxy tests" src="https://github.com/user-attachments/assets/9d996482-0c68-4ef4-bd6c-7faf4acbcbba" />

For maximum compatibility with OSVM, we should consider a command line option to disable the optimization (trimming) of `Context` stack frames imposed by the current execution model.