### PR TITLE
Multilevel dispatch reloaded

### DIFF
--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
@@ -166,7 +166,8 @@ public final class SqueakImageContext {
     // The maximum message arity that supports DNU shortcuts.
     public static final int MAX_DNU_SHORTCUT_ARITY = 3;
 
-    @CompilationFinal(dimensions = 1) private NativeObject[] dnuShortcutSelectors = new NativeObject[0];
+    @CompilationFinal private Assumption dnuShortcutsAbsent = Truffle.getRuntime().createAssumption("DNU shortcuts");
+    @CompilationFinal(dimensions = 1) private NativeObject[] dnuShortcutSelectors = null;
 
     /* Method Cache */
     private static final int METHOD_CACHE_SIZE = 2 << 12;
@@ -478,16 +479,44 @@ public final class SqueakImageContext {
         return null;
     }
 
+    public boolean hasDNUShortcut(final int arity) {
+        return hasDNUShortcuts() && arity < MAX_DNU_SHORTCUT_ARITY + 1;
+    }
+
+    public boolean hasDNUShortcuts() {
+        assert (dnuShortcutSelectors == null) == dnuShortcutsAbsent.isValid() : "DNU shortcuts assumption out of sync";
+        return dnuShortcutSelectors != null;
+    }
+
+    public Assumption getDnuShortcutsAbsent() {
+        return dnuShortcutsAbsent;
+    }
+
     public void setDNUShortcutSelectors(final NativeObject[] newSelectors) {
         CompilerDirectives.transferToInterpreterAndInvalidate();
+
+        if (newSelectors != null) {
+            // Invalidate the fast-path assumption if it's currently valid.
+            if (dnuShortcutsAbsent.isValid()) {
+                dnuShortcutsAbsent.invalidate("DNU shortcuts set");
+            }
+        } else {
+            // Recreate the assumption so the fast path can recover.
+            if (!dnuShortcutsAbsent.isValid()) {
+                dnuShortcutsAbsent = Truffle.getRuntime().createAssumption("DNU shortcuts");
+            }
+        }
+
         dnuShortcutSelectors = newSelectors;
         flushMethodCache();
     }
 
     private boolean isDNUShortcutSelector(final NativeObject selector) {
-        for (final NativeObject shortcutSelector : dnuShortcutSelectors) {
-            if (selector == shortcutSelector) {
-                return true;
+        if (hasDNUShortcuts()) {
+            for (final NativeObject shortcutSelector : dnuShortcutSelectors) {
+                if (selector == shortcutSelector) {
+                    return true;
+                }
             }
         }
         return false;
@@ -717,7 +746,6 @@ public final class SqueakImageContext {
         }
     }
 
-    @TruffleBoundary
     public Assumption getAbsentSelectorAssumption(final NativeObject selector) {
         CyclicAssumption absentAssumption = absentSelectorAssumptions.get(selector);
         if (absentAssumption == null) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 
+import org.graalvm.collections.EconomicMap;
 import org.graalvm.collections.UnmodifiableEconomicMap;
 
 import com.oracle.truffle.api.Assumption;
@@ -130,7 +131,7 @@ public final class SqueakImageContext {
     @CompilationFinal private ClassObject doubleByteArrayClass;
     @CompilationFinal private ClassObject wordArrayClass;
     @CompilationFinal private ClassObject doubleWordArrayClass;
-    public final NativeObject cannotInterpretSelector = new NativeObject(); // TODO: use selector
+    public final NativeObject cannotInterpretSelector = new NativeObject();
     public final ClassObject blockClosureClass = new ClassObject(this);
     @CompilationFinal private ClassObject fullBlockClosureClass;
     public final ClassObject largeNegativeIntegerClass = new ClassObject(this);
@@ -162,12 +163,18 @@ public final class SqueakImageContext {
                     ArrayUtils.EMPTY_ARRAY, compiledMethodClass);
     public final VirtualFrame externalSenderFrame = Truffle.getRuntime().createVirtualFrame(FrameAccess.newWith(NilObject.SINGLETON, null, NilObject.SINGLETON), dummyMethod.getFrameDescriptor());
 
+    // The maximum message arity that supports DNU shortcuts.
+    public static final int MAX_DNU_SHORTCUT_ARITY = 3;
+
+    @CompilationFinal(dimensions = 1) private NativeObject[] dnuShortcutSelectors = new NativeObject[0];
+
     /* Method Cache */
     private static final int METHOD_CACHE_SIZE = 2 << 12;
     private static final int METHOD_CACHE_MASK = METHOD_CACHE_SIZE - 1;
     private static final int METHOD_CACHE_REPROBES = 4;
     private int methodCacheRandomish;
     @CompilationFinal(dimensions = 1) private final MethodCacheEntry[] methodCache = new MethodCacheEntry[METHOD_CACHE_SIZE];
+    private final EconomicMap<NativeObject, CyclicAssumption> absentSelectorAssumptions = EconomicMap.create();
 
     /* Interpreter state */
     private int primFailCode = 0;
@@ -464,6 +471,28 @@ public final class SqueakImageContext {
         return currentMarkingFlag = !currentMarkingFlag;
     }
 
+    public NativeObject getDNUShortcutSelector(final int arity) {
+        if (0 <= arity && arity < dnuShortcutSelectors.length) {
+            return dnuShortcutSelectors[arity];
+        }
+        return null;
+    }
+
+    public void setDNUShortcutSelectors(final NativeObject[] newSelectors) {
+        CompilerDirectives.transferToInterpreterAndInvalidate();
+        dnuShortcutSelectors = newSelectors;
+        flushMethodCache();
+    }
+
+    private boolean isDNUShortcutSelector(final NativeObject selector) {
+        for (final NativeObject shortcutSelector : dnuShortcutSelectors) {
+            if (selector == shortcutSelector) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /* SpurMemoryManager>>#setHiddenRootsObj: */
     public void setHiddenRoots(final ArrayObject theHiddenRoots) {
         assert hiddenRoots == null && (theHiddenRoots.isObjectType() || isTesting());
@@ -688,9 +717,31 @@ public final class SqueakImageContext {
         }
     }
 
-    public void flushCachesForSelector(final NativeObject selector) {
-        flushCachesForSelectorInClassTable(selector);
-        flushMethodCacheForSelector(selector);
+    @TruffleBoundary
+    public Assumption getAbsentSelectorAssumption(final NativeObject selector) {
+        CyclicAssumption absentAssumption = absentSelectorAssumptions.get(selector);
+        if (absentAssumption == null) {
+            absentAssumption = new CyclicAssumption("Absent selector globally: " + selector.asStringUnsafe());
+            absentSelectorAssumptions.put(selector, absentAssumption);
+        }
+        return absentAssumption.getAssumption();
+    }
+
+    @TruffleBoundary
+    private void invalidateAllAbsentSelectorAssumptions() {
+        for (final CyclicAssumption absentAssumption : absentSelectorAssumptions.getValues()) {
+            absentAssumption.invalidate("Fallback method (DNU/CI) shadowed or modified");
+        }
+        absentSelectorAssumptions.clear();
+    }
+
+    @TruffleBoundary
+    private void invalidateAbsentSelectorAssumption(final NativeObject selector) {
+        final CyclicAssumption absentAssumption = absentSelectorAssumptions.get(selector);
+        if (absentAssumption != null) {
+            absentAssumption.invalidate("Absent selector flushed globally");
+            absentSelectorAssumptions.removeKey(selector);
+        }
     }
 
     public TruffleFile getHomePath() {
@@ -1067,17 +1118,27 @@ public final class SqueakImageContext {
 
     /* Clear all cache entries (prim 89). */
     public void flushMethodCache() {
+        invalidateAllAbsentSelectorAssumptions();
         for (int i = 0; i < METHOD_CACHE_SIZE; i++) {
             methodCache[i].freeAndRelease();
         }
     }
 
     /* Clear cache entries for selector (prim 119). */
-    private void flushMethodCacheForSelector(final NativeObject selector) {
-        if (selector == doesNotUnderstand || selector == cannotInterpretSelector) {
+    public void flushCachesForSelector(final NativeObject selector) {
+        if (selector == doesNotUnderstand || selector == cannotInterpretSelector || isDNUShortcutSelector(selector)) {
+            // A core fallback changed. Invalidate the entire method cache to ensure
+            // no missing selectors are holding onto the stale fallback method.
             flushMethodCache();
-            return;
+            flushCachesForSelectorInClassTable(selector);
+        } else {
+            invalidateAbsentSelectorAssumption(selector);
+            flushCachesForSelectorInClassTable(selector);
+            flushMethodCacheForSelector(selector);
         }
+    }
+
+    private void flushMethodCacheForSelector(final NativeObject selector) {
         for (int i = 0; i < METHOD_CACHE_SIZE; i++) {
             if (methodCache[i].getSelector() == selector) {
                 methodCache[i].freeAndRelease();

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/image/SqueakImageContext.java
@@ -1136,7 +1136,31 @@ public final class SqueakImageContext {
         return methodCache[firstProbe].reuseFor(classObject, selector);
     }
 
+    @ExplodeLoop
     public Object lookup(final ClassObject receiverClass, final NativeObject selector) {
+        // 1. Read-Only Fast Path: strictly side-effect free for PE
+        final int selectorHash = System.identityHashCode(selector);
+        final int stride = (selectorHash << 1) | 1;
+        int probe = (System.identityHashCode(receiverClass) ^ selectorHash) & METHOD_CACHE_MASK;
+
+        for (int i = 0; i < METHOD_CACHE_REPROBES; i++) {
+            final MethodCacheEntry entry = methodCache[probe];
+            if (entry.getClassObject() == receiverClass && entry.getSelector() == selector) {
+                final Object result = entry.getResult();
+                if (result != null) {
+                    return result; // Fast path hit!
+                }
+                break; // Found the entry, but result is null. Drop to slow path.
+            }
+            probe = (probe + stride) & METHOD_CACHE_MASK;
+        }
+
+        // 2. Cache Miss: delegate to the out-of-line slow path
+        return lookupSlow(receiverClass, selector);
+    }
+
+    @TruffleBoundary
+    private Object lookupSlow(final ClassObject receiverClass, final NativeObject selector) {
         final MethodCacheEntry cachedEntry = findMethodCacheEntry(receiverClass, selector);
         if (cachedEntry.getResult() == null) {
             cachedEntry.setResult(receiverClass.lookupInMethodDictSlow(selector));

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ClassObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ClassObject.java
@@ -6,6 +6,7 @@
  */
 package de.hpi.swa.trufflesqueak.model;
 
+import de.hpi.swa.trufflesqueak.util.LogUtils;
 import org.graalvm.collections.UnmodifiableEconomicMap;
 
 import com.oracle.truffle.api.Assumption;
@@ -36,6 +37,21 @@ import de.hpi.swa.trufflesqueak.util.ObjectGraphUtils.ObjectTracer;
  */
 @SuppressWarnings("static-method")
 public final class ClassObject extends AbstractSqueakObjectWithClassAndHash {
+    public enum FallbackConvention {
+        CANNOT_INTERPRET, // Use #cannotInterpret: and build nested Message objects
+        STANDARD_DNU,     // Use #doesNotUnderstand: and build a Message object
+        SHORTCUT_DNU      // Use #dnu...: and pass arguments and selector directly (no Message
+                          // object)
+    }
+
+    public record DispatchFailureResult(
+                    CompiledCodeObject fallbackMethod,
+                    int fallbackDepth,
+                    FallbackConvention convention,
+                    NativeObject fallbackSelector,
+                    int arity) {
+    }
+
     @CompilationFinal private CyclicAssumption classHierarchyAndMethodDictStable;
     @CompilationFinal private CyclicAssumption classFormatStable;
 
@@ -466,9 +482,10 @@ public final class ClassObject extends AbstractSqueakObjectWithClassAndHash {
      * @throws SqueakException if the fallback method cannot be found (fatal VM error).
      */
     @TruffleBoundary
-    public CompiledCodeObject resolveDispatchFailure(final NativeObject originalSelector) {
+    public DispatchFailureResult resolveDispatchFailure(final NativeObject originalSelector, final int arity) {
         CompilerAsserts.neverPartOfCompilation();
-        // Walk superclass chain to determine if #cannotInterpret:.
+
+        // Walk superclass chain to determine if this is a #cannotInterpret: case.
         ClassObject current = this;
         while (current != null) {
             assert current.assertNotForwarded();
@@ -478,31 +495,52 @@ public final class ClassObject extends AbstractSqueakObjectWithClassAndHash {
             current = current.getSuperclassOrNull();
         }
 
-        // If the walk terminates with null, we have a DNU.
+        // --- DNU Path (No nil method dictionaries) ---
         if (current == null) {
             assert originalSelector != image.doesNotUnderstand : "Fatal dispatch error: Recursive doesNotUnderstand:";
 
+            // Attempt the Shortcut DNU first
+            final NativeObject shortcutSelector = image.getDNUShortcutSelector(arity);
+            if (shortcutSelector != null) {
+                final CompiledCodeObject shortcutMethod = lookupMethodInMethodDictSlow(shortcutSelector);
+                if (shortcutMethod != null) {
+                    if (shortcutMethod.getNumArgs() == arity + 1) {
+                        return new DispatchFailureResult(shortcutMethod, 1, FallbackConvention.SHORTCUT_DNU, shortcutSelector, arity);
+                    } else {
+                        LogUtils.DEBUG.warning(() -> "Ignoring misconfigured DNU shortcut " + shortcutSelector.asStringUnsafe() +
+                                        ": expected " + (arity + 1) + " arguments, but got " + shortcutMethod.getNumArgs());
+                    }
+                }
+            }
+
+            // Fall back to standard #doesNotUnderstand:
             final CompiledCodeObject dnuMethod = lookupMethodInMethodDictSlow(image.doesNotUnderstand);
             if (dnuMethod != null) {
-                return dnuMethod;
+                return new DispatchFailureResult(dnuMethod, 1, FallbackConvention.STANDARD_DNU, image.doesNotUnderstand, arity);
             } else {
                 throw SqueakException.create("Fatal dispatch error: #doesNotUnderstand: not found in", this);
             }
-        } else {
-            // Search for #cannotInterpret: starting in the superclass of the missing method
-            // dictionary class.
-            final ClassObject startingClass = current.getSuperclassOrNull();
-            if (startingClass == null) {
-                throw SqueakException.create("Fatal dispatch error: hit nil method dictionary in class with no superclass while sending", originalSelector);
-            }
-
-            final CompiledCodeObject ciMethod = startingClass.lookupMethodInMethodDictSlow(image.cannotInterpretSelector);
-            if (ciMethod != null) {
-                return ciMethod;
-            } else {
-                throw SqueakException.create("Fatal dispatch error: #cannotInterpret: not found in superclass chain of", current);
-            }
         }
+
+        // --- CannotInterpret Path (Hit a nil dictionary) ---
+        int depth = 1;
+        ClassObject searchClass = current.getSuperclassOrNull();
+        final NativeObject selector = image.cannotInterpretSelector;
+        final int messageSelectorHash = selector.getSqueakHashInt();
+
+        while (searchClass != null) {
+            if (searchClass.methodDict == null) {
+                depth++;
+            } else {
+                final Object result = lookupMethodInDictionary(searchClass.getResolvedMethodDict(), selector, messageSelectorHash);
+                if (result instanceof CompiledCodeObject ciMethod) {
+                    return new DispatchFailureResult(ciMethod, depth, FallbackConvention.CANNOT_INTERPRET, selector, arity);
+                }
+            }
+            searchClass = searchClass.getSuperclassOrNull();
+        }
+
+        throw SqueakException.create("Fatal dispatch error: #cannotInterpret: not found in superclass chain of", this);
     }
 
     /**

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ClassObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/ClassObject.java
@@ -6,7 +6,6 @@
  */
 package de.hpi.swa.trufflesqueak.model;
 
-import de.hpi.swa.trufflesqueak.util.LogUtils;
 import org.graalvm.collections.UnmodifiableEconomicMap;
 
 import com.oracle.truffle.api.Assumption;
@@ -30,6 +29,7 @@ import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.METACLASS;
 import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.METHOD_DICT;
 import de.hpi.swa.trufflesqueak.nodes.accessing.AbstractPointersObjectNodes.AbstractPointersObjectReadNode;
 import de.hpi.swa.trufflesqueak.util.ArrayUtils;
+import de.hpi.swa.trufflesqueak.util.LogUtils;
 import de.hpi.swa.trufflesqueak.util.ObjectGraphUtils.ObjectTracer;
 
 /*
@@ -481,7 +481,6 @@ public final class ClassObject extends AbstractSqueakObjectWithClassAndHash {
      * @return The CompiledCodeObject for the fallback method.
      * @throws SqueakException if the fallback method cannot be found (fatal VM error).
      */
-    @TruffleBoundary
     public DispatchFailureResult resolveDispatchFailure(final NativeObject originalSelector, final int arity) {
         CompilerAsserts.neverPartOfCompilation();
 
@@ -500,15 +499,17 @@ public final class ClassObject extends AbstractSqueakObjectWithClassAndHash {
             assert originalSelector != image.doesNotUnderstand : "Fatal dispatch error: Recursive doesNotUnderstand:";
 
             // Attempt the Shortcut DNU first
-            final NativeObject shortcutSelector = image.getDNUShortcutSelector(arity);
-            if (shortcutSelector != null) {
-                final CompiledCodeObject shortcutMethod = lookupMethodInMethodDictSlow(shortcutSelector);
-                if (shortcutMethod != null) {
-                    if (shortcutMethod.getNumArgs() == arity + 1) {
-                        return new DispatchFailureResult(shortcutMethod, 1, FallbackConvention.SHORTCUT_DNU, shortcutSelector, arity);
-                    } else {
-                        LogUtils.DEBUG.warning(() -> "Ignoring misconfigured DNU shortcut " + shortcutSelector.asStringUnsafe() +
-                                        ": expected " + (arity + 1) + " arguments, but got " + shortcutMethod.getNumArgs());
+            if (image.hasDNUShortcut(arity)) {
+                final NativeObject shortcutSelector = image.getDNUShortcutSelector(arity);
+                if (shortcutSelector != null) {
+                    final CompiledCodeObject shortcutMethod = lookupMethodInMethodDictSlow(shortcutSelector);
+                    if (shortcutMethod != null) {
+                        if (shortcutMethod.getNumArgs() == arity + 1) {
+                            return new DispatchFailureResult(shortcutMethod, 1, FallbackConvention.SHORTCUT_DNU, shortcutSelector, arity);
+                        } else {
+                            LogUtils.DEBUG.warning(() -> "Ignoring misconfigured DNU shortcut " + shortcutSelector.asStringUnsafe() +
+                                            ": expected " + (arity + 1) + " arguments, but got " + shortcutMethod.getNumArgs());
+                        }
                     }
                 }
             }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/CompiledCodeObject.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/model/CompiledCodeObject.java
@@ -744,7 +744,7 @@ public final class CompiledCodeObject extends AbstractSqueakObjectWithClassAndHa
         final boolean oldHasPrimitive = hasPrimitive();
         internalHeader = CompiledCodeHeaderUtils.fromSmallIntegerValue(value);
         assert getNumLiterals() == oldNumLiterals;
-        if (oldHasPrimitive && !hasPrimitive()) {
+        if (oldHasPrimitive != hasPrimitive()) {
             primitiveNodeOrNull = UNINITIALIZED_PRIMITIVE_NODE;
         }
         invalidateCallTarget();

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/CacheLimits.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/CacheLimits.java
@@ -10,7 +10,8 @@ public final class CacheLimits {
     public static final int EXECUTE_METHOD_CACHE_LIMIT = 4;
     public static final int INDIRECT_PRIMITIVE_CACHE_LIMIT = 2;
     public static final int INLINE_BLOCK_CACHE_LIMIT = 4;
-    public static final int INLINE_METHOD_CACHE_LIMIT = 4;
+    public static final int LOOKUP_CACHE_LIMIT = 8;
+    public static final int DISPATCH_CACHE_LIMIT = 4;
     public static final int NEW_CACHE_LIMIT = 3;
     public static final int PERFORM_SELECTOR_CACHE_LIMIT = 4;
     public static final int POINTERS_LAYOUT_CACHE_LIMIT = 4;

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/AbstractCreateFrameArgumentsForIndirectCallNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/AbstractCreateFrameArgumentsForIndirectCallNode.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Software Architecture Group, Hasso Plattner Institute
+ * Copyright (c) 2026 Oracle and/or its affiliates
+ *
+ * Licensed under the MIT License.
+ */
+package de.hpi.swa.trufflesqueak.nodes.dispatch;
+
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.profiles.InlinedConditionProfile;
+
+import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
+import de.hpi.swa.trufflesqueak.model.AbstractSqueakObject;
+import de.hpi.swa.trufflesqueak.model.ClassObject;
+import de.hpi.swa.trufflesqueak.model.NativeObject;
+import de.hpi.swa.trufflesqueak.model.PointersObject;
+import de.hpi.swa.trufflesqueak.nodes.AbstractNode;
+import de.hpi.swa.trufflesqueak.nodes.accessing.AbstractPointersObjectNodes.AbstractPointersObjectWriteNode;
+import de.hpi.swa.trufflesqueak.util.FrameAccess;
+
+public abstract class AbstractCreateFrameArgumentsForIndirectCallNode extends AbstractNode {
+    protected static final Object[] newMessage(final Node node,
+                    final AbstractSqueakObject sender, final Object receiver, final Object[] arguments, final ClassObject receiverClass,
+                    final NativeObject selector, final ClassObject.DispatchFailureResult result,
+                    final SqueakImageContext image,
+                    final InlinedConditionProfile isCannotInterpretProfile,
+                    final AbstractPointersObjectWriteNode writeNode,
+                    final CreateMessageNode createMessageNode) {
+        final PointersObject message;
+        if (isCannotInterpretProfile.profile(node, result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET)) {
+            message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
+        } else {
+            message = image.newMessage(writeNode, selector, receiverClass, arguments);
+        }
+        return FrameAccess.newMessageFallbackWith(sender, receiver, message);
+    }
+}

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/AbstractDispatchNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/AbstractDispatchNode.java
@@ -7,6 +7,7 @@
 package de.hpi.swa.trufflesqueak.nodes.dispatch;
 
 import java.util.Arrays;
+import java.util.function.Supplier;
 
 import com.oracle.truffle.api.Assumption;
 import com.oracle.truffle.api.CompilerDirectives;
@@ -23,156 +24,166 @@ import de.hpi.swa.trufflesqueak.nodes.CacheLimits;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectClassNode;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectClassNodeGen;
 
-public abstract class AbstractDispatchNode extends AbstractNode {
+public abstract class AbstractDispatchNode<T extends AbstractDispatchDirectNode> extends AbstractNode {
+    protected static final byte HAS_FAST = 1 << 0;
+    protected static final byte HAS_WIDE = 1 << 1;
+    protected static final byte HAS_INDIRECT = 1 << 2;
+    protected static final byte FLAG_PRIM_FAIL = 1 << 3;
+
     protected final NativeObject selector;
 
-    AbstractDispatchNode(final NativeObject selector) {
+    @CompilationFinal protected byte state;
+
+    @SuppressWarnings("rawtypes")
+    private static final DispatchEntry[] EMPTY_ENTRIES = new DispatchEntry[0];
+
+    @Children protected DispatchEntry<T>[] fastEntries;
+    @Children protected DispatchEntry<T>[] wideEntries;
+    @Child protected SqueakObjectClassNode classNode;
+
+    @SuppressWarnings("unchecked")
+    AbstractDispatchNode(final NativeObject selector, final boolean canPrimFail) {
         this.selector = selector;
+        this.fastEntries = (DispatchEntry<T>[]) EMPTY_ENTRIES;
+        this.wideEntries = (DispatchEntry<T>[]) EMPTY_ENTRIES;
+        this.state = canPrimFail ? FLAG_PRIM_FAIL : 0;
     }
 
-    // --- Cache Manager and Data Nodes ---
+    protected final boolean canPrimFail() {
+        return (state & FLAG_PRIM_FAIL) != 0;
+    }
 
-    /**
-     * This manager organizes dispatch caching into two distinct tiers to balance compilation size
-     * and execution efficiency, using a parallel array architecture to preserve JIT profiling data.
-     * <p>
-     * 1. Fast Tier ({@code fastEntries}): Caches standard methods and unique fallback scenarios up to a
-     * configured limit ({@code DISPATCH_CACHE_LIMIT}). Each entry maintains a chain of class guards.
-     * <br>
-     * 2. Wide Tier ({@code wideEntries}): Handles class polymorphism. When a standard method exceeds its
-     * allotted class guard limit ({@code LOOKUP_CACHE_LIMIT}) in the fast tier, it is promoted here.
-     * <p>
-     * <b>Unified Entry Architecture:</b><br>
-     * To bypass Truffle's strict tree-parenting constraints during fast-to-wide promotion, the execution
-     * nodes are wrapped in a generic {@code DispatchEntry}. When promoted, the entry drops its fast-tier
-     * AST guards to free memory and is directly moved from the {@code fastEntries} array to the
-     * {@code wideEntries} array within the same parent node.
-     * <p>
-     * The manager is responsible for evaluating lookup results, transitioning nodes between tiers,
-     * pruning invalidated cache entries, and signaling a transition to indirect execution when
-     * the cache capacity is exhausted. Fallback mechanisms (e.g., #doesNotUnderstand) are strictly
-     * isolated in the fast tier and are ineligible for wide tier promotion.
-     *
-     * @param <T> The type of direct dispatch node managed by this cache.
-     */
-    public static final class DispatchCacheManager<T extends AbstractDispatchDirectNode> extends Node {
-        @Children public DispatchEntry<T>[] fastEntries;
-        @Children public DispatchEntry<T>[] wideEntries;
-        @Child public SqueakObjectClassNode classNode;
-
-        @SuppressWarnings("unchecked")
-        public DispatchCacheManager() {
-            this.fastEntries = (DispatchEntry<T>[]) new DispatchEntry<?>[0];
-            this.wideEntries = (DispatchEntry<T>[]) new DispatchEntry<?>[0];
-            this.classNode = insert(SqueakObjectClassNodeGen.create());
+    protected final void ensureClassNode() {
+        if (classNode == null) {
+            CompilerDirectives.transferToInterpreterAndInvalidate();
+            classNode = insert(SqueakObjectClassNodeGen.create());
         }
+    }
 
-        @SuppressWarnings("unchecked")
-        @TruffleBoundary
-        protected T convertToIndirect() {
-            // Safely drop the fast and wide tiers to free memory.
-            this.fastEntries = insert((DispatchEntry<T>[]) new DispatchEntry<?>[0]);
-            this.wideEntries = insert((DispatchEntry<T>[]) new DispatchEntry<?>[0]);
-            this.classNode = null;
-            return null;
-        }
+    @SuppressWarnings("unchecked")
+    @TruffleBoundary
+    protected final T convertToIndirect() {
+        this.fastEntries = (DispatchEntry<T>[]) EMPTY_ENTRIES;
+        this.wideEntries = (DispatchEntry<T>[]) EMPTY_ENTRIES;
+        this.classNode = null;
+        this.state = (byte) ((state & FLAG_PRIM_FAIL) | HAS_INDIRECT);
+        return null;
+    }
 
-        @SuppressWarnings("unchecked")
-        @TruffleBoundary
-        protected T specialize(final Object receiver, final ClassObject receiverClass, final Object lookupResult, final java.util.function.Supplier<T> nodeSupplier) {
-            final DispatchEntry<T>[] newFastEntries = (DispatchEntry<T>[]) new DispatchEntry<?>[CacheLimits.DISPATCH_CACHE_LIMIT];
-            final DispatchEntry<T>[] newWideEntries = (DispatchEntry<T>[]) new DispatchEntry<?>[CacheLimits.DISPATCH_CACHE_LIMIT];
+    @SuppressWarnings("unchecked")
+    @TruffleBoundary
+    protected final T specialize(final Object receiver, final ClassObject receiverClass, final Object lookupResult, final Supplier<T> nodeSupplier) {
+        /*
+         * THREAD SAFETY NOTE:
+         * TruffleSqueak executes Smalltalk strictly on a single thread. Therefore, AST mutations
+         * (like array cloning and Node insertion here) do not require getLock().lock() synchronization.
+         *
+         * If the VM architecture ever transitions to multithreaded execution, this method MUST be
+         * wrapped in the node's intrinsic lock to prevent AST corruption and lost updates.
+         */
 
-            int fastEntriesNeeded = 0;
-            CompiledCodeObject targetMethodToWiden = null;
-            DispatchEntry<T> targetEntry = null;
+        final DispatchEntry<T>[] newFastEntries = (DispatchEntry<T>[]) new DispatchEntry<?>[CacheLimits.DISPATCH_CACHE_LIMIT];
+        final DispatchEntry<T>[] newWideEntries = (DispatchEntry<T>[]) new DispatchEntry<?>[CacheLimits.DISPATCH_CACHE_LIMIT];
 
-            // 1. Prune dead Fast entries and search for coalescing/promotion
-            for (final DispatchEntry<T> current : fastEntries) {
-                if (!current.isFastValid()) {
-                    continue;
-                }
+        int fastEntriesNeeded = 0;
+        CompiledCodeObject targetMethodToWiden = null;
+        DispatchEntry<T> targetEntry = null;
 
-                // Only coalesce standard methods. Fallbacks (null) and OAMs are isolated by class.
-                if (targetEntry == null && lookupResult instanceof CompiledCodeObject targetMethod &&
-                                current.methodOrNull == targetMethod) {
+        for (final DispatchEntry<T> current : fastEntries) {
+            if (!current.isFastValid()) {
+                continue;
+            }
 
-                    // Method matches fast entry: append new guard or transition to wide, if needed.
-                    if (current.guardChainNode.append(receiver, receiverClass, targetMethod)) {
-                        newFastEntries[fastEntriesNeeded++] = current;
-                        targetEntry = current;
-                    } else {
-                        targetMethodToWiden = targetMethod;
-                        targetEntry = current;
-                    }
-                } else {
-                    // Node survives unchanged
+            if (targetEntry == null && lookupResult instanceof CompiledCodeObject targetMethod && current.methodOrNull == targetMethod) {
+                if (current.append(receiver, receiverClass, targetMethod)) {
                     newFastEntries[fastEntriesNeeded++] = current;
+                    targetEntry = current;
+                } else {
+                    targetMethodToWiden = targetMethod;
+                    targetEntry = current;
                 }
+            } else {
+                newFastEntries[fastEntriesNeeded++] = current;
             }
-
-            // 2. Prune dead Wide entries
-            int wideEntriesNeeded = 0;
-            for (final DispatchEntry<T> current : wideEntries) {
-                if (current.isWideValid()) {
-                    newWideEntries[wideEntriesNeeded++] = current;
-                }
-            }
-
-            // 3. Handle Wide transition by mutating and moving the entry
-            if (targetMethodToWiden != null) {
-                targetEntry.promoteToWide();
-                newWideEntries[wideEntriesNeeded++] = targetEntry;
-                this.fastEntries = insert(Arrays.copyOf(newFastEntries, fastEntriesNeeded));
-                this.wideEntries = insert(Arrays.copyOf(newWideEntries, wideEntriesNeeded));
-                return targetEntry.executor;
-            }
-
-            // Make sure Wide entries are up to date (used by Step 4 and 5)
-            if (wideEntriesNeeded != wideEntries.length) {
-                this.wideEntries = insert(Arrays.copyOf(newWideEntries, wideEntriesNeeded));
-            }
-
-            // 4. Return existing appended executor, if found
-            if (targetEntry != null) {
-                // Update AST only if dead fast entries were pruned
-                if (fastEntriesNeeded != fastEntries.length) {
-                    this.fastEntries = insert(Arrays.copyOf(newFastEntries, fastEntriesNeeded));
-                }
-                return targetEntry.executor;
-            }
-
-            // 5. Append new Fast entry, if cache has space
-            if (fastEntriesNeeded + wideEntriesNeeded < CacheLimits.DISPATCH_CACHE_LIMIT) {
-                // Dispatch Node is only built when we need a new entry
-                final T newDispatchNode = nodeSupplier.get();
-                final DispatchEntry<T> newEntry = new DispatchEntry<>(receiver, lookupResult, newDispatchNode);
-                newFastEntries[fastEntriesNeeded++] = newEntry;
-                this.fastEntries = insert(Arrays.copyOf(newFastEntries, fastEntriesNeeded));
-                return newDispatchNode;
-            }
-
-            // Capacity exhausted
-            return convertToIndirect();
         }
+
+        int wideEntriesNeeded = 0;
+        for (final DispatchEntry<T> current : wideEntries) {
+            if (current.isWideValid()) {
+                newWideEntries[wideEntriesNeeded++] = current;
+            }
+        }
+
+        if (targetMethodToWiden != null) {
+            targetEntry.promoteToWide();
+            newWideEntries[wideEntriesNeeded++] = targetEntry;
+            this.fastEntries = insert(Arrays.copyOf(newFastEntries, fastEntriesNeeded));
+            this.wideEntries = insert(Arrays.copyOf(newWideEntries, wideEntriesNeeded));
+            this.state |= HAS_WIDE;
+            if (fastEntriesNeeded > 0) {
+                this.state |= HAS_FAST;
+            } else {
+                this.state &= ~HAS_FAST;
+            }
+            return targetEntry.executor;
+        }
+
+        if (wideEntriesNeeded != wideEntries.length) {
+            this.wideEntries = insert(Arrays.copyOf(newWideEntries, wideEntriesNeeded));
+        }
+
+        if (targetEntry != null) {
+            if (fastEntriesNeeded != fastEntries.length) {
+                this.fastEntries = insert(Arrays.copyOf(newFastEntries, fastEntriesNeeded));
+            }
+            return targetEntry.executor;
+        }
+
+        if (fastEntriesNeeded + wideEntriesNeeded < CacheLimits.DISPATCH_CACHE_LIMIT) {
+            final T newDispatchNode = nodeSupplier.get();
+            final DispatchEntry<T> newEntry = new DispatchEntry<>(receiver, lookupResult, newDispatchNode);
+            newFastEntries[fastEntriesNeeded++] = newEntry;
+            this.fastEntries = insert(Arrays.copyOf(newFastEntries, fastEntriesNeeded));
+            this.state |= HAS_FAST;
+            return newDispatchNode;
+        }
+
+        return convertToIndirect();
     }
 
     public static final class DispatchEntry<T extends AbstractDispatchDirectNode> extends Node {
         public final CompiledCodeObject methodOrNull;
         @CompilationFinal public final Assumption callTargetStable;
 
-        @Child public GuardChainNode guardChainNode;
+        @CompilationFinal(dimensions = 1) private LookupClassGuard[] guards;
+        @CompilationFinal(dimensions = 1) private Assumption[] unifiedAssumptions;
+
         @Child public T executor;
 
         public DispatchEntry(final Object receiver, final Object lookupResult, final T executor) {
             this.methodOrNull = lookupResult instanceof CompiledCodeObject m ? m : null;
             this.callTargetStable = methodOrNull != null ? methodOrNull.getCallTargetStable() : null;
-            this.guardChainNode = insert(new GuardChainNode(receiver, executor.getAssumptions()));
+            this.guards = new LookupClassGuard[]{LookupClassGuard.create(receiver)};
+            this.unifiedAssumptions = executor.getAssumptions();
             this.executor = insert(executor);
         }
 
+        @ExplodeLoop
         public boolean isFastCacheHit(final Object receiver) {
-            return guardChainNode.execute(receiver);
+            if (!Assumption.isValidAssumption(unifiedAssumptions)) {
+                CompilerDirectives.transferToInterpreterAndInvalidate();
+                return false;
+            }
+
+            final LookupClassGuard[] currentGuards = guards;
+            if (currentGuards != null) {
+                for (int i = 0; i < currentGuards.length; i++) {
+                    if (currentGuards[i].check(receiver)) {
+                        return true;
+                    }
+                }
+            }
+            return false;
         }
 
         public boolean isWideCacheHit(final CompiledCodeObject targetMethod) {
@@ -180,8 +191,7 @@ public abstract class AbstractDispatchNode extends AbstractNode {
         }
 
         public boolean isFastValid() {
-            final GuardChainNode chain = guardChainNode;
-            return chain != null && chain.hasValidGuards();
+            return guards != null && Assumption.isValidAssumption(unifiedAssumptions);
         }
 
         public boolean isWideValid() {
@@ -189,112 +199,42 @@ public abstract class AbstractDispatchNode extends AbstractNode {
         }
 
         public void promoteToWide() {
-            this.guardChainNode = null; // Drop fast-tier receiver checking to free memory
-        }
-    }
-
-    public static final class GuardChainNode extends AbstractNode {
-        @CompilationFinal(dimensions = 1) private LookupClassGuard[] guards;
-        @CompilationFinal(dimensions = 2) private Assumption[][] assumptions;
-
-        public GuardChainNode(final Object receiver, final Assumption[] initialAssumptions) {
-            this.guards = new LookupClassGuard[]{LookupClassGuard.create(receiver)};
-            this.assumptions = new Assumption[][]{initialAssumptions};
-        }
-
-        public boolean isEmpty() {
-            return guards.length == 0;
-        }
-
-        public boolean hasValidGuards() {
-            final Assumption[][] currentAssumptions = assumptions;
-            for (int i = 0; i < currentAssumptions.length; i++) {
-                if (Assumption.isValidAssumption(currentAssumptions[i])) {
-                    return true; // At least one guard is still alive
-                }
-            }
-            return false;
-        }
-
-        @ExplodeLoop
-        public boolean execute(final Object receiver) {
-            final LookupClassGuard[] currentGuards = guards;
-            final Assumption[][] currentAssumptions = assumptions;
-
-            for (int i = 0; i < currentGuards.length; i++) {
-                if (currentGuards[i].check(receiver)) {
-                    if (Assumption.isValidAssumption(currentAssumptions[i])) {
-                        return true;
-                    } else {
-                        CompilerDirectives.transferToInterpreterAndInvalidate();
-                        removeInvalid(currentGuards, currentAssumptions);
-                        return false;
-                    }
-                }
-            }
-            return false;
+            this.guards = null; // Drop fast-tier receiver checking to free memory
         }
 
         public boolean append(final Object receiver, final ClassObject receiverClass, final CompiledCodeObject targetMethod) {
-            final Assumption[][] currentAssumptions = assumptions;
-            int validCount = 0;
-
-            for (int i = 0; i < currentAssumptions.length; i++) {
-                if (Assumption.isValidAssumption(currentAssumptions[i])) {
-                    validCount++;
-                }
+            if (!Assumption.isValidAssumption(unifiedAssumptions)) {
+                return false;
             }
-
-            if (validCount >= CacheLimits.LOOKUP_CACHE_LIMIT) {
+            if (guards.length >= CacheLimits.LOOKUP_CACHE_LIMIT) {
                 return false;
             }
 
-            // Generate and add the new assumptions
-            final Assumption[] newAssumptions = DispatchUtils.createAssumptions(receiverClass, targetMethod);
-
-            final LookupClassGuard[] newGuards = new LookupClassGuard[validCount + 1];
-            final Assumption[][] newAssumptionsArray = new Assumption[validCount + 1][];
-
-            int index = 0;
-            for (int i = 0; i < currentAssumptions.length; i++) {
-                if (Assumption.isValidAssumption(currentAssumptions[i])) {
-                    newGuards[index] = guards[i];
-                    newAssumptionsArray[index] = currentAssumptions[i];
-                    index++;
-                }
-            }
-
-            newGuards[index] = LookupClassGuard.create(receiver);
-            newAssumptionsArray[index] = newAssumptions;
-
+            // Append Guard
+            final LookupClassGuard[] newGuards = Arrays.copyOf(guards, guards.length + 1);
+            newGuards[guards.length] = LookupClassGuard.create(receiver);
             this.guards = newGuards;
-            this.assumptions = newAssumptionsArray;
+
+            // Union Assumptions
+            Assumption[] newAssumptions = DispatchUtils.createAssumptions(receiverClass, targetMethod);
+            if (newAssumptions.length > 0) {
+                Assumption[] merged = Arrays.copyOf(unifiedAssumptions, unifiedAssumptions.length + newAssumptions.length);
+                int count = unifiedAssumptions.length;
+                for (Assumption newA : newAssumptions) {
+                    boolean exists = false;
+                    for (int i = 0; i < count; i++) {
+                        if (merged[i] == newA) {
+                            exists = true;
+                            break;
+                        }
+                    }
+                    if (!exists) {
+                        merged[count++] = newA;
+                    }
+                }
+                this.unifiedAssumptions = Arrays.copyOf(merged, count);
+            }
             return true;
-        }
-
-        @TruffleBoundary
-        private void removeInvalid(final LookupClassGuard[] currentGuards, final Assumption[][] currentAssumptions) {
-            int validCount = 0;
-            for (int i = 0; i < currentAssumptions.length; i++) {
-                if (Assumption.isValidAssumption(currentAssumptions[i])) {
-                    validCount++;
-                }
-            }
-
-            final LookupClassGuard[] newGuards = new LookupClassGuard[validCount];
-            final Assumption[][] newAssumptionsArray = new Assumption[validCount][];
-
-            int index = 0;
-            for (int i = 0; i < currentAssumptions.length; i++) {
-                if (Assumption.isValidAssumption(currentAssumptions[i])) {
-                    newGuards[index] = currentGuards[i];
-                    newAssumptionsArray[index] = currentAssumptions[i];
-                    index++;
-                }
-            }
-
-            this.guards = newGuards;
-            this.assumptions = newAssumptionsArray;
         }
     }
 }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/AbstractDispatchNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/AbstractDispatchNode.java
@@ -6,14 +6,279 @@
  */
 package de.hpi.swa.trufflesqueak.nodes.dispatch;
 
+import java.util.Arrays;
+
+import com.oracle.truffle.api.Assumption;
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.nodes.ExplodeLoop;
+import com.oracle.truffle.api.nodes.Node;
+
+import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
 import de.hpi.swa.trufflesqueak.model.NativeObject;
 import de.hpi.swa.trufflesqueak.nodes.AbstractNode;
+import de.hpi.swa.trufflesqueak.nodes.CacheLimits;
+import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectClassNode;
+import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectClassNodeGen;
 
 public abstract class AbstractDispatchNode extends AbstractNode {
     protected final NativeObject selector;
 
     AbstractDispatchNode(final NativeObject selector) {
         this.selector = selector;
+    }
+
+    // --- Cache Manager and Data Nodes ---
+
+    /**
+     * This manager organizes dispatch caching into two distinct tiers to balance compilation size
+     * and execution efficiency, using a parallel array architecture to preserve JIT profiling data.
+     * <p>
+     * 1. Fast Tier ({@code fastEntries}): Caches standard methods and unique fallback scenarios up to a
+     * configured limit ({@code DISPATCH_CACHE_LIMIT}). Each entry maintains a chain of class guards.
+     * <br>
+     * 2. Wide Tier ({@code wideEntries}): Handles class polymorphism. When a standard method exceeds its
+     * allotted class guard limit ({@code LOOKUP_CACHE_LIMIT}) in the fast tier, it is promoted here.
+     * <p>
+     * <b>Unified Entry Architecture:</b><br>
+     * To bypass Truffle's strict tree-parenting constraints during fast-to-wide promotion, the execution
+     * nodes are wrapped in a generic {@code DispatchEntry}. When promoted, the entry drops its fast-tier
+     * AST guards to free memory and is directly moved from the {@code fastEntries} array to the
+     * {@code wideEntries} array within the same parent node.
+     * <p>
+     * The manager is responsible for evaluating lookup results, transitioning nodes between tiers,
+     * pruning invalidated cache entries, and signaling a transition to indirect execution when
+     * the cache capacity is exhausted. Fallback mechanisms (e.g., #doesNotUnderstand) are strictly
+     * isolated in the fast tier and are ineligible for wide tier promotion.
+     *
+     * @param <T> The type of direct dispatch node managed by this cache.
+     */
+    public static final class DispatchCacheManager<T extends AbstractDispatchDirectNode> extends Node {
+        @Children public DispatchEntry<T>[] fastEntries;
+        @Children public DispatchEntry<T>[] wideEntries;
+        @Child public SqueakObjectClassNode classNode;
+
+        @SuppressWarnings("unchecked")
+        public DispatchCacheManager() {
+            this.fastEntries = (DispatchEntry<T>[]) new DispatchEntry<?>[0];
+            this.wideEntries = (DispatchEntry<T>[]) new DispatchEntry<?>[0];
+            this.classNode = insert(SqueakObjectClassNodeGen.create());
+        }
+
+        @SuppressWarnings("unchecked")
+        @TruffleBoundary
+        protected T convertToIndirect() {
+            // Safely drop the fast and wide tiers to free memory.
+            this.fastEntries = insert((DispatchEntry<T>[]) new DispatchEntry<?>[0]);
+            this.wideEntries = insert((DispatchEntry<T>[]) new DispatchEntry<?>[0]);
+            this.classNode = null;
+            return null;
+        }
+
+        @SuppressWarnings("unchecked")
+        @TruffleBoundary
+        protected T specialize(final Object receiver, final Object lookupResult, final T newDispatchNode) {
+            final DispatchEntry<T>[] newFastEntries = (DispatchEntry<T>[]) new DispatchEntry<?>[CacheLimits.DISPATCH_CACHE_LIMIT];
+            final DispatchEntry<T>[] newWideEntries = (DispatchEntry<T>[]) new DispatchEntry<?>[CacheLimits.DISPATCH_CACHE_LIMIT];
+
+            int fastEntriesNeeded = 0;
+            CompiledCodeObject targetMethodToWiden = null;
+            DispatchEntry<T> targetEntry = null;
+
+            // 1. Prune dead Fast entries and search for coalescing/promotion
+            for (final DispatchEntry<T> current : fastEntries) {
+                if (!current.isFastValid()) {
+                    continue;
+                }
+
+                // Only coalesce standard methods. Fallbacks (null) and OAMs are isolated by class.
+                if (targetEntry == null && lookupResult instanceof CompiledCodeObject targetMethod &&
+                                current.methodOrNull == targetMethod &&
+                                current.executor.getClass() == newDispatchNode.getClass()) {
+
+                    // Method matches fast entry: append new guard or transition to wide, if needed.
+                    if (current.guardChainNode.append(receiver, newDispatchNode.getAssumptions())) {
+                        newFastEntries[fastEntriesNeeded++] = current;
+                        targetEntry = current;
+                    } else {
+                        targetMethodToWiden = targetMethod;
+                        targetEntry = current;
+                    }
+                } else {
+                    // Node survives unchanged
+                    newFastEntries[fastEntriesNeeded++] = current;
+                }
+            }
+
+            // 2. Prune dead Wide entries
+            int wideEntriesNeeded = 0;
+            for (final DispatchEntry<T> current : wideEntries) {
+                if (current.isWideValid()) {
+                    newWideEntries[wideEntriesNeeded++] = current;
+                }
+            }
+
+            // 3. Handle Wide transition by mutating and moving the entry
+            if (targetMethodToWiden != null) {
+                targetEntry.promoteToWide();
+                newWideEntries[wideEntriesNeeded++] = targetEntry;
+                this.fastEntries = insert(Arrays.copyOf(newFastEntries, fastEntriesNeeded));
+                this.wideEntries = insert(Arrays.copyOf(newWideEntries, wideEntriesNeeded));
+                return targetEntry.executor;
+            }
+
+            // Make sure Wide entries are up to date (used by Step 4 and 5)
+            if (wideEntriesNeeded != wideEntries.length) {
+                this.wideEntries = insert(Arrays.copyOf(newWideEntries, wideEntriesNeeded));
+            }
+
+            // 4. Return existing appended executor, if found
+            if (targetEntry != null) {
+                // Update AST only if dead fast entries were pruned
+                if (fastEntriesNeeded != fastEntries.length) {
+                    this.fastEntries = insert(Arrays.copyOf(newFastEntries, fastEntriesNeeded));
+                }
+                return targetEntry.executor;
+            }
+
+            // 5. Append new Fast entry, if cache has space
+            if (fastEntriesNeeded + wideEntriesNeeded < CacheLimits.DISPATCH_CACHE_LIMIT) {
+                final DispatchEntry<T> newEntry = new DispatchEntry<>(receiver, lookupResult, newDispatchNode);
+                newFastEntries[fastEntriesNeeded++] = newEntry;
+                this.fastEntries = insert(Arrays.copyOf(newFastEntries, fastEntriesNeeded));
+                return newDispatchNode;
+            }
+
+            // Capacity exhausted
+            return convertToIndirect();
+        }
+    }
+
+    public static final class DispatchEntry<T extends AbstractDispatchDirectNode> extends Node {
+        public final CompiledCodeObject methodOrNull;
+        @CompilationFinal(dimensions = 1) public final Assumption[] assumptions;
+
+        @Child public GuardChainNode guardChainNode;
+        @Child public T executor;
+
+        public DispatchEntry(final Object receiver, final Object lookupResult, final T executor) {
+            this.methodOrNull = lookupResult instanceof CompiledCodeObject m ? m : null;
+            this.assumptions = executor.getAssumptions();
+            this.guardChainNode = insert(new GuardChainNode(receiver, this.assumptions));
+            this.executor = insert(executor);
+        }
+
+        public boolean isFastCacheHit(final Object receiver) {
+            final GuardChainNode chain = this.guardChainNode;
+            if (chain == null) {
+                return false;
+            }
+            return chain.execute(receiver);
+        }
+
+        public boolean isWideCacheHit(final CompiledCodeObject targetMethod) {
+            return methodOrNull == targetMethod && Assumption.isValidAssumption(assumptions);
+        }
+
+        public boolean isFastValid() {
+            final GuardChainNode chain = this.guardChainNode;
+            return chain != null && !chain.isEmpty();
+        }
+
+        public boolean isWideValid() {
+            return Assumption.isValidAssumption(assumptions);
+        }
+
+        public void promoteToWide() {
+            this.guardChainNode = null; // Drop fast-tier receiver checking to free memory
+        }
+    }
+
+    public static final class GuardChainNode extends AbstractNode {
+        @Children private GuardChainDataNode[] guards;
+
+        public GuardChainNode(final Object receiver, final Assumption[] assumptions) {
+            this.guards = insert(new GuardChainDataNode[]{new GuardChainDataNode(receiver, assumptions)});
+        }
+
+        public boolean isEmpty() {
+            return guards.length == 0;
+        }
+
+        @ExplodeLoop
+        public boolean execute(final Object receiver) {
+            final GuardChainDataNode[] currentGuards = this.guards;
+            for (int i = 0; i < currentGuards.length; i++) {
+                final GuardChainDataNode current = currentGuards[i];
+
+                if (current.guard.check(receiver)) {
+                    if (Assumption.isValidAssumption(current.assumptions)) {
+                        return true;
+                    } else {
+                        CompilerDirectives.transferToInterpreterAndInvalidate();
+                        removeInvalid(currentGuards);
+                        return false;
+                    }
+                }
+            }
+            return false;
+        }
+
+        public boolean append(final Object receiver, final Assumption[] assumptions) {
+            int validCount = 0;
+            for (final GuardChainDataNode guard : guards) {
+                if (Assumption.isValidAssumption(guard.assumptions)) {
+                    validCount++;
+                }
+            }
+
+            if (validCount >= CacheLimits.LOOKUP_CACHE_LIMIT) {
+                return false;
+            }
+
+            final GuardChainDataNode[] newGuards = new GuardChainDataNode[validCount + 1];
+            int index = 0;
+            for (final GuardChainDataNode guard : guards) {
+                if (Assumption.isValidAssumption(guard.assumptions)) {
+                    newGuards[index++] = guard;
+                }
+            }
+
+            newGuards[index] = new GuardChainDataNode(receiver, assumptions);
+            this.guards = insert(newGuards);
+            return true;
+        }
+
+        @TruffleBoundary
+        private void removeInvalid(final GuardChainDataNode[] currentGuards) {
+            int validCount = 0;
+            for (final GuardChainDataNode node : currentGuards) {
+                if (Assumption.isValidAssumption(node.assumptions)) {
+                    validCount++;
+                }
+            }
+
+            final GuardChainDataNode[] newGuards = new GuardChainDataNode[validCount];
+            int index = 0;
+            for (final GuardChainDataNode node : currentGuards) {
+                if (Assumption.isValidAssumption(node.assumptions)) {
+                    newGuards[index++] = node;
+                }
+            }
+
+            this.guards = insert(newGuards);
+        }
+    }
+
+    public static final class GuardChainDataNode extends Node {
+        public final LookupClassGuard guard;
+        @CompilationFinal(dimensions = 1) public final Assumption[] assumptions;
+
+        public GuardChainDataNode(final Object receiver, final Assumption[] assumptions) {
+            this.guard = LookupClassGuard.create(receiver);
+            this.assumptions = assumptions;
+        }
     }
 
     @Override

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/AbstractDispatchNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/AbstractDispatchNode.java
@@ -172,11 +172,7 @@ public abstract class AbstractDispatchNode extends AbstractNode {
         }
 
         public boolean isFastCacheHit(final Object receiver) {
-            final GuardChainNode chain = this.guardChainNode;
-            if (chain == null) {
-                return false;
-            }
-            return chain.execute(receiver);
+            return guardChainNode.execute(receiver);
         }
 
         public boolean isWideCacheHit(final CompiledCodeObject targetMethod) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/AbstractDispatchNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/AbstractDispatchNode.java
@@ -15,6 +15,7 @@ import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.Node;
 
+import de.hpi.swa.trufflesqueak.model.ClassObject;
 import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
 import de.hpi.swa.trufflesqueak.model.NativeObject;
 import de.hpi.swa.trufflesqueak.nodes.AbstractNode;
@@ -78,7 +79,7 @@ public abstract class AbstractDispatchNode extends AbstractNode {
 
         @SuppressWarnings("unchecked")
         @TruffleBoundary
-        protected T specialize(final Object receiver, final Object lookupResult, final T newDispatchNode) {
+        protected T specialize(final Object receiver, final ClassObject receiverClass, final Object lookupResult, final java.util.function.Supplier<T> nodeSupplier) {
             final DispatchEntry<T>[] newFastEntries = (DispatchEntry<T>[]) new DispatchEntry<?>[CacheLimits.DISPATCH_CACHE_LIMIT];
             final DispatchEntry<T>[] newWideEntries = (DispatchEntry<T>[]) new DispatchEntry<?>[CacheLimits.DISPATCH_CACHE_LIMIT];
 
@@ -94,11 +95,10 @@ public abstract class AbstractDispatchNode extends AbstractNode {
 
                 // Only coalesce standard methods. Fallbacks (null) and OAMs are isolated by class.
                 if (targetEntry == null && lookupResult instanceof CompiledCodeObject targetMethod &&
-                                current.methodOrNull == targetMethod &&
-                                current.executor.getClass() == newDispatchNode.getClass()) {
+                                current.methodOrNull == targetMethod) {
 
                     // Method matches fast entry: append new guard or transition to wide, if needed.
-                    if (current.guardChainNode.append(receiver, newDispatchNode.getAssumptions())) {
+                    if (current.guardChainNode.append(receiver, receiverClass, targetMethod)) {
                         newFastEntries[fastEntriesNeeded++] = current;
                         targetEntry = current;
                     } else {
@@ -144,6 +144,8 @@ public abstract class AbstractDispatchNode extends AbstractNode {
 
             // 5. Append new Fast entry, if cache has space
             if (fastEntriesNeeded + wideEntriesNeeded < CacheLimits.DISPATCH_CACHE_LIMIT) {
+                // Dispatch Node is only built when we need a new entry
+                final T newDispatchNode = nodeSupplier.get();
                 final DispatchEntry<T> newEntry = new DispatchEntry<>(receiver, lookupResult, newDispatchNode);
                 newFastEntries[fastEntriesNeeded++] = newEntry;
                 this.fastEntries = insert(Arrays.copyOf(newFastEntries, fastEntriesNeeded));
@@ -157,15 +159,15 @@ public abstract class AbstractDispatchNode extends AbstractNode {
 
     public static final class DispatchEntry<T extends AbstractDispatchDirectNode> extends Node {
         public final CompiledCodeObject methodOrNull;
-        @CompilationFinal(dimensions = 1) public final Assumption[] assumptions;
+        @CompilationFinal public final Assumption callTargetStable;
 
         @Child public GuardChainNode guardChainNode;
         @Child public T executor;
 
         public DispatchEntry(final Object receiver, final Object lookupResult, final T executor) {
             this.methodOrNull = lookupResult instanceof CompiledCodeObject m ? m : null;
-            this.assumptions = executor.getAssumptions();
-            this.guardChainNode = insert(new GuardChainNode(receiver, this.assumptions));
+            this.callTargetStable = methodOrNull != null ? methodOrNull.getCallTargetStable() : null;
+            this.guardChainNode = insert(new GuardChainNode(receiver, executor.getAssumptions()));
             this.executor = insert(executor);
         }
 
@@ -178,16 +180,16 @@ public abstract class AbstractDispatchNode extends AbstractNode {
         }
 
         public boolean isWideCacheHit(final CompiledCodeObject targetMethod) {
-            return methodOrNull == targetMethod && Assumption.isValidAssumption(assumptions);
+            return methodOrNull == targetMethod && Assumption.isValidAssumption(callTargetStable);
         }
 
         public boolean isFastValid() {
-            final GuardChainNode chain = this.guardChainNode;
-            return chain != null && !chain.isEmpty();
+            final GuardChainNode chain = guardChainNode;
+            return chain != null && chain.hasValidGuards();
         }
 
         public boolean isWideValid() {
-            return Assumption.isValidAssumption(assumptions);
+            return methodOrNull != null && Assumption.isValidAssumption(callTargetStable);
         }
 
         public void promoteToWide() {
@@ -196,28 +198,40 @@ public abstract class AbstractDispatchNode extends AbstractNode {
     }
 
     public static final class GuardChainNode extends AbstractNode {
-        @Children private GuardChainDataNode[] guards;
+        @CompilationFinal(dimensions = 1) private LookupClassGuard[] guards;
+        @CompilationFinal(dimensions = 2) private Assumption[][] assumptions;
 
-        public GuardChainNode(final Object receiver, final Assumption[] assumptions) {
-            this.guards = insert(new GuardChainDataNode[]{new GuardChainDataNode(receiver, assumptions)});
+        public GuardChainNode(final Object receiver, final Assumption[] initialAssumptions) {
+            this.guards = new LookupClassGuard[]{LookupClassGuard.create(receiver)};
+            this.assumptions = new Assumption[][]{initialAssumptions};
         }
 
         public boolean isEmpty() {
             return guards.length == 0;
         }
 
+        public boolean hasValidGuards() {
+            final Assumption[][] currentAssumptions = assumptions;
+            for (int i = 0; i < currentAssumptions.length; i++) {
+                if (Assumption.isValidAssumption(currentAssumptions[i])) {
+                    return true; // At least one guard is still alive
+                }
+            }
+            return false;
+        }
+
         @ExplodeLoop
         public boolean execute(final Object receiver) {
-            final GuardChainDataNode[] currentGuards = this.guards;
-            for (int i = 0; i < currentGuards.length; i++) {
-                final GuardChainDataNode current = currentGuards[i];
+            final LookupClassGuard[] currentGuards = guards;
+            final Assumption[][] currentAssumptions = assumptions;
 
-                if (current.guard.check(receiver)) {
-                    if (Assumption.isValidAssumption(current.assumptions)) {
+            for (int i = 0; i < currentGuards.length; i++) {
+                if (currentGuards[i].check(receiver)) {
+                    if (Assumption.isValidAssumption(currentAssumptions[i])) {
                         return true;
                     } else {
                         CompilerDirectives.transferToInterpreterAndInvalidate();
-                        removeInvalid(currentGuards);
+                        removeInvalid(currentGuards, currentAssumptions);
                         return false;
                     }
                 }
@@ -225,10 +239,12 @@ public abstract class AbstractDispatchNode extends AbstractNode {
             return false;
         }
 
-        public boolean append(final Object receiver, final Assumption[] assumptions) {
+        public boolean append(final Object receiver, final ClassObject receiverClass, final CompiledCodeObject targetMethod) {
+            final Assumption[][] currentAssumptions = assumptions;
             int validCount = 0;
-            for (final GuardChainDataNode guard : guards) {
-                if (Assumption.isValidAssumption(guard.assumptions)) {
+
+            for (int i = 0; i < currentAssumptions.length; i++) {
+                if (Assumption.isValidAssumption(currentAssumptions[i])) {
                     validCount++;
                 }
             }
@@ -237,52 +253,52 @@ public abstract class AbstractDispatchNode extends AbstractNode {
                 return false;
             }
 
-            final GuardChainDataNode[] newGuards = new GuardChainDataNode[validCount + 1];
+            // Generate and add the new assumptions
+            final Assumption[] newAssumptions = DispatchUtils.createAssumptions(receiverClass, targetMethod);
+
+            final LookupClassGuard[] newGuards = new LookupClassGuard[validCount + 1];
+            final Assumption[][] newAssumptionsArray = new Assumption[validCount + 1][];
+
             int index = 0;
-            for (final GuardChainDataNode guard : guards) {
-                if (Assumption.isValidAssumption(guard.assumptions)) {
-                    newGuards[index++] = guard;
+            for (int i = 0; i < currentAssumptions.length; i++) {
+                if (Assumption.isValidAssumption(currentAssumptions[i])) {
+                    newGuards[index] = guards[i];
+                    newAssumptionsArray[index] = currentAssumptions[i];
+                    index++;
                 }
             }
 
-            newGuards[index] = new GuardChainDataNode(receiver, assumptions);
-            this.guards = insert(newGuards);
+            newGuards[index] = LookupClassGuard.create(receiver);
+            newAssumptionsArray[index] = newAssumptions;
+
+            this.guards = newGuards;
+            this.assumptions = newAssumptionsArray;
             return true;
         }
 
         @TruffleBoundary
-        private void removeInvalid(final GuardChainDataNode[] currentGuards) {
+        private void removeInvalid(final LookupClassGuard[] currentGuards, final Assumption[][] currentAssumptions) {
             int validCount = 0;
-            for (final GuardChainDataNode node : currentGuards) {
-                if (Assumption.isValidAssumption(node.assumptions)) {
+            for (int i = 0; i < currentAssumptions.length; i++) {
+                if (Assumption.isValidAssumption(currentAssumptions[i])) {
                     validCount++;
                 }
             }
 
-            final GuardChainDataNode[] newGuards = new GuardChainDataNode[validCount];
+            final LookupClassGuard[] newGuards = new LookupClassGuard[validCount];
+            final Assumption[][] newAssumptionsArray = new Assumption[validCount][];
+
             int index = 0;
-            for (final GuardChainDataNode node : currentGuards) {
-                if (Assumption.isValidAssumption(node.assumptions)) {
-                    newGuards[index++] = node;
+            for (int i = 0; i < currentAssumptions.length; i++) {
+                if (Assumption.isValidAssumption(currentAssumptions[i])) {
+                    newGuards[index] = currentGuards[i];
+                    newAssumptionsArray[index] = currentAssumptions[i];
+                    index++;
                 }
             }
 
-            this.guards = insert(newGuards);
+            this.guards = newGuards;
+            this.assumptions = newAssumptionsArray;
         }
-    }
-
-    public static final class GuardChainDataNode extends Node {
-        public final LookupClassGuard guard;
-        @CompilationFinal(dimensions = 1) public final Assumption[] assumptions;
-
-        public GuardChainDataNode(final Object receiver, final Assumption[] assumptions) {
-            this.guard = LookupClassGuard.create(receiver);
-            this.assumptions = assumptions;
-        }
-    }
-
-    @Override
-    public final String toString() {
-        return "send: " + selector.toString();
     }
 }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/AbstractDispatchNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/AbstractDispatchNode.java
@@ -144,6 +144,37 @@ public abstract class AbstractDispatchNode<T extends AbstractDispatchDirectNode>
         this.wideEntries = EMPTY_ENTRIES;
     }
 
+    private DispatchEntry<T> findTargetFastEntry(final Object lookupResult) {
+        if (lookupResult instanceof CompiledCodeObject targetMethod) {
+            for (final DispatchEntry<T> current : fastEntries) {
+                if (current.isFastValid() && current.methodOrNull == targetMethod) {
+                    return current;
+                }
+            }
+        }
+        return null;
+    }
+
+    private int filterFastEntries(final DispatchEntry<T>[] newFastEntries) {
+        int count = 0;
+        for (final DispatchEntry<T> current : fastEntries) {
+            if (current.isFastValid()) {
+                newFastEntries[count++] = current;
+            }
+        }
+        return count;
+    }
+
+    private int filterWideEntries(final DispatchEntry<T>[] newWideEntries) {
+        int count = 0;
+        for (final DispatchEntry<T> current : wideEntries) {
+            if (current.isWideValid()) {
+                newWideEntries[count++] = current;
+            }
+        }
+        return count;
+    }
+
     /*
      * Note on concurrency: Smalltalk execution is strictly single-threaded.
      * If multiple OS threads of execution are ever permitted in the VM,
@@ -171,45 +202,29 @@ public abstract class AbstractDispatchNode<T extends AbstractDispatchDirectNode>
         final DispatchEntry<T>[] newFastEntries = (DispatchEntry<T>[]) new DispatchEntry<?>[CacheLimits.DISPATCH_CACHE_LIMIT];
         final DispatchEntry<T>[] newWideEntries = (DispatchEntry<T>[]) new DispatchEntry<?>[CacheLimits.DISPATCH_CACHE_LIMIT];
 
-        int fastEntriesNeeded = 0;
-        CompiledCodeObject targetMethodToWiden = null;
-        DispatchEntry<T> targetEntry = null;
+        // 2. Find target and determine if we need to promote to Wide
+        final DispatchEntry<T> targetEntry = findTargetFastEntry(lookupResult);
+        boolean needsWidening = false;
 
-        // 2. Process Fast Entries
-        for (final DispatchEntry<T> current : fastEntries) {
-            if (!current.isFastValid()) {
-                continue;
-            }
-
-            if (targetEntry == null && lookupResult instanceof CompiledCodeObject targetMethod && current.methodOrNull == targetMethod) {
-                if (current.append(receiver, receiverClass, targetMethod)) {
-                    newFastEntries[fastEntriesNeeded++] = current;
-                    targetEntry = current;
-                } else {
-                    targetMethodToWiden = targetMethod;
-                    targetEntry = current;
-                }
-            } else {
-                newFastEntries[fastEntriesNeeded++] = current;
+        if (targetEntry != null) {
+            needsWidening = !targetEntry.append(receiver, receiverClass, (CompiledCodeObject) lookupResult);
+            if (needsWidening) {
+                // This nulls the guards, causing the filter below to remove the Fast entry.
+                targetEntry.promoteToWide();
             }
         }
 
-        // 3. Process Wide Entries
-        int wideEntriesNeeded = 0;
-        for (final DispatchEntry<T> current : wideEntries) {
-            if (current.isWideValid()) {
-                newWideEntries[wideEntriesNeeded++] = current;
-            }
-        }
+        // 3. Filter valid entries.
+        int fastCount = filterFastEntries(newFastEntries);
+        int wideCount = filterWideEntries(newWideEntries);
 
-        // 4. Handle Wide Promotion
-        if (targetMethodToWiden != null) {
-            targetEntry.promoteToWide();
-            newWideEntries[wideEntriesNeeded++] = targetEntry;
-            this.fastEntries = insert(Arrays.copyOf(newFastEntries, fastEntriesNeeded));
-            this.wideEntries = insert(Arrays.copyOf(newWideEntries, wideEntriesNeeded));
+        // 4. Reassign Fast entry to Wide list, if needed.
+        if (needsWidening) {
+            newWideEntries[wideCount++] = targetEntry;
+            this.fastEntries = insert(Arrays.copyOf(newFastEntries, fastCount));
+            this.wideEntries = insert(Arrays.copyOf(newWideEntries, wideCount));
             this.state |= HAS_WIDE;
-            if (fastEntriesNeeded > 0) {
+            if (fastCount > 0) {
                 this.state |= HAS_FAST;
             } else {
                 this.state &= ~HAS_FAST;
@@ -217,23 +232,24 @@ public abstract class AbstractDispatchNode<T extends AbstractDispatchDirectNode>
             return targetEntry.executor;
         }
 
-        if (wideEntriesNeeded != wideEntries.length) {
-            this.wideEntries = insert(Arrays.copyOf(newWideEntries, wideEntriesNeeded));
+        // 5. Update arrays for successful Fast append or invalid entry cleanup.
+        if (wideCount != wideEntries.length) {
+            this.wideEntries = insert(Arrays.copyOf(newWideEntries, wideCount));
         }
 
         if (targetEntry != null) {
-            if (fastEntriesNeeded != fastEntries.length) {
-                this.fastEntries = insert(Arrays.copyOf(newFastEntries, fastEntriesNeeded));
+            if (fastCount != fastEntries.length) {
+                this.fastEntries = insert(Arrays.copyOf(newFastEntries, fastCount));
             }
             return targetEntry.executor;
         }
 
-        // 5. Append New Fast Entry
-        if (fastEntriesNeeded + wideEntriesNeeded < CacheLimits.DISPATCH_CACHE_LIMIT) {
+        // 6. Append New Fast Entry
+        if (fastCount + wideCount < CacheLimits.DISPATCH_CACHE_LIMIT) {
             final T newDispatchNode = nodeSupplier.get();
             final DispatchEntry<T> newEntry = new DispatchEntry<>(receiver, lookupResult, newDispatchNode);
-            newFastEntries[fastEntriesNeeded++] = newEntry;
-            this.fastEntries = insert(Arrays.copyOf(newFastEntries, fastEntriesNeeded));
+            newFastEntries[fastCount++] = newEntry;
+            this.fastEntries = insert(Arrays.copyOf(newFastEntries, fastCount));
             this.state |= HAS_FAST;
             return newDispatchNode;
         }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/AbstractDispatchNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/AbstractDispatchNode.java
@@ -98,6 +98,39 @@ public abstract class AbstractDispatchNode<T extends AbstractDispatchDirectNode>
         return Arrays.copyOf(merged, count);
     }
 
+    private T initializeMono(final Object receiver, final Supplier<T> nodeSupplier) {
+        this.monoExecutor = insert(nodeSupplier.get());
+        this.monoGuard = LookupClassGuard.create(receiver);
+        this.state |= HAS_MONO;
+        return monoExecutor;
+    }
+
+    @SuppressWarnings("unchecked")
+    private T transitionMonoToFast(final Object receiver, final ClassObject receiverClass, final Object lookupResult, final Supplier<T> nodeSupplier) {
+        final Assumption[] originalAssumptions = monoExecutor.getAssumptions();
+
+        if (Assumption.isValidAssumption(originalAssumptions)) {
+            // Convert the existing mono cache entry into a fast cache entry
+            final ClassObject originalClass = monoGuard.getSqueakClassInternal(null);
+            final Object originalLookupResult = getContext().lookup(originalClass, selector);
+            final CompiledCodeObject originalMethod = originalLookupResult instanceof CompiledCodeObject m ? m : null;
+            final Assumption originalCallTargetStable = originalMethod != null ? originalMethod.getCallTargetStable() : null;
+
+            final DispatchEntry<T> monoEntry = new DispatchEntry<>(originalMethod, originalCallTargetStable,
+                            new LookupClassGuard[]{monoGuard}, originalAssumptions);
+
+            // Avoid reparenting issues: add new cache entry as our child first, then add monoEntry as its child
+            this.fastEntries = insert((DispatchEntry<T>[]) new DispatchEntry<?>[]{monoEntry});
+            monoEntry.executor = monoEntry.insert(monoExecutor);
+
+            this.state |= HAS_FAST;
+        }
+
+        // RE-ENTER: Process the new class insertion
+        this.state &= ~HAS_MONO;
+        return specialize(receiver, receiverClass, lookupResult, nodeSupplier);
+    }
+
     @SuppressWarnings("unchecked")
     @TruffleBoundary
     protected final void convertToIndirect() {
@@ -123,36 +156,12 @@ public abstract class AbstractDispatchNode<T extends AbstractDispatchDirectNode>
 
         // 0. Base Case: Uninitialized Node -> Enter Tier 0 (Mono)
         if ((state & (HAS_MONO | HAS_FAST | HAS_WIDE | HAS_INDIRECT)) == 0) {
-            this.monoExecutor = insert(nodeSupplier.get());
-            this.monoGuard = LookupClassGuard.create(receiver);
-            this.state |= HAS_MONO;
-            return monoExecutor;
+            return initializeMono(receiver, nodeSupplier);
         }
 
         // 1. Transition Tier 0 (Mono) to Tier 1 (Fast) via Recursion
         if ((state & HAS_MONO) != 0) {
-            final Assumption[] originalAssumptions = monoExecutor.getAssumptions();
-
-            if (Assumption.isValidAssumption(originalAssumptions)) {
-                final ClassObject originalClass = monoGuard.getSqueakClassInternal(null);
-                final Object originalLookupResult = getContext().lookup(originalClass, selector);
-                final CompiledCodeObject originalMethod = originalLookupResult instanceof CompiledCodeObject m ? m : null;
-                final Assumption originalCallTargetStable = originalMethod != null ? originalMethod.getCallTargetStable() : null;
-
-                final DispatchEntry<T> monoEntry = new DispatchEntry<>(originalMethod, originalCallTargetStable,
-                                new LookupClassGuard[]{monoGuard}, originalAssumptions);
-
-                // Avoid reparenting issues: add new cache entry as our child first, then add monoEntry as its child
-                this.fastEntries = insert((DispatchEntry<T>[]) new DispatchEntry<?>[]{monoEntry});
-                monoEntry.executor = monoEntry.insert(monoExecutor);
-
-                this.state |= HAS_FAST;
-            }
-
-            this.state &= ~HAS_MONO;
-
-            // RE-ENTER: Process the new class insertion
-            return specialize(receiver, receiverClass, lookupResult, nodeSupplier);
+            return transitionMonoToFast(receiver, receiverClass, lookupResult, nodeSupplier);
         }
 
         // ------------------------------------------------------------------
@@ -269,8 +278,8 @@ public abstract class AbstractDispatchNode<T extends AbstractDispatchDirectNode>
 
             final LookupClassGuard[] currentGuards = guards;
             if (currentGuards != null) {
-                for (int i = 0; i < currentGuards.length; i++) {
-                    if (currentGuards[i].check(receiver)) {
+                for (LookupClassGuard currentGuard : currentGuards) {
+                    if (currentGuard.check(receiver)) {
                         return true;
                     }
                 }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/AbstractDispatchNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/AbstractDispatchNode.java
@@ -24,28 +24,45 @@ import de.hpi.swa.trufflesqueak.nodes.CacheLimits;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectClassNode;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectClassNodeGen;
 
+/*
+ * Multi-tier dispatch architecture for method resolution and execution.
+ *
+ * Tier 0 (Monomorphic): Direct execution guarded by a single fast receiver check.
+ *                       Bypasses wrapper objects and array iterations.
+ * Tier 1 (Fast): Receiver-based polymorphism. Dispatches based on fast receiver guards.
+ *                Bounded by DISPATCH_CACHE_LIMIT. Each entry maps
+ *                up to LOOKUP_CACHE_LIMIT receiver types to a single method.
+ * Tier 2 (Wide): Target-based polymorphism. Performs a full Smalltalk class and method
+ *                dictionary lookup, dispatching based on the resolved target method.
+ *                Bounded by DISPATCH_CACHE_LIMIT. Consolidates execution
+ *                for deep hierarchies where many distinct classes inherit the same method.
+ * Tier 3 (Indirect): Megamorphic fallback using uncached lookups and indirect calls.
+ */
 public abstract class AbstractDispatchNode<T extends AbstractDispatchDirectNode> extends AbstractNode {
-    protected static final byte HAS_FAST = 1 << 0;
-    protected static final byte HAS_WIDE = 1 << 1;
-    protected static final byte HAS_INDIRECT = 1 << 2;
-    protected static final byte FLAG_PRIM_FAIL = 1 << 3;
+    protected static final byte HAS_MONO = 1 << 0;
+    protected static final byte HAS_FAST = 1 << 1;
+    protected static final byte HAS_WIDE = 1 << 2;
+    protected static final byte HAS_INDIRECT = 1 << 3;
+    protected static final byte FLAG_PRIM_FAIL = 1 << 4;
 
     protected final NativeObject selector;
 
     @CompilationFinal protected byte state;
 
-    @SuppressWarnings("rawtypes")
-    private static final DispatchEntry[] EMPTY_ENTRIES = new DispatchEntry[0];
+    @SuppressWarnings("rawtypes") private static final DispatchEntry[] EMPTY_ENTRIES = new DispatchEntry[0];
 
     @Children protected DispatchEntry<T>[] fastEntries;
     @Children protected DispatchEntry<T>[] wideEntries;
     @Child protected SqueakObjectClassNode classNode;
 
+    @Child protected T monoExecutor;
+    @CompilationFinal protected LookupClassGuard monoGuard;
+
     @SuppressWarnings("unchecked")
     AbstractDispatchNode(final NativeObject selector, final boolean canPrimFail) {
         this.selector = selector;
-        this.fastEntries = (DispatchEntry<T>[]) EMPTY_ENTRIES;
-        this.wideEntries = (DispatchEntry<T>[]) EMPTY_ENTRIES;
+        this.fastEntries = EMPTY_ENTRIES;
+        this.wideEntries = EMPTY_ENTRIES;
         this.state = canPrimFail ? FLAG_PRIM_FAIL : 0;
     }
 
@@ -60,27 +77,87 @@ public abstract class AbstractDispatchNode<T extends AbstractDispatchDirectNode>
         }
     }
 
-    @SuppressWarnings("unchecked")
-    @TruffleBoundary
-    protected final T convertToIndirect() {
-        this.fastEntries = (DispatchEntry<T>[]) EMPTY_ENTRIES;
-        this.wideEntries = (DispatchEntry<T>[]) EMPTY_ENTRIES;
-        this.classNode = null;
-        this.state = (byte) ((state & FLAG_PRIM_FAIL) | HAS_INDIRECT);
-        return null;
+    protected static Assumption[] mergeAssumptions(final Assumption[] a1, final Assumption[] a2) {
+        if (a2.length == 0) {
+            return a1;
+        }
+        final Assumption[] merged = Arrays.copyOf(a1, a1.length + a2.length);
+        int count = a1.length;
+        for (final Assumption newA : a2) {
+            boolean exists = false;
+            for (int i = 0; i < count; i++) {
+                if (merged[i] == newA) {
+                    exists = true;
+                    break;
+                }
+            }
+            if (!exists) {
+                merged[count++] = newA;
+            }
+        }
+        return Arrays.copyOf(merged, count);
     }
 
     @SuppressWarnings("unchecked")
     @TruffleBoundary
+    protected final void convertToIndirect() {
+        this.state = (byte) ((state & FLAG_PRIM_FAIL) | HAS_INDIRECT);
+
+        /* Clear child nodes and arrays to release memory. */
+        this.monoGuard = null;
+        this.monoExecutor = null;
+        this.classNode = null;
+        this.fastEntries = EMPTY_ENTRIES;
+        this.wideEntries = EMPTY_ENTRIES;
+    }
+
+    /*
+     * Note on concurrency: Smalltalk execution is strictly single-threaded.
+     * If multiple OS threads of execution are ever permitted in the VM,
+     * the non-atomic state bit transitions and cache array mutations in
+     * this implementation will require synchronization and revision.
+     */
+    @SuppressWarnings("unchecked")
+    @TruffleBoundary
     protected final T specialize(final Object receiver, final ClassObject receiverClass, final Object lookupResult, final Supplier<T> nodeSupplier) {
-        /*
-         * THREAD SAFETY NOTE:
-         * TruffleSqueak executes Smalltalk strictly on a single thread. Therefore, AST mutations
-         * (like array cloning and Node insertion here) do not require getLock().lock() synchronization.
-         *
-         * If the VM architecture ever transitions to multithreaded execution, this method MUST be
-         * wrapped in the node's intrinsic lock to prevent AST corruption and lost updates.
-         */
+
+        // 0. Base Case: Uninitialized Node -> Enter Tier 0 (Mono)
+        if ((state & (HAS_MONO | HAS_FAST | HAS_WIDE | HAS_INDIRECT)) == 0) {
+            this.monoExecutor = insert(nodeSupplier.get());
+            this.monoGuard = LookupClassGuard.create(receiver);
+            this.state |= HAS_MONO;
+            return monoExecutor;
+        }
+
+        // 1. Transition Tier 0 (Mono) to Tier 1 (Fast) via Recursion
+        if ((state & HAS_MONO) != 0) {
+            final Assumption[] originalAssumptions = monoExecutor.getAssumptions();
+
+            if (Assumption.isValidAssumption(originalAssumptions)) {
+                final ClassObject originalClass = monoGuard.getSqueakClassInternal(null);
+                final Object originalLookupResult = getContext().lookup(originalClass, selector);
+                final CompiledCodeObject originalMethod = originalLookupResult instanceof CompiledCodeObject m ? m : null;
+                final Assumption originalCallTargetStable = originalMethod != null ? originalMethod.getCallTargetStable() : null;
+
+                final DispatchEntry<T> monoEntry = new DispatchEntry<>(originalMethod, originalCallTargetStable,
+                                new LookupClassGuard[]{monoGuard}, originalAssumptions);
+
+                // Avoid reparenting issues: add new cache entry as our child first, then add monoEntry as its child
+                this.fastEntries = insert((DispatchEntry<T>[]) new DispatchEntry<?>[]{monoEntry});
+                monoEntry.executor = monoEntry.insert(monoExecutor);
+
+                this.state |= HAS_FAST;
+            }
+
+            this.state &= ~HAS_MONO;
+
+            // RE-ENTER: Process the new class insertion
+            return specialize(receiver, receiverClass, lookupResult, nodeSupplier);
+        }
+
+        // ------------------------------------------------------------------
+        // Standard Fast/Wide Tier Processing (Tier 1 & Tier 2)
+        // ------------------------------------------------------------------
 
         final DispatchEntry<T>[] newFastEntries = (DispatchEntry<T>[]) new DispatchEntry<?>[CacheLimits.DISPATCH_CACHE_LIMIT];
         final DispatchEntry<T>[] newWideEntries = (DispatchEntry<T>[]) new DispatchEntry<?>[CacheLimits.DISPATCH_CACHE_LIMIT];
@@ -89,6 +166,7 @@ public abstract class AbstractDispatchNode<T extends AbstractDispatchDirectNode>
         CompiledCodeObject targetMethodToWiden = null;
         DispatchEntry<T> targetEntry = null;
 
+        // 2. Process Fast Entries
         for (final DispatchEntry<T> current : fastEntries) {
             if (!current.isFastValid()) {
                 continue;
@@ -107,6 +185,7 @@ public abstract class AbstractDispatchNode<T extends AbstractDispatchDirectNode>
             }
         }
 
+        // 3. Process Wide Entries
         int wideEntriesNeeded = 0;
         for (final DispatchEntry<T> current : wideEntries) {
             if (current.isWideValid()) {
@@ -114,6 +193,7 @@ public abstract class AbstractDispatchNode<T extends AbstractDispatchDirectNode>
             }
         }
 
+        // 4. Handle Wide Promotion
         if (targetMethodToWiden != null) {
             targetEntry.promoteToWide();
             newWideEntries[wideEntriesNeeded++] = targetEntry;
@@ -139,6 +219,7 @@ public abstract class AbstractDispatchNode<T extends AbstractDispatchDirectNode>
             return targetEntry.executor;
         }
 
+        // 5. Append New Fast Entry
         if (fastEntriesNeeded + wideEntriesNeeded < CacheLimits.DISPATCH_CACHE_LIMIT) {
             final T newDispatchNode = nodeSupplier.get();
             final DispatchEntry<T> newEntry = new DispatchEntry<>(receiver, lookupResult, newDispatchNode);
@@ -148,7 +229,8 @@ public abstract class AbstractDispatchNode<T extends AbstractDispatchDirectNode>
             return newDispatchNode;
         }
 
-        return convertToIndirect();
+        // Cache exhausted: convert to indirect
+        return null;
     }
 
     public static final class DispatchEntry<T extends AbstractDispatchDirectNode> extends Node {
@@ -160,12 +242,22 @@ public abstract class AbstractDispatchNode<T extends AbstractDispatchDirectNode>
 
         @Child public T executor;
 
+        // Normal Constructor
         public DispatchEntry(final Object receiver, final Object lookupResult, final T executor) {
             this.methodOrNull = lookupResult instanceof CompiledCodeObject m ? m : null;
             this.callTargetStable = methodOrNull != null ? methodOrNull.getCallTargetStable() : null;
             this.guards = new LookupClassGuard[]{LookupClassGuard.create(receiver)};
             this.unifiedAssumptions = executor.getAssumptions();
             this.executor = insert(executor);
+        }
+
+        // Internal Constructor for migrating Mono to Fast
+        protected DispatchEntry(final CompiledCodeObject method, final Assumption callTargetStable, final LookupClassGuard[] guards, final Assumption[] unifiedAssumptions) {
+            this.methodOrNull = method;
+            this.callTargetStable = callTargetStable;
+            this.guards = guards;
+            this.unifiedAssumptions = unifiedAssumptions;
+            // Executor is deliberately NOT inserted here to avoid Truffle reparenting issues
         }
 
         @ExplodeLoop
@@ -199,7 +291,7 @@ public abstract class AbstractDispatchNode<T extends AbstractDispatchDirectNode>
         }
 
         public void promoteToWide() {
-            this.guards = null; // Drop fast-tier receiver checking to free memory
+            this.guards = null;
         }
 
         public boolean append(final Object receiver, final ClassObject receiverClass, final CompiledCodeObject targetMethod) {
@@ -210,30 +302,11 @@ public abstract class AbstractDispatchNode<T extends AbstractDispatchDirectNode>
                 return false;
             }
 
-            // Append Guard
             final LookupClassGuard[] newGuards = Arrays.copyOf(guards, guards.length + 1);
             newGuards[guards.length] = LookupClassGuard.create(receiver);
             this.guards = newGuards;
 
-            // Union Assumptions
-            Assumption[] newAssumptions = DispatchUtils.createAssumptions(receiverClass, targetMethod);
-            if (newAssumptions.length > 0) {
-                Assumption[] merged = Arrays.copyOf(unifiedAssumptions, unifiedAssumptions.length + newAssumptions.length);
-                int count = unifiedAssumptions.length;
-                for (Assumption newA : newAssumptions) {
-                    boolean exists = false;
-                    for (int i = 0; i < count; i++) {
-                        if (merged[i] == newA) {
-                            exists = true;
-                            break;
-                        }
-                    }
-                    if (!exists) {
-                        merged[count++] = newA;
-                    }
-                }
-                this.unifiedAssumptions = Arrays.copyOf(merged, count);
-            }
+            this.unifiedAssumptions = mergeAssumptions(unifiedAssumptions, DispatchUtils.createAssumptions(receiverClass, targetMethod));
             return true;
         }
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/AbstractDispatchNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/AbstractDispatchNode.java
@@ -131,19 +131,6 @@ public abstract class AbstractDispatchNode<T extends AbstractDispatchDirectNode>
         return specialize(receiver, receiverClass, lookupResult, nodeSupplier);
     }
 
-    @SuppressWarnings("unchecked")
-    @TruffleBoundary
-    protected final void convertToIndirect() {
-        this.state = (byte) ((state & FLAG_PRIM_FAIL) | HAS_INDIRECT);
-
-        /* Clear child nodes and arrays to release memory. */
-        this.monoGuard = null;
-        this.monoExecutor = null;
-        this.classNode = null;
-        this.fastEntries = EMPTY_ENTRIES;
-        this.wideEntries = EMPTY_ENTRIES;
-    }
-
     private DispatchEntry<T> findTargetFastEntry(final Object lookupResult) {
         if (lookupResult instanceof CompiledCodeObject targetMethod) {
             for (final DispatchEntry<T> current : fastEntries) {
@@ -175,34 +162,47 @@ public abstract class AbstractDispatchNode<T extends AbstractDispatchDirectNode>
         return count;
     }
 
-    /*
-     * Note on concurrency: Smalltalk execution is strictly single-threaded.
-     * If multiple OS threads of execution are ever permitted in the VM,
-     * the non-atomic state bit transitions and cache array mutations in
-     * this implementation will require synchronization and revision.
-     */
+    private T performWidePromotion(final DispatchEntry<T> targetEntry, final DispatchEntry<T>[] newFastEntries, final int fastCount, final DispatchEntry<T>[] newWideEntries, final int wideCount) {
+        newWideEntries[wideCount] = targetEntry;
+        this.fastEntries = insert(Arrays.copyOf(newFastEntries, fastCount));
+        this.wideEntries = insert(Arrays.copyOf(newWideEntries, wideCount + 1));
+        this.state |= HAS_WIDE;
+        if (fastCount > 0) {
+            this.state |= HAS_FAST;
+        } else {
+            this.state &= ~HAS_FAST;
+        }
+        return targetEntry.executor;
+    }
+
+    private T appendNewFastEntry(final Object receiver, final Object lookupResult, final Supplier<T> nodeSupplier, final DispatchEntry<T>[] newFastEntries, final int fastCount) {
+        final T newDispatchNode = nodeSupplier.get();
+        final DispatchEntry<T> newEntry = new DispatchEntry<>(receiver, lookupResult, newDispatchNode);
+        newFastEntries[fastCount] = newEntry;
+        this.fastEntries = insert(Arrays.copyOf(newFastEntries, fastCount + 1));
+        this.state |= HAS_FAST;
+        return newDispatchNode;
+    }
+
     @SuppressWarnings("unchecked")
     @TruffleBoundary
-    protected final T specialize(final Object receiver, final ClassObject receiverClass, final Object lookupResult, final Supplier<T> nodeSupplier) {
+    protected final void convertToIndirect() {
+        this.state = (byte) ((state & FLAG_PRIM_FAIL) | HAS_INDIRECT);
 
-        // 0. Base Case: Uninitialized Node -> Enter Tier 0 (Mono)
-        if ((state & (HAS_MONO | HAS_FAST | HAS_WIDE | HAS_INDIRECT)) == 0) {
-            return initializeMono(receiver, nodeSupplier);
-        }
+        /* Clear child nodes and arrays to release memory. */
+        this.monoGuard = null;
+        this.monoExecutor = null;
+        this.classNode = null;
+        this.fastEntries = EMPTY_ENTRIES;
+        this.wideEntries = EMPTY_ENTRIES;
+    }
 
-        // 1. Transition Tier 0 (Mono) to Tier 1 (Fast) via Recursion
-        if ((state & HAS_MONO) != 0) {
-            return transitionMonoToFast(receiver, receiverClass, lookupResult, nodeSupplier);
-        }
-
-        // ------------------------------------------------------------------
-        // Standard Fast/Wide Tier Processing (Tier 1 & Tier 2)
-        // ------------------------------------------------------------------
-
+    @SuppressWarnings("unchecked")
+    private T specializePolymorphic(final Object receiver, final ClassObject receiverClass, final Object lookupResult, final Supplier<T> nodeSupplier) {
         final DispatchEntry<T>[] newFastEntries = (DispatchEntry<T>[]) new DispatchEntry<?>[CacheLimits.DISPATCH_CACHE_LIMIT];
         final DispatchEntry<T>[] newWideEntries = (DispatchEntry<T>[]) new DispatchEntry<?>[CacheLimits.DISPATCH_CACHE_LIMIT];
 
-        // 2. Find target and determine if we need to promote to Wide
+        // Find target and determine if we need to promote to Wide
         final DispatchEntry<T> targetEntry = findTargetFastEntry(lookupResult);
         boolean needsWidening = false;
 
@@ -214,25 +214,16 @@ public abstract class AbstractDispatchNode<T extends AbstractDispatchDirectNode>
             }
         }
 
-        // 3. Filter valid entries.
-        int fastCount = filterFastEntries(newFastEntries);
-        int wideCount = filterWideEntries(newWideEntries);
+        // Filter valid entries.
+        final int fastCount = filterFastEntries(newFastEntries);
+        final int wideCount = filterWideEntries(newWideEntries);
 
-        // 4. Reassign Fast entry to Wide list, if needed.
+        // Reassign Fast entry to Wide list, if needed.
         if (needsWidening) {
-            newWideEntries[wideCount++] = targetEntry;
-            this.fastEntries = insert(Arrays.copyOf(newFastEntries, fastCount));
-            this.wideEntries = insert(Arrays.copyOf(newWideEntries, wideCount));
-            this.state |= HAS_WIDE;
-            if (fastCount > 0) {
-                this.state |= HAS_FAST;
-            } else {
-                this.state &= ~HAS_FAST;
-            }
-            return targetEntry.executor;
+            return performWidePromotion(targetEntry, newFastEntries, fastCount, newWideEntries, wideCount);
         }
 
-        // 5. Update arrays for successful Fast append or invalid entry cleanup.
+        // Update arrays for successful Fast append or invalid entry cleanup.
         if (wideCount != wideEntries.length) {
             this.wideEntries = insert(Arrays.copyOf(newWideEntries, wideCount));
         }
@@ -244,18 +235,37 @@ public abstract class AbstractDispatchNode<T extends AbstractDispatchDirectNode>
             return targetEntry.executor;
         }
 
-        // 6. Append New Fast Entry
+        // Append New Fast Entry, if possible.
         if (fastCount + wideCount < CacheLimits.DISPATCH_CACHE_LIMIT) {
-            final T newDispatchNode = nodeSupplier.get();
-            final DispatchEntry<T> newEntry = new DispatchEntry<>(receiver, lookupResult, newDispatchNode);
-            newFastEntries[fastCount++] = newEntry;
-            this.fastEntries = insert(Arrays.copyOf(newFastEntries, fastCount));
-            this.state |= HAS_FAST;
-            return newDispatchNode;
+            return appendNewFastEntry(receiver, lookupResult, nodeSupplier, newFastEntries, fastCount);
         }
 
         // Cache exhausted: convert to indirect
         return null;
+    }
+
+    /*
+     * Note on concurrency: Smalltalk execution is strictly single-threaded.
+     * If multiple OS threads of execution are ever permitted in the VM,
+     * the non-atomic state bit transitions and cache array mutations in
+     * this implementation will require synchronization and revision.
+     */
+    @SuppressWarnings("unchecked")
+    @TruffleBoundary
+    protected final T specialize(final Object receiver, final ClassObject receiverClass, final Object lookupResult, final Supplier<T> nodeSupplier) {
+
+        // Base Case: Uninitialized Node -> Enter Tier 0 (Mono)
+        if ((state & (HAS_MONO | HAS_FAST | HAS_WIDE | HAS_INDIRECT)) == 0) {
+            return initializeMono(receiver, nodeSupplier);
+        }
+
+        // Transition Tier 0 (Mono) to Tier 1 (Fast) via Recursion
+        if ((state & HAS_MONO) != 0) {
+            return transitionMonoToFast(receiver, receiverClass, lookupResult, nodeSupplier);
+        }
+
+        // Standard Fast/Wide Tier Processing
+        return specializePolymorphic(receiver, receiverClass, lookupResult, nodeSupplier);
     }
 
     public static final class DispatchEntry<T extends AbstractDispatchDirectNode> extends Node {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/AbstractDispatchSelectorNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/AbstractDispatchSelectorNode.java
@@ -7,8 +7,9 @@
 package de.hpi.swa.trufflesqueak.nodes.dispatch;
 
 import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
+import de.hpi.swa.trufflesqueak.nodes.AbstractNode;
 
-public abstract class DispatchSelectorNode {
+public abstract class AbstractDispatchSelectorNode extends AbstractNode {
     protected static final boolean checkArgumentCount(final CompiledCodeObject method, final int expectedNumArgs) {
         assert method.getNumArgs() == expectedNumArgs : "Unexpected number of arguments: " + method.getNumArgs();
         return true;

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/CreateMessageNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/CreateMessageNode.java
@@ -20,7 +20,7 @@ import de.hpi.swa.trufflesqueak.nodes.accessing.AbstractPointersObjectNodes.Abst
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectClassNode;
 
 @GenerateInline(false)
-abstract class CreateMessageNode extends AbstractNode {
+public abstract class CreateMessageNode extends AbstractNode {
     public abstract PointersObject execute(NativeObject selector, Object receiver, Object[] arguments);
 
     @Specialization

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector0Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector0Node.java
@@ -138,9 +138,15 @@ public final class DispatchSelector0Node extends DispatchSelectorNode {
             return new DispatchDirectMethod0Node(assumptions, method);
         }
 
-        private static DispatchDirectMessageFallback0Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
-            final CompiledCodeObject fallbackMethod = receiverClass.resolveDispatchFailure(selector);
-            return new DispatchDirectMessageFallback0Node(assumptions, selector, fallbackMethod);
+        private static DispatchDirect0Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
+            final ClassObject.DispatchFailureResult result = receiverClass.resolveDispatchFailure(selector, 0);
+            final Assumption[] finalAssumptions = DispatchUtils.getAssumptionsForMessageFallback(assumptions, selector, result.fallbackMethod());
+
+            return switch (result.convention()) {
+                case SHORTCUT_DNU -> new DispatchDirectShortcutFallback0Node(finalAssumptions, selector, result.fallbackMethod());
+                case STANDARD_DNU -> new DispatchDirectDNUFallback0Node(finalAssumptions, selector, result.fallbackMethod());
+                case CANNOT_INTERPRET -> new DispatchDirectCannotInterpretFallback0Node(finalAssumptions, selector, result.fallbackMethod(), result.fallbackDepth(), result.fallbackSelector());
+            };
         }
     }
 
@@ -219,21 +225,68 @@ public final class DispatchSelector0Node extends DispatchSelectorNode {
         }
     }
 
-    static final class DispatchDirectMessageFallback0Node extends DispatchDirectWithSender0Node {
-        private final NativeObject selector;
-        @Child private DirectCallNode callNode;
-        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+    abstract static class AbstractDispatchDirectFallback0Node extends DispatchDirectWithSender0Node {
+        protected final NativeObject selector;
+        @Child protected DirectCallNode callNode;
 
-        DispatchDirectMessageFallback0Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+        AbstractDispatchDirectFallback0Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject targetMethod) {
             super(assumptions);
             this.selector = selector;
-            callNode = DirectCallNode.create(dnuMethod.getCallTarget());
+            this.callNode = DirectCallNode.create(targetMethod.getCallTarget());
+        }
+
+        @Override
+        public abstract Object execute(VirtualFrame frame, Object receiver);
+    }
+
+    static final class DispatchDirectDNUFallback0Node extends AbstractDispatchDirectFallback0Node {
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectDNUFallback0Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+            super(assumptions, selector, dnuMethod);
         }
 
         @Override
         public Object execute(final VirtualFrame frame, final Object receiver) {
             final PointersObject message = createMessageNode.execute(selector, receiver, ArrayUtils.EMPTY_ARRAY);
             return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
+        }
+    }
+
+    static final class DispatchDirectCannotInterpretFallback0Node extends AbstractDispatchDirectFallback0Node {
+        private final int fallbackDepth;
+        private final NativeObject ciSelector;
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectCannotInterpretFallback0Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject ciMethod, final int fallbackDepth,
+                        final NativeObject ciSelector) {
+            super(assumptions, selector, ciMethod);
+            this.fallbackDepth = fallbackDepth;
+            this.ciSelector = ciSelector;
+        }
+
+        @Override
+        public Object execute(final VirtualFrame frame, final Object receiver) {
+            final PointersObject message = DispatchUtils.buildNestedMessage(
+                            createMessageNode,
+                            selector,
+                            ciSelector,
+                            receiver,
+                            ArrayUtils.EMPTY_ARRAY,
+                            fallbackDepth);
+            return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
+        }
+    }
+
+    static final class DispatchDirectShortcutFallback0Node extends AbstractDispatchDirectFallback0Node {
+
+        DispatchDirectShortcutFallback0Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject shortcutMethod) {
+            super(assumptions, selector, shortcutMethod);
+        }
+
+        @Override
+        public Object execute(final VirtualFrame frame, final Object receiver) {
+            return callNode.call(FrameAccess.newWith(senderNode.execute(frame), null, receiver, selector));
         }
     }
 
@@ -272,7 +325,14 @@ public final class DispatchSelector0Node extends DispatchSelectorNode {
             final ClassObject receiverClass = classNode.executeLookup(node, receiver);
             final Object lookupResult = getContext(node).lookup(receiverClass, selector);
             final CompiledCodeObject method = methodNode.execute(node, getContext(node), 0, canPrimFail, selector, receiverClass, lookupResult);
-            final Object result = tryPrimitiveNode.execute(frame, method, receiver);
+
+            final Object result;
+            if (lookupResult instanceof CompiledCodeObject) {
+                result = tryPrimitiveNode.execute(frame, method, receiver);
+            } else {
+                result = null;
+            }
+
             if (result != null) {
                 return result;
             } else {
@@ -345,9 +405,21 @@ public final class DispatchSelector0Node extends DispatchSelectorNode {
             @Specialization(guards = "lookupResult == null")
             protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final ClassObject receiverClass,
                             @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
-                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode) {
+                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(0);
+
+                if (result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU) {
+                    return FrameAccess.newWith(sender, null, receiver, selector);
+                }
+
                 final Object[] arguments = ArrayUtils.EMPTY_ARRAY;
-                final PointersObject message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                final PointersObject message;
+                if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
+                    message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
+                } else {
+                    message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                }
                 return FrameAccess.newMessageFallbackWith(sender, receiver, message);
             }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector0Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector0Node.java
@@ -13,6 +13,7 @@ import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.HostCompilerDirectives;
 import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Cached.Exclusive;
 import com.oracle.truffle.api.dsl.GenerateCached;
 import com.oracle.truffle.api.dsl.GenerateInline;
 import com.oracle.truffle.api.dsl.ImportStatic;
@@ -47,10 +48,15 @@ import de.hpi.swa.trufflesqueak.nodes.primitives.PrimitiveNodeFactory;
 import de.hpi.swa.trufflesqueak.util.ArrayUtils;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
-public final class DispatchSelector0Node extends DispatchSelectorNode {
+public final class DispatchSelector0Node extends AbstractDispatchSelectorNode {
     public abstract static class Dispatch0Node extends AbstractDispatchNode {
         Dispatch0Node(final NativeObject selector) {
             super(selector);
+        }
+
+        @NeverDefault
+        public static Dispatch0Node create(final NativeObject selector) {
+            return DispatchSelector0NodeFactory.Dispatch0NodeGen.create(selector);
         }
 
         public abstract Object execute(VirtualFrame frame, Object receiver);
@@ -81,7 +87,7 @@ public final class DispatchSelector0Node extends DispatchSelectorNode {
 
         @NeverDefault
         protected static final DispatchDirect0Node create(final NativeObject selector, final LookupClassGuard guard) {
-            return create(selector, guard, false);
+            return create(selector, guard, true);
         }
 
         @NeverDefault
@@ -392,7 +398,7 @@ public final class DispatchSelector0Node extends DispatchSelectorNode {
 
         @GenerateInline
         @GenerateCached(false)
-        protected abstract static class CreateFrameArgumentsForIndirectCall0Node extends AbstractNode {
+        protected abstract static class CreateFrameArgumentsForIndirectCall0Node extends AbstractCreateFrameArgumentsForIndirectCallNode {
             abstract Object[] execute(Node node, AbstractSqueakObject sender, Object receiver, ClassObject receiverClass, Object lookupResult, NativeObject selector);
 
             @Specialization
@@ -402,25 +408,33 @@ public final class DispatchSelector0Node extends DispatchSelectorNode {
                 return FrameAccess.newWith(sender, null, receiver);
             }
 
-            @Specialization(guards = "lookupResult == null")
+            @Specialization(guards = "lookupResult == null", assumptions = {"image.getDnuShortcutsAbsent()"})
             protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final ClassObject receiverClass,
                             @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
-                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
-                            @Cached(inline = false) final CreateMessageNode createMessageNode) {
-                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(0);
-
-                if (result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU) {
-                    return FrameAccess.newWith(sender, null, receiver, selector);
-                }
-
+                            @Bind final SqueakImageContext image,
+                            @Exclusive @Cached final InlinedConditionProfile isCannotInterpretProfile,
+                            @Exclusive @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Exclusive @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = image.findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(0);
                 final Object[] arguments = ArrayUtils.EMPTY_ARRAY;
-                final PointersObject message;
-                if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
-                    message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
+                return newMessage(node, sender, receiver, arguments, receiverClass, selector, result, image, isCannotInterpretProfile, writeNode, createMessageNode);
+            }
+
+            @Specialization(guards = "lookupResult == null", replaces = "doMessageFallback")
+            protected static final Object[] doMessageFallbackWithShortcuts(final Node node, final AbstractSqueakObject sender, final Object receiver, final ClassObject receiverClass,
+                            @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
+                            @Bind final SqueakImageContext image,
+                            @Exclusive @Cached final InlinedConditionProfile isShortcutProfile,
+                            @Exclusive @Cached final InlinedConditionProfile isCannotInterpretProfile,
+                            @Exclusive @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Exclusive @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = image.findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(0);
+                if (isShortcutProfile.profile(node, result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU)) {
+                    return FrameAccess.newWith(sender, null, receiver, selector);
                 } else {
-                    message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                    final Object[] arguments = ArrayUtils.EMPTY_ARRAY;
+                    return newMessage(node, sender, receiver, arguments, receiverClass, selector, result, image, isCannotInterpretProfile, writeNode, createMessageNode);
                 }
-                return FrameAccess.newMessageFallbackWith(sender, receiver, message);
             }
 
             @Specialization(guards = {"targetObject != null", "!isCompiledCodeObject(targetObject)"})

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector0Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector0Node.java
@@ -50,13 +50,21 @@ import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
 public final class DispatchSelector0Node extends AbstractDispatchSelectorNode {
     public abstract static class Dispatch0Node extends AbstractDispatchNode {
-        Dispatch0Node(final NativeObject selector) {
+        protected final boolean canPrimFail;
+
+        Dispatch0Node(final NativeObject selector, final boolean canPrimFail) {
             super(selector);
+            this.canPrimFail = canPrimFail;
         }
 
         @NeverDefault
         public static Dispatch0Node create(final NativeObject selector) {
-            return DispatchSelector0NodeFactory.Dispatch0NodeGen.create(selector);
+            return DispatchSelector0NodeFactory.Dispatch0NodeGen.create(selector, false);
+        }
+
+        @NeverDefault
+        public static Dispatch0Node create(final NativeObject selector, final boolean canPrimFail) {
+            return DispatchSelector0NodeFactory.Dispatch0NodeGen.create(selector, canPrimFail);
         }
 
         public abstract Object execute(VirtualFrame frame, Object receiver);
@@ -74,7 +82,7 @@ public final class DispatchSelector0Node extends AbstractDispatchSelectorNode {
         @SuppressWarnings("truffle-static-method")
         protected final Object doIndirect(final VirtualFrame frame, final Object receiver,
                         @Cached final DispatchIndirect0Node dispatchNode) {
-            return dispatchNode.execute(frame, false, selector, receiver);
+            return dispatchNode.execute(frame, canPrimFail, selector, receiver);
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector0Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector0Node.java
@@ -10,7 +10,7 @@ import com.oracle.truffle.api.Assumption;
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
-import com.oracle.truffle.api.HostCompilerDirectives;
+import com.oracle.truffle.api.HostCompilerDirectives.InliningCutoff;
 import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Cached.Exclusive;
@@ -18,11 +18,11 @@ import com.oracle.truffle.api.dsl.GenerateCached;
 import com.oracle.truffle.api.dsl.GenerateInline;
 import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.NeverDefault;
-import com.oracle.truffle.api.dsl.ReportPolymorphism;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.DirectCallNode;
+import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.IndirectCallNode;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.InlinedBranchProfile;
@@ -41,6 +41,7 @@ import de.hpi.swa.trufflesqueak.nodes.accessing.AbstractPointersObjectNodes.Abst
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectClassNode;
 import de.hpi.swa.trufflesqueak.nodes.context.GetOrCreateContextWithoutFrameNode;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector0NodeFactory.DispatchDirectPrimitiveFallback0NodeGen;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector0NodeFactory.DispatchIndirect0NodeGen;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNode.DispatchPrimitiveNode;
 import de.hpi.swa.trufflesqueak.nodes.primitives.AbstractPrimitiveNode;
 import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive0;
@@ -49,40 +50,91 @@ import de.hpi.swa.trufflesqueak.util.ArrayUtils;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
 public final class DispatchSelector0Node extends AbstractDispatchSelectorNode {
-    public abstract static class Dispatch0Node extends AbstractDispatchNode {
+    public static final class Dispatch0Node extends AbstractDispatchNode {
         protected final boolean canPrimFail;
+        @Child private DispatchCacheManager<DispatchDirect0Node> cache;
+        @Child private DispatchIndirect0Node indirectNode;
 
-        Dispatch0Node(final NativeObject selector, final boolean canPrimFail) {
+        private Dispatch0Node(final NativeObject selector, final boolean canPrimFail) {
             super(selector);
             this.canPrimFail = canPrimFail;
         }
 
         @NeverDefault
         public static Dispatch0Node create(final NativeObject selector) {
-            return DispatchSelector0NodeFactory.Dispatch0NodeGen.create(selector, false);
+            return new Dispatch0Node(selector, false);
         }
 
         @NeverDefault
         public static Dispatch0Node create(final NativeObject selector, final boolean canPrimFail) {
-            return DispatchSelector0NodeFactory.Dispatch0NodeGen.create(selector, canPrimFail);
+            return new Dispatch0Node(selector, canPrimFail);
         }
 
-        public abstract Object execute(VirtualFrame frame, Object receiver);
+        @ExplodeLoop
+        @InliningCutoff
+        public Object execute(final VirtualFrame frame, final Object receiver) {
+            // TIER 3: Megamorphic Fallback (Indirect Execution)
+            if (indirectNode != null) {
+                return indirectNode.execute(frame, canPrimFail, selector, receiver);
+            }
 
-        @Specialization(guards = "guard.check(receiver)", assumptions = "dispatchDirectNode.getAssumptions()", limit = "INLINE_METHOD_CACHE_LIMIT")
-        protected static final Object doDirect(final VirtualFrame frame, final Object receiver,
-                        @SuppressWarnings("unused") @Cached("create(receiver)") final LookupClassGuard guard,
-                        @Cached("create(selector, guard)") final DispatchDirect0Node dispatchDirectNode) {
-            return dispatchDirectNode.execute(frame, receiver);
+            if (cache == null) {
+                CompilerDirectives.transferToInterpreterAndInvalidate();
+                cache = insert(new DispatchCacheManager<>());
+            }
+
+            // TIER 1: Direct Execution Fast Path
+            for (final DispatchEntry<DispatchDirect0Node> entry : cache.fastEntries) {
+                if (entry.isFastCacheHit(receiver)) {
+                    return entry.executor.execute(frame, receiver);
+                }
+            }
+
+            // TIER 2: Wide Execution (Class Polymorphism)
+            if (cache.wideEntries.length > 0) {
+                final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
+                final Object lookupResult = getContext().lookup(receiverClass, selector);
+
+                if (lookupResult instanceof CompiledCodeObject targetMethod) {
+                    for (final DispatchEntry<DispatchDirect0Node> entry : cache.wideEntries) {
+                        if (entry.isWideCacheHit(targetMethod)) {
+                            return entry.executor.execute(frame, receiver);
+                        }
+                    }
+                }
+            }
+
+            // Cache Miss: Delegate to Manager for Specialization
+            CompilerDirectives.transferToInterpreterAndInvalidate();
+            return executeAndSpecialize(frame, receiver);
         }
 
-        @ReportPolymorphism.Megamorphic
-        @Specialization(replaces = "doDirect")
-        @HostCompilerDirectives.InliningCutoff
-        @SuppressWarnings("truffle-static-method")
-        protected final Object doIndirect(final VirtualFrame frame, final Object receiver,
-                        @Cached final DispatchIndirect0Node dispatchNode) {
-            return dispatchNode.execute(frame, canPrimFail, selector, receiver);
+        private Object executeAndSpecialize(final VirtualFrame frame, final Object receiver) {
+            /*
+             * Guard against lagging recursive frames. If multiple frames of this method are on the
+             * stack executing compiled code, a deeper frame may have already deoptimized and
+             * transitioned this node to the indirect tier. This intercepts older deoptimized frames
+             * to prevent redundant specialization.
+             */
+            if (indirectNode != null) {
+                return indirectNode.execute(frame, canPrimFail, selector, receiver);
+            }
+
+            final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
+            final Object lookupResult = getContext().lookup(receiverClass, selector);
+
+            // Node creation handles method resolution, including DNU and OAM fallbacks.
+            final DispatchDirect0Node newDirectNode = DispatchDirect0Node.create(selector, receiverClass, canPrimFail);
+
+            final DispatchDirect0Node executor = cache.specialize(receiver, lookupResult, newDirectNode);
+
+            if (executor != null) {
+                return executor.execute(frame, receiver);
+            } else {
+                this.reportPolymorphicSpecialize();
+                indirectNode = insert(DispatchIndirect0NodeGen.create());
+                return indirectNode.execute(frame, canPrimFail, selector, receiver);
+            }
         }
     }
 
@@ -95,7 +147,7 @@ public final class DispatchSelector0Node extends AbstractDispatchSelectorNode {
 
         @NeverDefault
         protected static final DispatchDirect0Node create(final NativeObject selector, final LookupClassGuard guard) {
-            return create(selector, guard, true);
+            return create(selector, guard, false);
         }
 
         @NeverDefault

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector0Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector0Node.java
@@ -102,9 +102,14 @@ public final class DispatchSelector0Node extends AbstractDispatchSelectorNode {
                         }
                     }
                 }
+
+                // Wide Cache Miss: Delegate to Manager for Specialization
+                CompilerDirectives.transferToInterpreterAndInvalidate();
+                return executeAndSpecialize(frame, receiverClass, lookupResult, receiver);
+
             }
 
-            // Cache Miss: Delegate to Manager for Specialization
+            // Fast Cache Miss: Delegate to Manager for Specialization
             CompilerDirectives.transferToInterpreterAndInvalidate();
             return executeAndSpecialize(frame, receiver);
         }
@@ -122,6 +127,14 @@ public final class DispatchSelector0Node extends AbstractDispatchSelectorNode {
 
             final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
             final Object lookupResult = getContext().lookup(receiverClass, selector);
+            return executeAndSpecialize(frame, receiverClass, lookupResult, receiver);
+        }
+
+        private Object executeAndSpecialize(final VirtualFrame frame, final ClassObject receiverClass, final Object lookupResult, final Object receiver) {
+            // Guard against lagging recursive frames.
+            if (indirectNode != null) {
+                return indirectNode.execute(frame, canPrimFail, selector, receiver);
+            }
 
             // Node creation handles method resolution, including DNU and OAM fallbacks.
             final DispatchDirect0Node newDirectNode = DispatchDirect0Node.create(selector, receiverClass, canPrimFail);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector0Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector0Node.java
@@ -102,14 +102,9 @@ public final class DispatchSelector0Node extends AbstractDispatchSelectorNode {
                         }
                     }
                 }
-
-                // Wide Cache Miss: Delegate to Manager for Specialization
-                CompilerDirectives.transferToInterpreterAndInvalidate();
-                return executeAndSpecialize(frame, receiverClass, lookupResult, receiver);
-
             }
 
-            // Fast Cache Miss: Delegate to Manager for Specialization
+            // Cache Miss: Delegate to Manager for Specialization
             CompilerDirectives.transferToInterpreterAndInvalidate();
             return executeAndSpecialize(frame, receiver);
         }
@@ -127,14 +122,6 @@ public final class DispatchSelector0Node extends AbstractDispatchSelectorNode {
 
             final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
             final Object lookupResult = getContext().lookup(receiverClass, selector);
-            return executeAndSpecialize(frame, receiverClass, lookupResult, receiver);
-        }
-
-        private Object executeAndSpecialize(final VirtualFrame frame, final ClassObject receiverClass, final Object lookupResult, final Object receiver) {
-            // Guard against lagging recursive frames.
-            if (indirectNode != null) {
-                return indirectNode.execute(frame, canPrimFail, selector, receiver);
-            }
 
             // Node creation handles method resolution, including DNU and OAM fallbacks.
             final DispatchDirect0Node executor = cache.specialize(receiver, receiverClass, lookupResult,
@@ -143,7 +130,7 @@ public final class DispatchSelector0Node extends AbstractDispatchSelectorNode {
             if (executor != null) {
                 return executor.execute(frame, receiver);
             } else {
-                this.reportPolymorphicSpecialize();
+                reportPolymorphicSpecialize();
                 indirectNode = insert(DispatchIndirect0NodeGen.create());
                 return indirectNode.execute(frame, canPrimFail, selector, receiver);
             }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector0Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector0Node.java
@@ -50,14 +50,11 @@ import de.hpi.swa.trufflesqueak.util.ArrayUtils;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
 public final class DispatchSelector0Node extends AbstractDispatchSelectorNode {
-    public static final class Dispatch0Node extends AbstractDispatchNode {
-        protected final boolean canPrimFail;
-        @Child private DispatchCacheManager<DispatchDirect0Node> cache;
+    public static final class Dispatch0Node extends AbstractDispatchNode<DispatchDirect0Node> {
         @Child private DispatchIndirect0Node indirectNode;
 
         private Dispatch0Node(final NativeObject selector, final boolean canPrimFail) {
-            super(selector);
-            this.canPrimFail = canPrimFail;
+            super(selector, canPrimFail);
         }
 
         @NeverDefault
@@ -73,30 +70,29 @@ public final class DispatchSelector0Node extends AbstractDispatchSelectorNode {
         @ExplodeLoop
         @InliningCutoff
         public Object execute(final VirtualFrame frame, final Object receiver) {
-            // TIER 3: Megamorphic Fallback (Indirect Execution)
-            if (indirectNode != null) {
-                return indirectNode.execute(frame, canPrimFail, selector, receiver);
-            }
+            final byte currentState = state;
 
-            if (cache == null) {
-                CompilerDirectives.transferToInterpreterAndInvalidate();
-                cache = insert(new DispatchCacheManager<>());
+            // TIER 3: Megamorphic Fallback (Indirect Execution)
+            if ((currentState & HAS_INDIRECT) != 0) {
+                return indirectNode.execute(frame, (currentState & FLAG_PRIM_FAIL) != 0, selector, receiver);
             }
 
             // TIER 1: Direct Execution Fast Path
-            for (final DispatchEntry<DispatchDirect0Node> entry : cache.fastEntries) {
-                if (entry.isFastCacheHit(receiver)) {
-                    return entry.executor.execute(frame, receiver);
+            if ((currentState & HAS_FAST) != 0) {
+                for (final DispatchEntry<DispatchDirect0Node> entry : fastEntries) {
+                    if (entry.isFastCacheHit(receiver)) {
+                        return entry.executor.execute(frame, receiver);
+                    }
                 }
             }
 
             // TIER 2: Wide Execution (Class Polymorphism)
-            if (cache.wideEntries.length > 0) {
-                final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
+            if ((currentState & HAS_WIDE) != 0) {
+                final ClassObject receiverClass = classNode.executeLookup(this, receiver);
                 final Object lookupResult = getContext().lookup(receiverClass, selector);
 
                 if (lookupResult instanceof CompiledCodeObject targetMethod) {
-                    for (final DispatchEntry<DispatchDirect0Node> entry : cache.wideEntries) {
+                    for (final DispatchEntry<DispatchDirect0Node> entry : wideEntries) {
                         if (entry.isWideCacheHit(targetMethod)) {
                             return entry.executor.execute(frame, receiver);
                         }
@@ -104,35 +100,33 @@ public final class DispatchSelector0Node extends AbstractDispatchSelectorNode {
                 }
             }
 
-            // Cache Miss: Delegate to Manager for Specialization
+            // Cache Miss: Delegate to superclass for Specialization
             CompilerDirectives.transferToInterpreterAndInvalidate();
             return executeAndSpecialize(frame, receiver);
         }
 
         private Object executeAndSpecialize(final VirtualFrame frame, final Object receiver) {
             /*
-             * Guard against lagging recursive frames. If multiple frames of this method are on the
-             * stack executing compiled code, a deeper frame may have already deoptimized and
-             * transitioned this node to the indirect tier. This intercepts older deoptimized frames
-             * to prevent redundant specialization.
+             * Guard against lagging recursive frames.
              */
-            if (indirectNode != null) {
-                return indirectNode.execute(frame, canPrimFail, selector, receiver);
+            if ((state & HAS_INDIRECT) != 0) {
+                return indirectNode.execute(frame, canPrimFail(), selector, receiver);
             }
 
-            final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
+            ensureClassNode();
+            final ClassObject receiverClass = classNode.executeLookup(this, receiver);
             final Object lookupResult = getContext().lookup(receiverClass, selector);
 
             // Node creation handles method resolution, including DNU and OAM fallbacks.
-            final DispatchDirect0Node executor = cache.specialize(receiver, receiverClass, lookupResult,
-                            () -> DispatchDirect0Node.create(selector, receiverClass, canPrimFail));
+            final DispatchDirect0Node executor = specialize(receiver, receiverClass, lookupResult,
+                    () -> DispatchDirect0Node.create(selector, receiverClass, canPrimFail()));
 
             if (executor != null) {
                 return executor.execute(frame, receiver);
             } else {
                 reportPolymorphicSpecialize();
                 indirectNode = insert(DispatchIndirect0NodeGen.create());
-                return indirectNode.execute(frame, canPrimFail, selector, receiver);
+                return indirectNode.execute(frame, canPrimFail(), selector, receiver);
             }
         }
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector0Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector0Node.java
@@ -72,6 +72,13 @@ public final class DispatchSelector0Node extends AbstractDispatchSelectorNode {
         public Object execute(final VirtualFrame frame, final Object receiver) {
             final byte currentState = state;
 
+            // TIER 0: Pure Monomorphic Fast Path
+            if ((currentState & HAS_MONO) != 0) {
+                if (Assumption.isValidAssumption(monoExecutor.getAssumptions()) && monoGuard.check(receiver)) {
+                    return monoExecutor.execute(frame, receiver);
+                }
+            }
+
             // TIER 3: Megamorphic Fallback (Indirect Execution)
             if ((currentState & HAS_INDIRECT) != 0) {
                 return indirectNode.execute(frame, (currentState & FLAG_PRIM_FAIL) != 0, selector, receiver);
@@ -88,13 +95,17 @@ public final class DispatchSelector0Node extends AbstractDispatchSelectorNode {
 
             // TIER 2: Wide Execution (Class Polymorphism)
             if ((currentState & HAS_WIDE) != 0) {
-                final ClassObject receiverClass = classNode.executeLookup(this, receiver);
-                final Object lookupResult = getContext().lookup(receiverClass, selector);
+                /* Local snapshot guards against stale compiled code during invalidation. */
+                final SqueakObjectClassNode node = classNode;
+                if (node != null) {
+                    final ClassObject receiverClass = node.executeLookup(this, receiver);
+                    final Object lookupResult = getContext().lookup(receiverClass, selector);
 
-                if (lookupResult instanceof CompiledCodeObject targetMethod) {
-                    for (final DispatchEntry<DispatchDirect0Node> entry : wideEntries) {
-                        if (entry.isWideCacheHit(targetMethod)) {
-                            return entry.executor.execute(frame, receiver);
+                    if (lookupResult instanceof CompiledCodeObject targetMethod) {
+                        for (final DispatchEntry<DispatchDirect0Node> entry : wideEntries) {
+                            if (entry.isWideCacheHit(targetMethod)) {
+                                return entry.executor.execute(frame, receiver);
+                            }
                         }
                     }
                 }
@@ -119,13 +130,14 @@ public final class DispatchSelector0Node extends AbstractDispatchSelectorNode {
 
             // Node creation handles method resolution, including DNU and OAM fallbacks.
             final DispatchDirect0Node executor = specialize(receiver, receiverClass, lookupResult,
-                    () -> DispatchDirect0Node.create(selector, receiverClass, canPrimFail()));
+                            () -> DispatchDirect0Node.create(selector, receiverClass, canPrimFail()));
 
             if (executor != null) {
                 return executor.execute(frame, receiver);
             } else {
                 reportPolymorphicSpecialize();
                 indirectNode = insert(DispatchIndirect0NodeGen.create());
+                convertToIndirect();
                 return indirectNode.execute(frame, canPrimFail(), selector, receiver);
             }
         }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector0Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector0Node.java
@@ -137,9 +137,8 @@ public final class DispatchSelector0Node extends AbstractDispatchSelectorNode {
             }
 
             // Node creation handles method resolution, including DNU and OAM fallbacks.
-            final DispatchDirect0Node newDirectNode = DispatchDirect0Node.create(selector, receiverClass, canPrimFail);
-
-            final DispatchDirect0Node executor = cache.specialize(receiver, lookupResult, newDirectNode);
+            final DispatchDirect0Node executor = cache.specialize(receiver, receiverClass, lookupResult,
+                            () -> DispatchDirect0Node.create(selector, receiverClass, canPrimFail));
 
             if (executor != null) {
                 return executor.execute(frame, receiver);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector1Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector1Node.java
@@ -137,9 +137,15 @@ public final class DispatchSelector1Node extends DispatchSelectorNode {
             return new DispatchDirectMethod1Node(assumptions, method);
         }
 
-        private static DispatchDirectMessageFallback1Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
-            final CompiledCodeObject fallbackMethod = receiverClass.resolveDispatchFailure(selector);
-            return new DispatchDirectMessageFallback1Node(assumptions, selector, fallbackMethod);
+        private static DispatchDirect1Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
+            final ClassObject.DispatchFailureResult result = receiverClass.resolveDispatchFailure(selector, 1);
+            final Assumption[] finalAssumptions = DispatchUtils.getAssumptionsForMessageFallback(assumptions, selector, result.fallbackMethod());
+
+            return switch (result.convention()) {
+                case SHORTCUT_DNU -> new DispatchDirectShortcutFallback1Node(finalAssumptions, selector, result.fallbackMethod());
+                case STANDARD_DNU -> new DispatchDirectDNUFallback1Node(finalAssumptions, selector, result.fallbackMethod());
+                case CANNOT_INTERPRET -> new DispatchDirectCannotInterpretFallback1Node(finalAssumptions, selector, result.fallbackMethod(), result.fallbackDepth(), result.fallbackSelector());
+            };
         }
     }
 
@@ -218,21 +224,68 @@ public final class DispatchSelector1Node extends DispatchSelectorNode {
         }
     }
 
-    static final class DispatchDirectMessageFallback1Node extends DispatchDirectWithSender1Node {
-        private final NativeObject selector;
-        @Child private DirectCallNode callNode;
-        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+    abstract static class AbstractDispatchDirectFallback1Node extends DispatchDirectWithSender1Node {
+        protected final NativeObject selector;
+        @Child protected DirectCallNode callNode;
 
-        DispatchDirectMessageFallback1Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+        AbstractDispatchDirectFallback1Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject targetMethod) {
             super(assumptions);
             this.selector = selector;
-            callNode = DirectCallNode.create(dnuMethod.getCallTarget());
+            this.callNode = DirectCallNode.create(targetMethod.getCallTarget());
+        }
+
+        @Override
+        public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1);
+    }
+
+    static final class DispatchDirectDNUFallback1Node extends AbstractDispatchDirectFallback1Node {
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectDNUFallback1Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+            super(assumptions, selector, dnuMethod);
         }
 
         @Override
         public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1) {
             final PointersObject message = createMessageNode.execute(selector, receiver, new Object[]{arg1});
             return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
+        }
+    }
+
+    static final class DispatchDirectCannotInterpretFallback1Node extends AbstractDispatchDirectFallback1Node {
+        private final int fallbackDepth;
+        private final NativeObject ciSelector;
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectCannotInterpretFallback1Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject ciMethod, final int fallbackDepth,
+                        final NativeObject ciSelector) {
+            super(assumptions, selector, ciMethod);
+            this.fallbackDepth = fallbackDepth;
+            this.ciSelector = ciSelector;
+        }
+
+        @Override
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1) {
+            final PointersObject message = DispatchUtils.buildNestedMessage(
+                            createMessageNode,
+                            selector,
+                            ciSelector,
+                            receiver,
+                            new Object[]{arg1},
+                            fallbackDepth);
+            return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
+        }
+    }
+
+    static final class DispatchDirectShortcutFallback1Node extends AbstractDispatchDirectFallback1Node {
+
+        DispatchDirectShortcutFallback1Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject shortcutMethod) {
+            super(assumptions, selector, shortcutMethod);
+        }
+
+        @Override
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1) {
+            return callNode.call(FrameAccess.newWith(senderNode.execute(frame), null, receiver, arg1, selector));
         }
     }
 
@@ -271,7 +324,14 @@ public final class DispatchSelector1Node extends DispatchSelectorNode {
             final ClassObject receiverClass = classNode.executeLookup(node, receiver);
             final Object lookupResult = getContext(node).lookup(receiverClass, selector);
             final CompiledCodeObject method = methodNode.execute(node, getContext(node), 1, canPrimFail, selector, receiverClass, lookupResult);
-            final Object result = tryPrimitiveNode.execute(frame, method, receiver, arg1);
+
+            final Object result;
+            if (lookupResult instanceof CompiledCodeObject) {
+                result = tryPrimitiveNode.execute(frame, method, receiver, arg1);
+            } else {
+                result = null;
+            }
+
             if (result != null) {
                 return result;
             } else {
@@ -345,9 +405,21 @@ public final class DispatchSelector1Node extends DispatchSelectorNode {
             @Specialization(guards = "lookupResult == null")
             protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final ClassObject receiverClass,
                             @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
-                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode) {
+                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(1);
+
+                if (result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU) {
+                    return FrameAccess.newWith(sender, null, receiver, arg1, selector);
+                }
+
                 final Object[] arguments = new Object[]{arg1};
-                final PointersObject message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                final PointersObject message;
+                if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
+                    message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
+                } else {
+                    message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                }
                 return FrameAccess.newMessageFallbackWith(sender, receiver, message);
             }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector1Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector1Node.java
@@ -101,13 +101,9 @@ public final class DispatchSelector1Node extends AbstractDispatchSelectorNode {
                         }
                     }
                 }
-
-                // Wide Cache Miss: Delegate to Manager for Specialization
-                CompilerDirectives.transferToInterpreterAndInvalidate();
-                return executeAndSpecialize(frame, receiverClass, lookupResult, receiver, arg1);
             }
 
-            // Fast Cache Miss: Delegate to Manager for Specialization
+            // Cache Miss: Delegate to Manager for Specialization
             CompilerDirectives.transferToInterpreterAndInvalidate();
             return executeAndSpecialize(frame, receiver, arg1);
         }
@@ -125,14 +121,6 @@ public final class DispatchSelector1Node extends AbstractDispatchSelectorNode {
 
             final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
             final Object lookupResult = getContext().lookup(receiverClass, selector);
-            return executeAndSpecialize(frame, receiverClass, lookupResult, receiver, arg1);
-        }
-
-        private Object executeAndSpecialize(final VirtualFrame frame, final ClassObject receiverClass, final Object lookupResult, final Object receiver, final Object arg1) {
-            // Guard against lagging recursive frames.
-            if (indirectNode != null) {
-                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1);
-            }
 
             // Node creation handles method resolution, including DNU and OAM fallbacks.
             final DispatchDirect1Node executor = cache.specialize(receiver, receiverClass, lookupResult,
@@ -141,7 +129,7 @@ public final class DispatchSelector1Node extends AbstractDispatchSelectorNode {
             if (executor != null) {
                 return executor.execute(frame, receiver, arg1);
             } else {
-                this.reportPolymorphicSpecialize();
+                reportPolymorphicSpecialize();
                 indirectNode = insert(DispatchIndirect1NodeGen.create());
                 return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1);
             }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector1Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector1Node.java
@@ -49,13 +49,21 @@ import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
 public final class DispatchSelector1Node extends AbstractDispatchSelectorNode {
     public abstract static class Dispatch1Node extends AbstractDispatchNode {
-        Dispatch1Node(final NativeObject selector) {
+        protected final boolean canPrimFail;
+
+        Dispatch1Node(final NativeObject selector, final boolean canPrimFail) {
             super(selector);
+            this.canPrimFail = canPrimFail;
         }
 
         @NeverDefault
         public static Dispatch1Node create(final NativeObject selector) {
-            return DispatchSelector1NodeFactory.Dispatch1NodeGen.create(selector);
+            return DispatchSelector1NodeFactory.Dispatch1NodeGen.create(selector, false);
+        }
+
+        @NeverDefault
+        public static Dispatch1Node create(final NativeObject selector, final boolean canPrimFail) {
+            return DispatchSelector1NodeFactory.Dispatch1NodeGen.create(selector, canPrimFail);
         }
 
         public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1);
@@ -73,7 +81,7 @@ public final class DispatchSelector1Node extends AbstractDispatchSelectorNode {
         @SuppressWarnings("truffle-static-method")
         protected final Object doIndirect(final VirtualFrame frame, final Object receiver, final Object arg1,
                         @Cached final DispatchIndirect1Node dispatchNode) {
-            return dispatchNode.execute(frame, false, selector, receiver, arg1);
+            return dispatchNode.execute(frame, canPrimFail, selector, receiver, arg1);
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector1Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector1Node.java
@@ -101,9 +101,13 @@ public final class DispatchSelector1Node extends AbstractDispatchSelectorNode {
                         }
                     }
                 }
+
+                // Wide Cache Miss: Delegate to Manager for Specialization
+                CompilerDirectives.transferToInterpreterAndInvalidate();
+                return executeAndSpecialize(frame, receiverClass, lookupResult, receiver, arg1);
             }
 
-            // Cache Miss: Delegate to Manager for Specialization
+            // Fast Cache Miss: Delegate to Manager for Specialization
             CompilerDirectives.transferToInterpreterAndInvalidate();
             return executeAndSpecialize(frame, receiver, arg1);
         }
@@ -121,6 +125,14 @@ public final class DispatchSelector1Node extends AbstractDispatchSelectorNode {
 
             final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
             final Object lookupResult = getContext().lookup(receiverClass, selector);
+            return executeAndSpecialize(frame, receiverClass, lookupResult, receiver, arg1);
+        }
+
+        private Object executeAndSpecialize(final VirtualFrame frame, final ClassObject receiverClass, final Object lookupResult, final Object receiver, final Object arg1) {
+            // Guard against lagging recursive frames.
+            if (indirectNode != null) {
+                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1);
+            }
 
             // Node creation handles method resolution, including DNU and OAM fallbacks.
             final DispatchDirect1Node newDirectNode = DispatchDirect1Node.create(selector, receiverClass, canPrimFail);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector1Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector1Node.java
@@ -49,14 +49,11 @@ import de.hpi.swa.trufflesqueak.nodes.primitives.PrimitiveNodeFactory;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
 public final class DispatchSelector1Node extends AbstractDispatchSelectorNode {
-    public static final class Dispatch1Node extends AbstractDispatchNode {
-        protected final boolean canPrimFail;
-        @Child private DispatchCacheManager<DispatchDirect1Node> cache;
+    public static final class Dispatch1Node extends AbstractDispatchNode<DispatchDirect1Node> {
         @Child private DispatchIndirect1Node indirectNode;
 
         private Dispatch1Node(final NativeObject selector, final boolean canPrimFail) {
-            super(selector);
-            this.canPrimFail = canPrimFail;
+            super(selector, canPrimFail);
         }
 
         @NeverDefault
@@ -72,30 +69,29 @@ public final class DispatchSelector1Node extends AbstractDispatchSelectorNode {
         @ExplodeLoop
         @InliningCutoff
         public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1) {
-            // TIER 3: Megamorphic Fallback (Indirect Execution)
-            if (indirectNode != null) {
-                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1);
-            }
+            final byte currentState = state;
 
-            if (cache == null) {
-                CompilerDirectives.transferToInterpreterAndInvalidate();
-                cache = insert(new DispatchCacheManager<>());
+            // TIER 3: Megamorphic Fallback (Indirect Execution)
+            if ((currentState & HAS_INDIRECT) != 0) {
+                return indirectNode.execute(frame, (currentState & FLAG_PRIM_FAIL) != 0, selector, receiver, arg1);
             }
 
             // TIER 1: Direct Execution Fast Path
-            for (final DispatchEntry<DispatchDirect1Node> entry : cache.fastEntries) {
-                if (entry.isFastCacheHit(receiver)) {
-                    return entry.executor.execute(frame, receiver, arg1);
+            if ((currentState & HAS_FAST) != 0) {
+                for (final DispatchEntry<DispatchDirect1Node> entry : fastEntries) {
+                    if (entry.isFastCacheHit(receiver)) {
+                        return entry.executor.execute(frame, receiver, arg1);
+                    }
                 }
             }
 
             // TIER 2: Wide Execution (Class Polymorphism)
-            if (cache.wideEntries.length > 0) {
-                final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
+            if ((currentState & HAS_WIDE) != 0) {
+                final ClassObject receiverClass = classNode.executeLookup(this, receiver);
                 final Object lookupResult = getContext().lookup(receiverClass, selector);
 
                 if (lookupResult instanceof CompiledCodeObject targetMethod) {
-                    for (final DispatchEntry<DispatchDirect1Node> entry : cache.wideEntries) {
+                    for (final DispatchEntry<DispatchDirect1Node> entry : wideEntries) {
                         if (entry.isWideCacheHit(targetMethod)) {
                             return entry.executor.execute(frame, receiver, arg1);
                         }
@@ -103,35 +99,33 @@ public final class DispatchSelector1Node extends AbstractDispatchSelectorNode {
                 }
             }
 
-            // Cache Miss: Delegate to Manager for Specialization
+            // Cache Miss: Delegate to superclass for Specialization
             CompilerDirectives.transferToInterpreterAndInvalidate();
             return executeAndSpecialize(frame, receiver, arg1);
         }
 
         private Object executeAndSpecialize(final VirtualFrame frame, final Object receiver, final Object arg1) {
             /*
-             * Guard against lagging recursive frames. If multiple frames of this method are on the
-             * stack executing compiled code, a deeper frame may have already deoptimized and
-             * transitioned this node to the indirect tier. This intercepts older deoptimized frames
-             * to prevent redundant specialization.
+             * Guard against lagging recursive frames.
              */
-            if (indirectNode != null) {
-                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1);
+            if ((state & HAS_INDIRECT) != 0) {
+                return indirectNode.execute(frame, canPrimFail(), selector, receiver, arg1);
             }
 
-            final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
+            ensureClassNode();
+            final ClassObject receiverClass = classNode.executeLookup(this, receiver);
             final Object lookupResult = getContext().lookup(receiverClass, selector);
 
             // Node creation handles method resolution, including DNU and OAM fallbacks.
-            final DispatchDirect1Node executor = cache.specialize(receiver, receiverClass, lookupResult,
-                            () -> DispatchDirect1Node.create(selector, receiverClass, canPrimFail));
+            final DispatchDirect1Node executor = specialize(receiver, receiverClass, lookupResult,
+                            () -> DispatchDirect1Node.create(selector, receiverClass, canPrimFail()));
 
             if (executor != null) {
                 return executor.execute(frame, receiver, arg1);
             } else {
                 reportPolymorphicSpecialize();
                 indirectNode = insert(DispatchIndirect1NodeGen.create());
-                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1);
+                return indirectNode.execute(frame, canPrimFail(), selector, receiver, arg1);
             }
         }
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector1Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector1Node.java
@@ -10,7 +10,7 @@ import com.oracle.truffle.api.Assumption;
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
-import com.oracle.truffle.api.HostCompilerDirectives;
+import com.oracle.truffle.api.HostCompilerDirectives.InliningCutoff;
 import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Cached.Exclusive;
@@ -18,11 +18,11 @@ import com.oracle.truffle.api.dsl.GenerateCached;
 import com.oracle.truffle.api.dsl.GenerateInline;
 import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.NeverDefault;
-import com.oracle.truffle.api.dsl.ReportPolymorphism;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.DirectCallNode;
+import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.IndirectCallNode;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.InlinedBranchProfile;
@@ -41,6 +41,7 @@ import de.hpi.swa.trufflesqueak.nodes.accessing.AbstractPointersObjectNodes.Abst
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectClassNode;
 import de.hpi.swa.trufflesqueak.nodes.context.GetOrCreateContextWithoutFrameNode;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector1NodeFactory.DispatchDirectPrimitiveFallback1NodeGen;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector1NodeFactory.DispatchIndirect1NodeGen;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNode.DispatchPrimitiveNode;
 import de.hpi.swa.trufflesqueak.nodes.primitives.AbstractPrimitiveNode;
 import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive1;
@@ -48,40 +49,91 @@ import de.hpi.swa.trufflesqueak.nodes.primitives.PrimitiveNodeFactory;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
 public final class DispatchSelector1Node extends AbstractDispatchSelectorNode {
-    public abstract static class Dispatch1Node extends AbstractDispatchNode {
+    public static final class Dispatch1Node extends AbstractDispatchNode {
         protected final boolean canPrimFail;
+        @Child private DispatchCacheManager<DispatchDirect1Node> cache;
+        @Child private DispatchIndirect1Node indirectNode;
 
-        Dispatch1Node(final NativeObject selector, final boolean canPrimFail) {
+        private Dispatch1Node(final NativeObject selector, final boolean canPrimFail) {
             super(selector);
             this.canPrimFail = canPrimFail;
         }
 
         @NeverDefault
         public static Dispatch1Node create(final NativeObject selector) {
-            return DispatchSelector1NodeFactory.Dispatch1NodeGen.create(selector, false);
+            return new Dispatch1Node(selector, false);
         }
 
         @NeverDefault
         public static Dispatch1Node create(final NativeObject selector, final boolean canPrimFail) {
-            return DispatchSelector1NodeFactory.Dispatch1NodeGen.create(selector, canPrimFail);
+            return new Dispatch1Node(selector, canPrimFail);
         }
 
-        public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1);
+        @ExplodeLoop
+        @InliningCutoff
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1) {
+            // TIER 3: Megamorphic Fallback (Indirect Execution)
+            if (indirectNode != null) {
+                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1);
+            }
 
-        @Specialization(guards = "guard.check(receiver)", assumptions = "dispatchDirectNode.getAssumptions()", limit = "INLINE_METHOD_CACHE_LIMIT")
-        protected static final Object doDirect(final VirtualFrame frame, final Object receiver, final Object arg1,
-                        @SuppressWarnings("unused") @Cached("create(receiver)") final LookupClassGuard guard,
-                        @Cached("create(selector, guard)") final DispatchDirect1Node dispatchDirectNode) {
-            return dispatchDirectNode.execute(frame, receiver, arg1);
+            if (cache == null) {
+                CompilerDirectives.transferToInterpreterAndInvalidate();
+                cache = insert(new DispatchCacheManager<>());
+            }
+
+            // TIER 1: Direct Execution Fast Path
+            for (final DispatchEntry<DispatchDirect1Node> entry : cache.fastEntries) {
+                if (entry.isFastCacheHit(receiver)) {
+                    return entry.executor.execute(frame, receiver, arg1);
+                }
+            }
+
+            // TIER 2: Wide Execution (Class Polymorphism)
+            if (cache.wideEntries.length > 0) {
+                final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
+                final Object lookupResult = getContext().lookup(receiverClass, selector);
+
+                if (lookupResult instanceof CompiledCodeObject targetMethod) {
+                    for (final DispatchEntry<DispatchDirect1Node> entry : cache.wideEntries) {
+                        if (entry.isWideCacheHit(targetMethod)) {
+                            return entry.executor.execute(frame, receiver, arg1);
+                        }
+                    }
+                }
+            }
+
+            // Cache Miss: Delegate to Manager for Specialization
+            CompilerDirectives.transferToInterpreterAndInvalidate();
+            return executeAndSpecialize(frame, receiver, arg1);
         }
 
-        @ReportPolymorphism.Megamorphic
-        @Specialization(replaces = "doDirect")
-        @HostCompilerDirectives.InliningCutoff
-        @SuppressWarnings("truffle-static-method")
-        protected final Object doIndirect(final VirtualFrame frame, final Object receiver, final Object arg1,
-                        @Cached final DispatchIndirect1Node dispatchNode) {
-            return dispatchNode.execute(frame, canPrimFail, selector, receiver, arg1);
+        private Object executeAndSpecialize(final VirtualFrame frame, final Object receiver, final Object arg1) {
+            /*
+             * Guard against lagging recursive frames. If multiple frames of this method are on the
+             * stack executing compiled code, a deeper frame may have already deoptimized and
+             * transitioned this node to the indirect tier. This intercepts older deoptimized frames
+             * to prevent redundant specialization.
+             */
+            if (indirectNode != null) {
+                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1);
+            }
+
+            final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
+            final Object lookupResult = getContext().lookup(receiverClass, selector);
+
+            // Node creation handles method resolution, including DNU and OAM fallbacks.
+            final DispatchDirect1Node newDirectNode = DispatchDirect1Node.create(selector, receiverClass, canPrimFail);
+
+            final DispatchDirect1Node executor = cache.specialize(receiver, lookupResult, newDirectNode);
+
+            if (executor != null) {
+                return executor.execute(frame, receiver, arg1);
+            } else {
+                this.reportPolymorphicSpecialize();
+                indirectNode = insert(DispatchIndirect1NodeGen.create());
+                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1);
+            }
         }
     }
 
@@ -94,7 +146,7 @@ public final class DispatchSelector1Node extends AbstractDispatchSelectorNode {
 
         @NeverDefault
         protected static final DispatchDirect1Node create(final NativeObject selector, final LookupClassGuard guard) {
-            return create(selector, guard, true);
+            return create(selector, guard, false);
         }
 
         @NeverDefault

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector1Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector1Node.java
@@ -13,6 +13,7 @@ import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.HostCompilerDirectives;
 import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Cached.Exclusive;
 import com.oracle.truffle.api.dsl.GenerateCached;
 import com.oracle.truffle.api.dsl.GenerateInline;
 import com.oracle.truffle.api.dsl.ImportStatic;
@@ -46,10 +47,15 @@ import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive1;
 import de.hpi.swa.trufflesqueak.nodes.primitives.PrimitiveNodeFactory;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
-public final class DispatchSelector1Node extends DispatchSelectorNode {
+public final class DispatchSelector1Node extends AbstractDispatchSelectorNode {
     public abstract static class Dispatch1Node extends AbstractDispatchNode {
         Dispatch1Node(final NativeObject selector) {
             super(selector);
+        }
+
+        @NeverDefault
+        public static Dispatch1Node create(final NativeObject selector) {
+            return DispatchSelector1NodeFactory.Dispatch1NodeGen.create(selector);
         }
 
         public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1);
@@ -392,7 +398,7 @@ public final class DispatchSelector1Node extends DispatchSelectorNode {
 
         @GenerateInline
         @GenerateCached(false)
-        protected abstract static class CreateFrameArgumentsForIndirectCall1Node extends AbstractNode {
+        protected abstract static class CreateFrameArgumentsForIndirectCall1Node extends AbstractCreateFrameArgumentsForIndirectCallNode {
             abstract Object[] execute(Node node, AbstractSqueakObject sender, Object receiver, Object arg1, ClassObject receiverClass, Object lookupResult, NativeObject selector);
 
             @Specialization
@@ -402,25 +408,34 @@ public final class DispatchSelector1Node extends DispatchSelectorNode {
                 return FrameAccess.newWith(sender, null, receiver, arg1);
             }
 
-            @Specialization(guards = "lookupResult == null")
+            @Specialization(guards = "lookupResult == null", assumptions = {"image.getDnuShortcutsAbsent()"})
             protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final ClassObject receiverClass,
                             @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
-                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
-                            @Cached(inline = false) final CreateMessageNode createMessageNode) {
-                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(1);
-
-                if (result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU) {
-                    return FrameAccess.newWith(sender, null, receiver, arg1, selector);
-                }
-
+                            @Bind final SqueakImageContext image,
+                            @Exclusive @Cached final InlinedConditionProfile isCannotInterpretProfile,
+                            @Exclusive @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Exclusive @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = image.findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(1);
                 final Object[] arguments = new Object[]{arg1};
-                final PointersObject message;
-                if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
-                    message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
+                return newMessage(node, sender, receiver, arguments, receiverClass, selector, result, image, isCannotInterpretProfile, writeNode, createMessageNode);
+            }
+
+            @Specialization(guards = "lookupResult == null", replaces = "doMessageFallback")
+            protected static final Object[] doMessageFallbackWithShortcuts(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1,
+                            final ClassObject receiverClass,
+                            @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
+                            @Bind final SqueakImageContext image,
+                            @Exclusive @Cached final InlinedConditionProfile isShortcutProfile,
+                            @Exclusive @Cached final InlinedConditionProfile isCannotInterpretProfile,
+                            @Exclusive @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Exclusive @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = image.findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(1);
+                if (isShortcutProfile.profile(node, result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU)) {
+                    return FrameAccess.newWith(sender, null, receiver, arg1, selector);
                 } else {
-                    message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                    final Object[] arguments = new Object[]{arg1};
+                    return newMessage(node, sender, receiver, arguments, receiverClass, selector, result, image, isCannotInterpretProfile, writeNode, createMessageNode);
                 }
-                return FrameAccess.newMessageFallbackWith(sender, receiver, message);
             }
 
             @Specialization(guards = {"targetObject != null", "!isCompiledCodeObject(targetObject)"})

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector1Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector1Node.java
@@ -135,9 +135,8 @@ public final class DispatchSelector1Node extends AbstractDispatchSelectorNode {
             }
 
             // Node creation handles method resolution, including DNU and OAM fallbacks.
-            final DispatchDirect1Node newDirectNode = DispatchDirect1Node.create(selector, receiverClass, canPrimFail);
-
-            final DispatchDirect1Node executor = cache.specialize(receiver, lookupResult, newDirectNode);
+            final DispatchDirect1Node executor = cache.specialize(receiver, receiverClass, lookupResult,
+                            () -> DispatchDirect1Node.create(selector, receiverClass, canPrimFail));
 
             if (executor != null) {
                 return executor.execute(frame, receiver, arg1);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector1Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector1Node.java
@@ -71,6 +71,13 @@ public final class DispatchSelector1Node extends AbstractDispatchSelectorNode {
         public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1) {
             final byte currentState = state;
 
+            // TIER 0: Pure Monomorphic Fast Path
+            if ((currentState & HAS_MONO) != 0) {
+                if (Assumption.isValidAssumption(monoExecutor.getAssumptions()) && monoGuard.check(receiver)) {
+                    return monoExecutor.execute(frame, receiver, arg1);
+                }
+            }
+
             // TIER 3: Megamorphic Fallback (Indirect Execution)
             if ((currentState & HAS_INDIRECT) != 0) {
                 return indirectNode.execute(frame, (currentState & FLAG_PRIM_FAIL) != 0, selector, receiver, arg1);
@@ -87,13 +94,17 @@ public final class DispatchSelector1Node extends AbstractDispatchSelectorNode {
 
             // TIER 2: Wide Execution (Class Polymorphism)
             if ((currentState & HAS_WIDE) != 0) {
-                final ClassObject receiverClass = classNode.executeLookup(this, receiver);
-                final Object lookupResult = getContext().lookup(receiverClass, selector);
+                /* Local snapshot guards against stale compiled code during invalidation. */
+                final SqueakObjectClassNode node = classNode;
+                if (node != null) {
+                    final ClassObject receiverClass = node.executeLookup(this, receiver);
+                    final Object lookupResult = getContext().lookup(receiverClass, selector);
 
-                if (lookupResult instanceof CompiledCodeObject targetMethod) {
-                    for (final DispatchEntry<DispatchDirect1Node> entry : wideEntries) {
-                        if (entry.isWideCacheHit(targetMethod)) {
-                            return entry.executor.execute(frame, receiver, arg1);
+                    if (lookupResult instanceof CompiledCodeObject targetMethod) {
+                        for (final DispatchEntry<DispatchDirect1Node> entry : wideEntries) {
+                            if (entry.isWideCacheHit(targetMethod)) {
+                                return entry.executor.execute(frame, receiver, arg1);
+                            }
                         }
                     }
                 }
@@ -125,6 +136,7 @@ public final class DispatchSelector1Node extends AbstractDispatchSelectorNode {
             } else {
                 reportPolymorphicSpecialize();
                 indirectNode = insert(DispatchIndirect1NodeGen.create());
+                convertToIndirect();
                 return indirectNode.execute(frame, canPrimFail(), selector, receiver, arg1);
             }
         }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector2Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector2Node.java
@@ -129,7 +129,7 @@ public final class DispatchSelector2Node extends DispatchSelectorNode {
             assert checkArgumentCount(method, 2);
             if (method.hasPrimitive()) {
                 final AbstractPrimitiveNode primitiveNode = PrimitiveNodeFactory.getOrCreateIndexedOrNamed(method);
-                if (primitiveNode instanceof Primitive2 primitive2) {
+                if (primitiveNode instanceof final Primitive2 primitive2) {
                     return new DispatchDirectPrimitive2Node(assumptions, method, primitive2);
                 }
                 DispatchUtils.logMissingPrimitive(primitiveNode, method);
@@ -137,9 +137,15 @@ public final class DispatchSelector2Node extends DispatchSelectorNode {
             return new DispatchDirectMethod2Node(assumptions, method);
         }
 
-        private static DispatchDirectMessageFallback2Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
-            final CompiledCodeObject fallbackMethod = receiverClass.resolveDispatchFailure(selector);
-            return new DispatchDirectMessageFallback2Node(assumptions, selector, fallbackMethod);
+        private static DispatchDirect2Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
+            final ClassObject.DispatchFailureResult result = receiverClass.resolveDispatchFailure(selector, 2);
+            final Assumption[] finalAssumptions = DispatchUtils.getAssumptionsForMessageFallback(assumptions, selector, result.fallbackMethod());
+
+            return switch (result.convention()) {
+                case SHORTCUT_DNU -> new DispatchDirectShortcutFallback2Node(finalAssumptions, selector, result.fallbackMethod());
+                case STANDARD_DNU -> new DispatchDirectDNUFallback2Node(finalAssumptions, selector, result.fallbackMethod());
+                case CANNOT_INTERPRET -> new DispatchDirectCannotInterpretFallback2Node(finalAssumptions, selector, result.fallbackMethod(), result.fallbackDepth(), result.fallbackSelector());
+            };
         }
     }
 
@@ -218,21 +224,68 @@ public final class DispatchSelector2Node extends DispatchSelectorNode {
         }
     }
 
-    static final class DispatchDirectMessageFallback2Node extends DispatchDirectWithSender2Node {
-        private final NativeObject selector;
-        @Child private DirectCallNode callNode;
-        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+    abstract static class AbstractDispatchDirectFallback2Node extends DispatchDirectWithSender2Node {
+        protected final NativeObject selector;
+        @Child protected DirectCallNode callNode;
 
-        DispatchDirectMessageFallback2Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+        AbstractDispatchDirectFallback2Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject targetMethod) {
             super(assumptions);
             this.selector = selector;
-            callNode = DirectCallNode.create(dnuMethod.getCallTarget());
+            this.callNode = DirectCallNode.create(targetMethod.getCallTarget());
+        }
+
+        @Override
+        public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2);
+    }
+
+    static final class DispatchDirectDNUFallback2Node extends AbstractDispatchDirectFallback2Node {
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectDNUFallback2Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+            super(assumptions, selector, dnuMethod);
         }
 
         @Override
         public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2) {
             final PointersObject message = createMessageNode.execute(selector, receiver, new Object[]{arg1, arg2});
             return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
+        }
+    }
+
+    static final class DispatchDirectCannotInterpretFallback2Node extends AbstractDispatchDirectFallback2Node {
+        private final int fallbackDepth;
+        private final NativeObject ciSelector;
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectCannotInterpretFallback2Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject ciMethod, final int fallbackDepth,
+                        final NativeObject ciSelector) {
+            super(assumptions, selector, ciMethod);
+            this.fallbackDepth = fallbackDepth;
+            this.ciSelector = ciSelector;
+        }
+
+        @Override
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2) {
+            final PointersObject message = DispatchUtils.buildNestedMessage(
+                            createMessageNode,
+                            selector,
+                            ciSelector,
+                            receiver,
+                            new Object[]{arg1, arg2},
+                            fallbackDepth);
+            return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
+        }
+    }
+
+    static final class DispatchDirectShortcutFallback2Node extends AbstractDispatchDirectFallback2Node {
+
+        DispatchDirectShortcutFallback2Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject shortcutMethod) {
+            super(assumptions, selector, shortcutMethod);
+        }
+
+        @Override
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2) {
+            return callNode.call(FrameAccess.newWith(senderNode.execute(frame), null, receiver, arg1, arg2, selector));
         }
     }
 
@@ -271,7 +324,14 @@ public final class DispatchSelector2Node extends DispatchSelectorNode {
             final ClassObject receiverClass = classNode.executeLookup(node, receiver);
             final Object lookupResult = getContext(node).lookup(receiverClass, selector);
             final CompiledCodeObject method = methodNode.execute(node, getContext(node), 2, canPrimFail, selector, receiverClass, lookupResult);
-            final Object result = tryPrimitiveNode.execute(frame, method, receiver, arg1, arg2);
+
+            final Object result;
+            if (lookupResult instanceof CompiledCodeObject) {
+                result = tryPrimitiveNode.execute(frame, method, receiver, arg1, arg2);
+            } else {
+                result = null;
+            }
+
             if (result != null) {
                 return result;
             } else {
@@ -346,9 +406,20 @@ public final class DispatchSelector2Node extends DispatchSelectorNode {
             protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final Object arg2,
                             final ClassObject receiverClass,
                             @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
-                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode) {
+                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(2);
+                if (result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU) {
+                    return FrameAccess.newWith(sender, null, receiver, arg1, arg2, selector);
+                }
+
                 final Object[] arguments = new Object[]{arg1, arg2};
-                final PointersObject message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                final PointersObject message;
+                if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
+                    message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
+                } else {
+                    message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                }
                 return FrameAccess.newMessageFallbackWith(sender, receiver, message);
             }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector2Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector2Node.java
@@ -13,6 +13,7 @@ import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.HostCompilerDirectives;
 import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Cached.Exclusive;
 import com.oracle.truffle.api.dsl.GenerateCached;
 import com.oracle.truffle.api.dsl.GenerateInline;
 import com.oracle.truffle.api.dsl.ImportStatic;
@@ -46,10 +47,15 @@ import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive2;
 import de.hpi.swa.trufflesqueak.nodes.primitives.PrimitiveNodeFactory;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
-public final class DispatchSelector2Node extends DispatchSelectorNode {
+public final class DispatchSelector2Node extends AbstractDispatchSelectorNode {
     public abstract static class Dispatch2Node extends AbstractDispatchNode {
         Dispatch2Node(final NativeObject selector) {
             super(selector);
+        }
+
+        @NeverDefault
+        public static Dispatch2Node create(final NativeObject selector) {
+            return DispatchSelector2NodeFactory.Dispatch2NodeGen.create(selector);
         }
 
         public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2);
@@ -392,7 +398,7 @@ public final class DispatchSelector2Node extends DispatchSelectorNode {
 
         @GenerateInline
         @GenerateCached(false)
-        protected abstract static class CreateFrameArgumentsForIndirectCall2Node extends AbstractNode {
+        protected abstract static class CreateFrameArgumentsForIndirectCall2Node extends AbstractCreateFrameArgumentsForIndirectCallNode {
             abstract Object[] execute(Node node, AbstractSqueakObject sender, Object receiver, Object arg1, Object arg2, ClassObject receiverClass, Object lookupResult, NativeObject selector);
 
             @Specialization
@@ -402,25 +408,35 @@ public final class DispatchSelector2Node extends DispatchSelectorNode {
                 return FrameAccess.newWith(sender, null, receiver, arg1, arg2);
             }
 
-            @Specialization(guards = "lookupResult == null")
+            @Specialization(guards = "lookupResult == null", assumptions = {"image.getDnuShortcutsAbsent()"})
             protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final Object arg2,
                             final ClassObject receiverClass,
                             @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
-                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
-                            @Cached(inline = false) final CreateMessageNode createMessageNode) {
-                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(2);
-                if (result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU) {
-                    return FrameAccess.newWith(sender, null, receiver, arg1, arg2, selector);
-                }
-
+                            @Bind final SqueakImageContext image,
+                            @Exclusive @Cached final InlinedConditionProfile isCannotInterpretProfile,
+                            @Exclusive @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Exclusive @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = image.findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(2);
                 final Object[] arguments = new Object[]{arg1, arg2};
-                final PointersObject message;
-                if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
-                    message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
+                return newMessage(node, sender, receiver, arguments, receiverClass, selector, result, image, isCannotInterpretProfile, writeNode, createMessageNode);
+            }
+
+            @Specialization(guards = "lookupResult == null", replaces = "doMessageFallback")
+            protected static final Object[] doMessageFallbackWithShortcuts(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final Object arg2,
+                            final ClassObject receiverClass,
+                            @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
+                            @Bind final SqueakImageContext image,
+                            @Exclusive @Cached final InlinedConditionProfile isShortcutProfile,
+                            @Exclusive @Cached final InlinedConditionProfile isCannotInterpretProfile,
+                            @Exclusive @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Exclusive @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = image.findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(2);
+                if (isShortcutProfile.profile(node, result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU)) {
+                    return FrameAccess.newWith(sender, null, receiver, arg1, arg2, selector);
                 } else {
-                    message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                    final Object[] arguments = new Object[]{arg1, arg2};
+                    return newMessage(node, sender, receiver, arguments, receiverClass, selector, result, image, isCannotInterpretProfile, writeNode, createMessageNode);
                 }
-                return FrameAccess.newMessageFallbackWith(sender, receiver, message);
             }
 
             @Specialization(guards = {"targetObject != null", "!isCompiledCodeObject(targetObject)"})

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector2Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector2Node.java
@@ -49,13 +49,21 @@ import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
 public final class DispatchSelector2Node extends AbstractDispatchSelectorNode {
     public abstract static class Dispatch2Node extends AbstractDispatchNode {
-        Dispatch2Node(final NativeObject selector) {
+        protected final boolean canPrimFail;
+
+        Dispatch2Node(final NativeObject selector, final boolean canPrimFail) {
             super(selector);
+            this.canPrimFail = canPrimFail;
         }
 
         @NeverDefault
         public static Dispatch2Node create(final NativeObject selector) {
-            return DispatchSelector2NodeFactory.Dispatch2NodeGen.create(selector);
+            return DispatchSelector2NodeFactory.Dispatch2NodeGen.create(selector, false);
+        }
+
+        @NeverDefault
+        public static Dispatch2Node create(final NativeObject selector, final boolean canPrimFail) {
+            return DispatchSelector2NodeFactory.Dispatch2NodeGen.create(selector, canPrimFail);
         }
 
         public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2);
@@ -73,7 +81,7 @@ public final class DispatchSelector2Node extends AbstractDispatchSelectorNode {
         @SuppressWarnings("truffle-static-method")
         protected final Object doIndirect(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2,
                         @Cached final DispatchIndirect2Node dispatchNode) {
-            return dispatchNode.execute(frame, false, selector, receiver, arg1, arg2);
+            return dispatchNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2);
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector2Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector2Node.java
@@ -10,7 +10,7 @@ import com.oracle.truffle.api.Assumption;
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
-import com.oracle.truffle.api.HostCompilerDirectives;
+import com.oracle.truffle.api.HostCompilerDirectives.InliningCutoff;
 import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Cached.Exclusive;
@@ -18,11 +18,11 @@ import com.oracle.truffle.api.dsl.GenerateCached;
 import com.oracle.truffle.api.dsl.GenerateInline;
 import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.NeverDefault;
-import com.oracle.truffle.api.dsl.ReportPolymorphism;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.DirectCallNode;
+import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.IndirectCallNode;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.InlinedBranchProfile;
@@ -41,6 +41,7 @@ import de.hpi.swa.trufflesqueak.nodes.accessing.AbstractPointersObjectNodes.Abst
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectClassNode;
 import de.hpi.swa.trufflesqueak.nodes.context.GetOrCreateContextWithoutFrameNode;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector2NodeFactory.DispatchDirectPrimitiveFallback2NodeGen;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector2NodeFactory.DispatchIndirect2NodeGen;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNode.DispatchPrimitiveNode;
 import de.hpi.swa.trufflesqueak.nodes.primitives.AbstractPrimitiveNode;
 import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive2;
@@ -48,40 +49,91 @@ import de.hpi.swa.trufflesqueak.nodes.primitives.PrimitiveNodeFactory;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
 public final class DispatchSelector2Node extends AbstractDispatchSelectorNode {
-    public abstract static class Dispatch2Node extends AbstractDispatchNode {
+    public static final class Dispatch2Node extends AbstractDispatchNode {
         protected final boolean canPrimFail;
+        @Child private DispatchCacheManager<DispatchDirect2Node> cache;
+        @Child private DispatchIndirect2Node indirectNode;
 
-        Dispatch2Node(final NativeObject selector, final boolean canPrimFail) {
+        private Dispatch2Node(final NativeObject selector, final boolean canPrimFail) {
             super(selector);
             this.canPrimFail = canPrimFail;
         }
 
         @NeverDefault
         public static Dispatch2Node create(final NativeObject selector) {
-            return DispatchSelector2NodeFactory.Dispatch2NodeGen.create(selector, false);
+            return new Dispatch2Node(selector, false);
         }
 
         @NeverDefault
         public static Dispatch2Node create(final NativeObject selector, final boolean canPrimFail) {
-            return DispatchSelector2NodeFactory.Dispatch2NodeGen.create(selector, canPrimFail);
+            return new Dispatch2Node(selector, canPrimFail);
         }
 
-        public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2);
+        @ExplodeLoop
+        @InliningCutoff
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2) {
+            // TIER 3: Megamorphic Fallback (Indirect Execution)
+            if (indirectNode != null) {
+                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2);
+            }
 
-        @Specialization(guards = "guard.check(receiver)", assumptions = "dispatchDirectNode.getAssumptions()", limit = "INLINE_METHOD_CACHE_LIMIT")
-        protected static final Object doDirect(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2,
-                        @SuppressWarnings("unused") @Cached("create(receiver)") final LookupClassGuard guard,
-                        @Cached("create(selector, guard)") final DispatchDirect2Node dispatchDirectNode) {
-            return dispatchDirectNode.execute(frame, receiver, arg1, arg2);
+            if (cache == null) {
+                CompilerDirectives.transferToInterpreterAndInvalidate();
+                cache = insert(new DispatchCacheManager<>());
+            }
+
+            // TIER 1: Direct Execution Fast Path
+            for (final DispatchEntry<DispatchDirect2Node> entry : cache.fastEntries) {
+                if (entry.isFastCacheHit(receiver)) {
+                    return entry.executor.execute(frame, receiver, arg1, arg2);
+                }
+            }
+
+            // TIER 2: Wide Execution (Class Polymorphism)
+            if (cache.wideEntries.length > 0) {
+                final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
+                final Object lookupResult = getContext().lookup(receiverClass, selector);
+
+                if (lookupResult instanceof CompiledCodeObject targetMethod) {
+                    for (final DispatchEntry<DispatchDirect2Node> entry : cache.wideEntries) {
+                        if (entry.isWideCacheHit(targetMethod)) {
+                            return entry.executor.execute(frame, receiver, arg1, arg2);
+                        }
+                    }
+                }
+            }
+
+            // Cache Miss: Delegate to Manager for Specialization
+            CompilerDirectives.transferToInterpreterAndInvalidate();
+            return executeAndSpecialize(frame, receiver, arg1, arg2);
         }
 
-        @ReportPolymorphism.Megamorphic
-        @Specialization(replaces = "doDirect")
-        @HostCompilerDirectives.InliningCutoff
-        @SuppressWarnings("truffle-static-method")
-        protected final Object doIndirect(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2,
-                        @Cached final DispatchIndirect2Node dispatchNode) {
-            return dispatchNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2);
+        private Object executeAndSpecialize(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2) {
+            /*
+             * Guard against lagging recursive frames. If multiple frames of this method are on the
+             * stack executing compiled code, a deeper frame may have already deoptimized and
+             * transitioned this node to the indirect tier. This intercepts older deoptimized frames
+             * to prevent redundant specialization.
+             */
+            if (indirectNode != null) {
+                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2);
+            }
+
+            final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
+            final Object lookupResult = getContext().lookup(receiverClass, selector);
+
+            // Node creation handles method resolution, including DNU and OAM fallbacks.
+            final DispatchDirect2Node newDirectNode = DispatchDirect2Node.create(selector, receiverClass, canPrimFail);
+
+            final DispatchDirect2Node executor = cache.specialize(receiver, lookupResult, newDirectNode);
+
+            if (executor != null) {
+                return executor.execute(frame, receiver, arg1, arg2);
+            } else {
+                this.reportPolymorphicSpecialize();
+                indirectNode = insert(DispatchIndirect2NodeGen.create());
+                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2);
+            }
         }
     }
 
@@ -94,7 +146,7 @@ public final class DispatchSelector2Node extends AbstractDispatchSelectorNode {
 
         @NeverDefault
         protected static final DispatchDirect2Node create(final NativeObject selector, final LookupClassGuard guard) {
-            return create(selector, guard, true);
+            return create(selector, guard, false);
         }
 
         @NeverDefault

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector2Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector2Node.java
@@ -49,14 +49,11 @@ import de.hpi.swa.trufflesqueak.nodes.primitives.PrimitiveNodeFactory;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
 public final class DispatchSelector2Node extends AbstractDispatchSelectorNode {
-    public static final class Dispatch2Node extends AbstractDispatchNode {
-        protected final boolean canPrimFail;
-        @Child private DispatchCacheManager<DispatchDirect2Node> cache;
+    public static final class Dispatch2Node extends AbstractDispatchNode<DispatchDirect2Node> {
         @Child private DispatchIndirect2Node indirectNode;
 
         private Dispatch2Node(final NativeObject selector, final boolean canPrimFail) {
-            super(selector);
-            this.canPrimFail = canPrimFail;
+            super(selector, canPrimFail);
         }
 
         @NeverDefault
@@ -72,30 +69,29 @@ public final class DispatchSelector2Node extends AbstractDispatchSelectorNode {
         @ExplodeLoop
         @InliningCutoff
         public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2) {
-            // TIER 3: Megamorphic Fallback (Indirect Execution)
-            if (indirectNode != null) {
-                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2);
-            }
+            final byte currentState = state;
 
-            if (cache == null) {
-                CompilerDirectives.transferToInterpreterAndInvalidate();
-                cache = insert(new DispatchCacheManager<>());
+            // TIER 3: Megamorphic Fallback (Indirect Execution)
+            if ((currentState & HAS_INDIRECT) != 0) {
+                return indirectNode.execute(frame, (currentState & FLAG_PRIM_FAIL) != 0, selector, receiver, arg1, arg2);
             }
 
             // TIER 1: Direct Execution Fast Path
-            for (final DispatchEntry<DispatchDirect2Node> entry : cache.fastEntries) {
-                if (entry.isFastCacheHit(receiver)) {
-                    return entry.executor.execute(frame, receiver, arg1, arg2);
+            if ((currentState & HAS_FAST) != 0) {
+                for (final DispatchEntry<DispatchDirect2Node> entry : fastEntries) {
+                    if (entry.isFastCacheHit(receiver)) {
+                        return entry.executor.execute(frame, receiver, arg1, arg2);
+                    }
                 }
             }
 
             // TIER 2: Wide Execution (Class Polymorphism)
-            if (cache.wideEntries.length > 0) {
-                final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
+            if ((currentState & HAS_WIDE) != 0) {
+                final ClassObject receiverClass = classNode.executeLookup(this, receiver);
                 final Object lookupResult = getContext().lookup(receiverClass, selector);
 
                 if (lookupResult instanceof CompiledCodeObject targetMethod) {
-                    for (final DispatchEntry<DispatchDirect2Node> entry : cache.wideEntries) {
+                    for (final DispatchEntry<DispatchDirect2Node> entry : wideEntries) {
                         if (entry.isWideCacheHit(targetMethod)) {
                             return entry.executor.execute(frame, receiver, arg1, arg2);
                         }
@@ -103,35 +99,33 @@ public final class DispatchSelector2Node extends AbstractDispatchSelectorNode {
                 }
             }
 
-            // Cache Miss: Delegate to Manager for Specialization
+            // Cache Miss: Delegate to superclass for Specialization
             CompilerDirectives.transferToInterpreterAndInvalidate();
             return executeAndSpecialize(frame, receiver, arg1, arg2);
         }
 
         private Object executeAndSpecialize(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2) {
             /*
-             * Guard against lagging recursive frames. If multiple frames of this method are on the
-             * stack executing compiled code, a deeper frame may have already deoptimized and
-             * transitioned this node to the indirect tier. This intercepts older deoptimized frames
-             * to prevent redundant specialization.
+             * Guard against lagging recursive frames.
              */
-            if (indirectNode != null) {
-                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2);
+            if ((state & HAS_INDIRECT) != 0) {
+                return indirectNode.execute(frame, canPrimFail(), selector, receiver, arg1, arg2);
             }
 
-            final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
+            ensureClassNode();
+            final ClassObject receiverClass = classNode.executeLookup(this, receiver);
             final Object lookupResult = getContext().lookup(receiverClass, selector);
 
             // Node creation handles method resolution, including DNU and OAM fallbacks.
-            final DispatchDirect2Node executor = cache.specialize(receiver, receiverClass, lookupResult,
-                            () -> DispatchDirect2Node.create(selector, receiverClass, canPrimFail));
+            final DispatchDirect2Node executor = specialize(receiver, receiverClass, lookupResult,
+                            () -> DispatchDirect2Node.create(selector, receiverClass, canPrimFail()));
 
             if (executor != null) {
                 return executor.execute(frame, receiver, arg1, arg2);
             } else {
                 reportPolymorphicSpecialize();
                 indirectNode = insert(DispatchIndirect2NodeGen.create());
-                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2);
+                return indirectNode.execute(frame, canPrimFail(), selector, receiver, arg1, arg2);
             }
         }
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector2Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector2Node.java
@@ -101,13 +101,9 @@ public final class DispatchSelector2Node extends AbstractDispatchSelectorNode {
                         }
                     }
                 }
-
-                // Wide Cache Miss: Delegate to Manager for Specialization
-                CompilerDirectives.transferToInterpreterAndInvalidate();
-                return executeAndSpecialize(frame, receiverClass, lookupResult, receiver, arg1, arg2);
             }
 
-            // Fast Cache Miss: Delegate to Manager for Specialization
+            // Cache Miss: Delegate to Manager for Specialization
             CompilerDirectives.transferToInterpreterAndInvalidate();
             return executeAndSpecialize(frame, receiver, arg1, arg2);
         }
@@ -125,14 +121,6 @@ public final class DispatchSelector2Node extends AbstractDispatchSelectorNode {
 
             final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
             final Object lookupResult = getContext().lookup(receiverClass, selector);
-            return executeAndSpecialize(frame, receiverClass, lookupResult, receiver, arg1, arg2);
-        }
-
-        private Object executeAndSpecialize(final VirtualFrame frame, final ClassObject receiverClass, final Object lookupResult, final Object receiver, final Object arg1, final Object arg2) {
-            // Guard against lagging recursive frames.
-            if (indirectNode != null) {
-                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2);
-            }
 
             // Node creation handles method resolution, including DNU and OAM fallbacks.
             final DispatchDirect2Node executor = cache.specialize(receiver, receiverClass, lookupResult,
@@ -141,7 +129,7 @@ public final class DispatchSelector2Node extends AbstractDispatchSelectorNode {
             if (executor != null) {
                 return executor.execute(frame, receiver, arg1, arg2);
             } else {
-                this.reportPolymorphicSpecialize();
+                reportPolymorphicSpecialize();
                 indirectNode = insert(DispatchIndirect2NodeGen.create());
                 return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2);
             }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector2Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector2Node.java
@@ -101,9 +101,13 @@ public final class DispatchSelector2Node extends AbstractDispatchSelectorNode {
                         }
                     }
                 }
+
+                // Wide Cache Miss: Delegate to Manager for Specialization
+                CompilerDirectives.transferToInterpreterAndInvalidate();
+                return executeAndSpecialize(frame, receiverClass, lookupResult, receiver, arg1, arg2);
             }
 
-            // Cache Miss: Delegate to Manager for Specialization
+            // Fast Cache Miss: Delegate to Manager for Specialization
             CompilerDirectives.transferToInterpreterAndInvalidate();
             return executeAndSpecialize(frame, receiver, arg1, arg2);
         }
@@ -121,6 +125,14 @@ public final class DispatchSelector2Node extends AbstractDispatchSelectorNode {
 
             final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
             final Object lookupResult = getContext().lookup(receiverClass, selector);
+            return executeAndSpecialize(frame, receiverClass, lookupResult, receiver, arg1, arg2);
+        }
+
+        private Object executeAndSpecialize(final VirtualFrame frame, final ClassObject receiverClass, final Object lookupResult, final Object receiver, final Object arg1, final Object arg2) {
+            // Guard against lagging recursive frames.
+            if (indirectNode != null) {
+                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2);
+            }
 
             // Node creation handles method resolution, including DNU and OAM fallbacks.
             final DispatchDirect2Node newDirectNode = DispatchDirect2Node.create(selector, receiverClass, canPrimFail);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector2Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector2Node.java
@@ -135,9 +135,8 @@ public final class DispatchSelector2Node extends AbstractDispatchSelectorNode {
             }
 
             // Node creation handles method resolution, including DNU and OAM fallbacks.
-            final DispatchDirect2Node newDirectNode = DispatchDirect2Node.create(selector, receiverClass, canPrimFail);
-
-            final DispatchDirect2Node executor = cache.specialize(receiver, lookupResult, newDirectNode);
+            final DispatchDirect2Node executor = cache.specialize(receiver, receiverClass, lookupResult,
+                            () -> DispatchDirect2Node.create(selector, receiverClass, canPrimFail));
 
             if (executor != null) {
                 return executor.execute(frame, receiver, arg1, arg2);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector2Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector2Node.java
@@ -71,6 +71,13 @@ public final class DispatchSelector2Node extends AbstractDispatchSelectorNode {
         public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2) {
             final byte currentState = state;
 
+            // TIER 0: Pure Monomorphic Fast Path
+            if ((currentState & HAS_MONO) != 0) {
+                if (Assumption.isValidAssumption(monoExecutor.getAssumptions()) && monoGuard.check(receiver)) {
+                    return monoExecutor.execute(frame, receiver, arg1, arg2);
+                }
+            }
+
             // TIER 3: Megamorphic Fallback (Indirect Execution)
             if ((currentState & HAS_INDIRECT) != 0) {
                 return indirectNode.execute(frame, (currentState & FLAG_PRIM_FAIL) != 0, selector, receiver, arg1, arg2);
@@ -87,13 +94,17 @@ public final class DispatchSelector2Node extends AbstractDispatchSelectorNode {
 
             // TIER 2: Wide Execution (Class Polymorphism)
             if ((currentState & HAS_WIDE) != 0) {
-                final ClassObject receiverClass = classNode.executeLookup(this, receiver);
-                final Object lookupResult = getContext().lookup(receiverClass, selector);
+                /* Local snapshot guards against stale compiled code during invalidation. */
+                final SqueakObjectClassNode node = classNode;
+                if (node != null) {
+                    final ClassObject receiverClass = node.executeLookup(this, receiver);
+                    final Object lookupResult = getContext().lookup(receiverClass, selector);
 
-                if (lookupResult instanceof CompiledCodeObject targetMethod) {
-                    for (final DispatchEntry<DispatchDirect2Node> entry : wideEntries) {
-                        if (entry.isWideCacheHit(targetMethod)) {
-                            return entry.executor.execute(frame, receiver, arg1, arg2);
+                    if (lookupResult instanceof CompiledCodeObject targetMethod) {
+                        for (final DispatchEntry<DispatchDirect2Node> entry : wideEntries) {
+                            if (entry.isWideCacheHit(targetMethod)) {
+                                return entry.executor.execute(frame, receiver, arg1, arg2);
+                            }
                         }
                     }
                 }
@@ -125,6 +136,7 @@ public final class DispatchSelector2Node extends AbstractDispatchSelectorNode {
             } else {
                 reportPolymorphicSpecialize();
                 indirectNode = insert(DispatchIndirect2NodeGen.create());
+                convertToIndirect();
                 return indirectNode.execute(frame, canPrimFail(), selector, receiver, arg1, arg2);
             }
         }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector3Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector3Node.java
@@ -106,9 +106,15 @@ public final class DispatchSelector3Node extends DispatchSelectorNode {
             return new DispatchDirectMethod3Node(assumptions, method);
         }
 
-        private static DispatchDirectMessageFallback3Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
-            final CompiledCodeObject fallbackMethod = receiverClass.resolveDispatchFailure(selector);
-            return new DispatchDirectMessageFallback3Node(assumptions, selector, fallbackMethod);
+        private static DispatchDirect3Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
+            final ClassObject.DispatchFailureResult result = receiverClass.resolveDispatchFailure(selector, 3);
+            final Assumption[] finalAssumptions = DispatchUtils.getAssumptionsForMessageFallback(assumptions, selector, result.fallbackMethod());
+
+            return switch (result.convention()) {
+                case SHORTCUT_DNU -> new DispatchDirectShortcutFallback3Node(finalAssumptions, selector, result.fallbackMethod());
+                case STANDARD_DNU -> new DispatchDirectDNUFallback3Node(finalAssumptions, selector, result.fallbackMethod());
+                case CANNOT_INTERPRET -> new DispatchDirectCannotInterpretFallback3Node(finalAssumptions, selector, result.fallbackMethod(), result.fallbackDepth(), result.fallbackSelector());
+            };
         }
     }
 
@@ -187,21 +193,68 @@ public final class DispatchSelector3Node extends DispatchSelectorNode {
         }
     }
 
-    static final class DispatchDirectMessageFallback3Node extends DispatchDirectWithSender3Node {
-        private final NativeObject selector;
-        @Child private DirectCallNode callNode;
-        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+    abstract static class AbstractDispatchDirectFallback3Node extends DispatchDirectWithSender3Node {
+        protected final NativeObject selector;
+        @Child protected DirectCallNode callNode;
 
-        DispatchDirectMessageFallback3Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+        AbstractDispatchDirectFallback3Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject targetMethod) {
             super(assumptions);
             this.selector = selector;
-            callNode = DirectCallNode.create(dnuMethod.getCallTarget());
+            this.callNode = DirectCallNode.create(targetMethod.getCallTarget());
+        }
+
+        @Override
+        public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2, Object arg3);
+    }
+
+    static final class DispatchDirectDNUFallback3Node extends AbstractDispatchDirectFallback3Node {
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectDNUFallback3Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+            super(assumptions, selector, dnuMethod);
         }
 
         @Override
         public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3) {
             final PointersObject message = createMessageNode.execute(selector, receiver, new Object[]{arg1, arg2, arg3});
             return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
+        }
+    }
+
+    static final class DispatchDirectCannotInterpretFallback3Node extends AbstractDispatchDirectFallback3Node {
+        private final int fallbackDepth;
+        private final NativeObject ciSelector;
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectCannotInterpretFallback3Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject ciMethod, final int fallbackDepth,
+                        final NativeObject ciSelector) {
+            super(assumptions, selector, ciMethod);
+            this.fallbackDepth = fallbackDepth;
+            this.ciSelector = ciSelector;
+        }
+
+        @Override
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3) {
+            final PointersObject message = DispatchUtils.buildNestedMessage(
+                            createMessageNode,
+                            selector,
+                            ciSelector,
+                            receiver,
+                            new Object[]{arg1, arg2, arg3},
+                            fallbackDepth);
+            return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
+        }
+    }
+
+    static final class DispatchDirectShortcutFallback3Node extends AbstractDispatchDirectFallback3Node {
+
+        DispatchDirectShortcutFallback3Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject shortcutMethod) {
+            super(assumptions, selector, shortcutMethod);
+        }
+
+        @Override
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3) {
+            return callNode.call(FrameAccess.newWith(senderNode.execute(frame), null, receiver, arg1, arg2, arg3, selector));
         }
     }
 
@@ -241,7 +294,14 @@ public final class DispatchSelector3Node extends DispatchSelectorNode {
             final ClassObject receiverClass = classNode.executeLookup(node, receiver);
             final Object lookupResult = getContext(node).lookup(receiverClass, selector);
             final CompiledCodeObject method = methodNode.execute(node, getContext(node), 3, canPrimFail, selector, receiverClass, lookupResult);
-            final Object result = tryPrimitiveNode.execute(frame, method, receiver, arg1, arg2, arg3);
+
+            final Object result;
+            if (lookupResult instanceof CompiledCodeObject) {
+                result = tryPrimitiveNode.execute(frame, method, receiver, arg1, arg2, arg3);
+            } else {
+                result = null;
+            }
+
             if (result != null) {
                 return result;
             } else {
@@ -317,9 +377,21 @@ public final class DispatchSelector3Node extends DispatchSelectorNode {
             @Specialization(guards = "lookupResult == null")
             protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final Object arg2, final Object arg3,
                             final ClassObject receiverClass, @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
-                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode) {
+                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(3);
+
+                if (result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU) {
+                    return FrameAccess.newWith(sender, null, receiver, arg1, arg2, arg3, selector);
+                }
+
                 final Object[] arguments = new Object[]{arg1, arg2, arg3};
-                final PointersObject message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                final PointersObject message;
+                if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
+                    message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
+                } else {
+                    message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                }
                 return FrameAccess.newMessageFallbackWith(sender, receiver, message);
             }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector3Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector3Node.java
@@ -10,12 +10,15 @@ import com.oracle.truffle.api.Assumption;
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.HostCompilerDirectives;
 import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Cached.Exclusive;
 import com.oracle.truffle.api.dsl.GenerateCached;
 import com.oracle.truffle.api.dsl.GenerateInline;
 import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.NeverDefault;
+import com.oracle.truffle.api.dsl.ReportPolymorphism;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
@@ -44,13 +47,47 @@ import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive3;
 import de.hpi.swa.trufflesqueak.nodes.primitives.PrimitiveNodeFactory;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
-public final class DispatchSelector3Node extends DispatchSelectorNode {
+public final class DispatchSelector3Node extends AbstractDispatchSelectorNode {
+    public abstract static class Dispatch3Node extends AbstractDispatchNode {
+        Dispatch3Node(final NativeObject selector) {
+            super(selector);
+        }
+
+        @NeverDefault
+        public static Dispatch3Node create(final NativeObject selector) {
+            return DispatchSelector3NodeFactory.Dispatch3NodeGen.create(selector);
+        }
+
+        public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2, Object arg3);
+
+        @Specialization(guards = "guard.check(receiver)", assumptions = "dispatchDirectNode.getAssumptions()", limit = "INLINE_METHOD_CACHE_LIMIT")
+        protected static final Object doDirect(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3,
+                        @SuppressWarnings("unused") @Cached("create(receiver)") final LookupClassGuard guard,
+                        @Cached("create(selector, guard)") final DispatchDirect3Node dispatchDirectNode) {
+            return dispatchDirectNode.execute(frame, receiver, arg1, arg2, arg3);
+        }
+
+        @ReportPolymorphism.Megamorphic
+        @Specialization(replaces = "doDirect")
+        @HostCompilerDirectives.InliningCutoff
+        @SuppressWarnings("truffle-static-method")
+        protected final Object doIndirect(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3,
+                        @Cached final DispatchIndirect3Node dispatchNode) {
+            return dispatchNode.execute(frame, false, selector, receiver, arg1, arg2, arg3);
+        }
+    }
+
     public abstract static class DispatchDirect3Node extends AbstractDispatchDirectNode {
         DispatchDirect3Node(final Assumption[] assumptions) {
             super(assumptions);
         }
 
         public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2, Object arg3);
+
+        @NeverDefault
+        protected static final DispatchDirect3Node create(final NativeObject selector, final LookupClassGuard guard) {
+            return create(selector, guard, true);
+        }
 
         @NeverDefault
         public static final DispatchDirect3Node create(final NativeObject selector, final LookupClassGuard guard, final boolean canPrimFail) {
@@ -363,7 +400,7 @@ public final class DispatchSelector3Node extends DispatchSelectorNode {
 
         @GenerateInline
         @GenerateCached(false)
-        protected abstract static class CreateFrameArgumentsForIndirectCall3Node extends AbstractNode {
+        protected abstract static class CreateFrameArgumentsForIndirectCall3Node extends AbstractCreateFrameArgumentsForIndirectCallNode {
             abstract Object[] execute(Node node, AbstractSqueakObject sender, Object receiver, Object arg1, Object arg2, Object arg3, ClassObject receiverClass, Object lookupResult,
                             NativeObject selector);
 
@@ -374,25 +411,34 @@ public final class DispatchSelector3Node extends DispatchSelectorNode {
                 return FrameAccess.newWith(sender, null, receiver, arg1, arg2, arg3);
             }
 
-            @Specialization(guards = "lookupResult == null")
+            @Specialization(guards = "lookupResult == null", assumptions = {"image.getDnuShortcutsAbsent()"})
             protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final Object arg2, final Object arg3,
                             final ClassObject receiverClass, @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
-                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
-                            @Cached(inline = false) final CreateMessageNode createMessageNode) {
-                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(3);
-
-                if (result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU) {
-                    return FrameAccess.newWith(sender, null, receiver, arg1, arg2, arg3, selector);
-                }
-
+                            @Bind final SqueakImageContext image,
+                            @Exclusive @Cached final InlinedConditionProfile isCannotInterpretProfile,
+                            @Exclusive @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Exclusive @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = image.findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(3);
                 final Object[] arguments = new Object[]{arg1, arg2, arg3};
-                final PointersObject message;
-                if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
-                    message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
+                return newMessage(node, sender, receiver, arguments, receiverClass, selector, result, image, isCannotInterpretProfile, writeNode, createMessageNode);
+            }
+
+            @Specialization(guards = "lookupResult == null", replaces = "doMessageFallback")
+            protected static final Object[] doMessageFallbackWithShortcuts(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final Object arg2,
+                            final Object arg3,
+                            final ClassObject receiverClass, @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
+                            @Bind final SqueakImageContext image,
+                            @Exclusive @Cached final InlinedConditionProfile isShortcutProfile,
+                            @Exclusive @Cached final InlinedConditionProfile isCannotInterpretProfile,
+                            @Exclusive @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Exclusive @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = image.findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(3);
+                if (isShortcutProfile.profile(node, result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU)) {
+                    return FrameAccess.newWith(sender, null, receiver, arg1, arg2, arg3, selector);
                 } else {
-                    message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                    final Object[] arguments = new Object[]{arg1, arg2, arg3};
+                    return newMessage(node, sender, receiver, arguments, receiverClass, selector, result, image, isCannotInterpretProfile, writeNode, createMessageNode);
                 }
-                return FrameAccess.newMessageFallbackWith(sender, receiver, message);
             }
 
             @Specialization(guards = {"targetObject != null", "!isCompiledCodeObject(targetObject)"})

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector3Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector3Node.java
@@ -49,13 +49,21 @@ import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
 public final class DispatchSelector3Node extends AbstractDispatchSelectorNode {
     public abstract static class Dispatch3Node extends AbstractDispatchNode {
-        Dispatch3Node(final NativeObject selector) {
+        protected final boolean canPrimFail;
+
+        Dispatch3Node(final NativeObject selector, final boolean canPrimFail) {
             super(selector);
+            this.canPrimFail = canPrimFail;
         }
 
         @NeverDefault
         public static Dispatch3Node create(final NativeObject selector) {
-            return DispatchSelector3NodeFactory.Dispatch3NodeGen.create(selector);
+            return DispatchSelector3NodeFactory.Dispatch3NodeGen.create(selector, false);
+        }
+
+        @NeverDefault
+        public static Dispatch3Node create(final NativeObject selector, final boolean canPrimFail) {
+            return DispatchSelector3NodeFactory.Dispatch3NodeGen.create(selector, canPrimFail);
         }
 
         public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2, Object arg3);
@@ -73,7 +81,7 @@ public final class DispatchSelector3Node extends AbstractDispatchSelectorNode {
         @SuppressWarnings("truffle-static-method")
         protected final Object doIndirect(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3,
                         @Cached final DispatchIndirect3Node dispatchNode) {
-            return dispatchNode.execute(frame, false, selector, receiver, arg1, arg2, arg3);
+            return dispatchNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3);
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector3Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector3Node.java
@@ -101,9 +101,13 @@ public final class DispatchSelector3Node extends AbstractDispatchSelectorNode {
                         }
                     }
                 }
+
+                // Wide Cache Miss: Delegate to Manager for Specialization
+                CompilerDirectives.transferToInterpreterAndInvalidate();
+                return executeAndSpecialize(frame, receiverClass, lookupResult, receiver, arg1, arg2, arg3);
             }
 
-            // Cache Miss: Delegate to Manager for Specialization
+            // Fast Cache Miss: Delegate to Manager for Specialization
             CompilerDirectives.transferToInterpreterAndInvalidate();
             return executeAndSpecialize(frame, receiver, arg1, arg2, arg3);
         }
@@ -121,6 +125,14 @@ public final class DispatchSelector3Node extends AbstractDispatchSelectorNode {
 
             final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
             final Object lookupResult = getContext().lookup(receiverClass, selector);
+            return executeAndSpecialize(frame, receiverClass, lookupResult, receiver, arg1, arg2, arg3);
+        }
+
+        private Object executeAndSpecialize(final VirtualFrame frame, final ClassObject receiverClass, final Object lookupResult, final Object receiver, final Object arg1, final Object arg2, final Object arg3) {
+            // Guard against lagging recursive frames.
+            if (indirectNode != null) {
+                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3);
+            }
 
             // Node creation handles method resolution, including DNU and OAM fallbacks.
             final DispatchDirect3Node newDirectNode = DispatchDirect3Node.create(selector, receiverClass, canPrimFail);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector3Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector3Node.java
@@ -49,14 +49,11 @@ import de.hpi.swa.trufflesqueak.nodes.primitives.PrimitiveNodeFactory;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
 public final class DispatchSelector3Node extends AbstractDispatchSelectorNode {
-    public static final class Dispatch3Node extends AbstractDispatchNode {
-        protected final boolean canPrimFail;
-        @Child private DispatchCacheManager<DispatchDirect3Node> cache;
+    public static final class Dispatch3Node extends AbstractDispatchNode<DispatchDirect3Node> {
         @Child private DispatchIndirect3Node indirectNode;
 
         private Dispatch3Node(final NativeObject selector, final boolean canPrimFail) {
-            super(selector);
-            this.canPrimFail = canPrimFail;
+            super(selector, canPrimFail);
         }
 
         @NeverDefault
@@ -72,30 +69,29 @@ public final class DispatchSelector3Node extends AbstractDispatchSelectorNode {
         @ExplodeLoop
         @InliningCutoff
         public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3) {
-            // TIER 3: Megamorphic Fallback (Indirect Execution)
-            if (indirectNode != null) {
-                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3);
-            }
+            final byte currentState = state;
 
-            if (cache == null) {
-                CompilerDirectives.transferToInterpreterAndInvalidate();
-                cache = insert(new DispatchCacheManager<>());
+            // TIER 3: Megamorphic Fallback (Indirect Execution)
+            if ((currentState & HAS_INDIRECT) != 0) {
+                return indirectNode.execute(frame, (currentState & FLAG_PRIM_FAIL) != 0, selector, receiver, arg1, arg2, arg3);
             }
 
             // TIER 1: Direct Execution Fast Path
-            for (final DispatchEntry<DispatchDirect3Node> entry : cache.fastEntries) {
-                if (entry.isFastCacheHit(receiver)) {
-                    return entry.executor.execute(frame, receiver, arg1, arg2, arg3);
+            if ((currentState & HAS_FAST) != 0) {
+                for (final DispatchEntry<DispatchDirect3Node> entry : fastEntries) {
+                    if (entry.isFastCacheHit(receiver)) {
+                        return entry.executor.execute(frame, receiver, arg1, arg2, arg3);
+                    }
                 }
             }
 
             // TIER 2: Wide Execution (Class Polymorphism)
-            if (cache.wideEntries.length > 0) {
-                final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
+            if ((currentState & HAS_WIDE) != 0) {
+                final ClassObject receiverClass = classNode.executeLookup(this, receiver);
                 final Object lookupResult = getContext().lookup(receiverClass, selector);
 
                 if (lookupResult instanceof CompiledCodeObject targetMethod) {
-                    for (final DispatchEntry<DispatchDirect3Node> entry : cache.wideEntries) {
+                    for (final DispatchEntry<DispatchDirect3Node> entry : wideEntries) {
                         if (entry.isWideCacheHit(targetMethod)) {
                             return entry.executor.execute(frame, receiver, arg1, arg2, arg3);
                         }
@@ -103,35 +99,33 @@ public final class DispatchSelector3Node extends AbstractDispatchSelectorNode {
                 }
             }
 
-            // Cache Miss: Delegate to Manager for Specialization
+            // Cache Miss: Delegate to superclass for Specialization
             CompilerDirectives.transferToInterpreterAndInvalidate();
             return executeAndSpecialize(frame, receiver, arg1, arg2, arg3);
         }
 
         private Object executeAndSpecialize(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3) {
             /*
-             * Guard against lagging recursive frames. If multiple frames of this method are on the
-             * stack executing compiled code, a deeper frame may have already deoptimized and
-             * transitioned this node to the indirect tier. This intercepts older deoptimized frames
-             * to prevent redundant specialization.
+             * Guard against lagging recursive frames.
              */
-            if (indirectNode != null) {
-                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3);
+            if ((state & HAS_INDIRECT) != 0) {
+                return indirectNode.execute(frame, canPrimFail(), selector, receiver, arg1, arg2, arg3);
             }
 
-            final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
+            ensureClassNode();
+            final ClassObject receiverClass = classNode.executeLookup(this, receiver);
             final Object lookupResult = getContext().lookup(receiverClass, selector);
 
             // Node creation handles method resolution, including DNU and OAM fallbacks.
-            final DispatchDirect3Node executor = cache.specialize(receiver, receiverClass, lookupResult,
-                            () -> DispatchDirect3Node.create(selector, receiverClass, canPrimFail));
+            final DispatchDirect3Node executor = specialize(receiver, receiverClass, lookupResult,
+                            () -> DispatchDirect3Node.create(selector, receiverClass, canPrimFail()));
 
             if (executor != null) {
                 return executor.execute(frame, receiver, arg1, arg2, arg3);
             } else {
                 reportPolymorphicSpecialize();
                 indirectNode = insert(DispatchIndirect3NodeGen.create());
-                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3);
+                return indirectNode.execute(frame, canPrimFail(), selector, receiver, arg1, arg2, arg3);
             }
         }
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector3Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector3Node.java
@@ -10,7 +10,7 @@ import com.oracle.truffle.api.Assumption;
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
-import com.oracle.truffle.api.HostCompilerDirectives;
+import com.oracle.truffle.api.HostCompilerDirectives.InliningCutoff;
 import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Cached.Exclusive;
@@ -18,11 +18,11 @@ import com.oracle.truffle.api.dsl.GenerateCached;
 import com.oracle.truffle.api.dsl.GenerateInline;
 import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.NeverDefault;
-import com.oracle.truffle.api.dsl.ReportPolymorphism;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.DirectCallNode;
+import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.IndirectCallNode;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.InlinedBranchProfile;
@@ -41,6 +41,7 @@ import de.hpi.swa.trufflesqueak.nodes.accessing.AbstractPointersObjectNodes.Abst
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectClassNode;
 import de.hpi.swa.trufflesqueak.nodes.context.GetOrCreateContextWithoutFrameNode;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector3NodeFactory.DispatchDirectPrimitiveFallback3NodeGen;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector3NodeFactory.DispatchIndirect3NodeGen;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNode.DispatchPrimitiveNode;
 import de.hpi.swa.trufflesqueak.nodes.primitives.AbstractPrimitiveNode;
 import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive3;
@@ -48,40 +49,91 @@ import de.hpi.swa.trufflesqueak.nodes.primitives.PrimitiveNodeFactory;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
 public final class DispatchSelector3Node extends AbstractDispatchSelectorNode {
-    public abstract static class Dispatch3Node extends AbstractDispatchNode {
+    public static final class Dispatch3Node extends AbstractDispatchNode {
         protected final boolean canPrimFail;
+        @Child private DispatchCacheManager<DispatchDirect3Node> cache;
+        @Child private DispatchIndirect3Node indirectNode;
 
-        Dispatch3Node(final NativeObject selector, final boolean canPrimFail) {
+        private Dispatch3Node(final NativeObject selector, final boolean canPrimFail) {
             super(selector);
             this.canPrimFail = canPrimFail;
         }
 
         @NeverDefault
         public static Dispatch3Node create(final NativeObject selector) {
-            return DispatchSelector3NodeFactory.Dispatch3NodeGen.create(selector, false);
+            return new Dispatch3Node(selector, false);
         }
 
         @NeverDefault
         public static Dispatch3Node create(final NativeObject selector, final boolean canPrimFail) {
-            return DispatchSelector3NodeFactory.Dispatch3NodeGen.create(selector, canPrimFail);
+            return new Dispatch3Node(selector, canPrimFail);
         }
 
-        public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2, Object arg3);
+        @ExplodeLoop
+        @InliningCutoff
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3) {
+            // TIER 3: Megamorphic Fallback (Indirect Execution)
+            if (indirectNode != null) {
+                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3);
+            }
 
-        @Specialization(guards = "guard.check(receiver)", assumptions = "dispatchDirectNode.getAssumptions()", limit = "INLINE_METHOD_CACHE_LIMIT")
-        protected static final Object doDirect(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3,
-                        @SuppressWarnings("unused") @Cached("create(receiver)") final LookupClassGuard guard,
-                        @Cached("create(selector, guard)") final DispatchDirect3Node dispatchDirectNode) {
-            return dispatchDirectNode.execute(frame, receiver, arg1, arg2, arg3);
+            if (cache == null) {
+                CompilerDirectives.transferToInterpreterAndInvalidate();
+                cache = insert(new DispatchCacheManager<>());
+            }
+
+            // TIER 1: Direct Execution Fast Path
+            for (final DispatchEntry<DispatchDirect3Node> entry : cache.fastEntries) {
+                if (entry.isFastCacheHit(receiver)) {
+                    return entry.executor.execute(frame, receiver, arg1, arg2, arg3);
+                }
+            }
+
+            // TIER 2: Wide Execution (Class Polymorphism)
+            if (cache.wideEntries.length > 0) {
+                final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
+                final Object lookupResult = getContext().lookup(receiverClass, selector);
+
+                if (lookupResult instanceof CompiledCodeObject targetMethod) {
+                    for (final DispatchEntry<DispatchDirect3Node> entry : cache.wideEntries) {
+                        if (entry.isWideCacheHit(targetMethod)) {
+                            return entry.executor.execute(frame, receiver, arg1, arg2, arg3);
+                        }
+                    }
+                }
+            }
+
+            // Cache Miss: Delegate to Manager for Specialization
+            CompilerDirectives.transferToInterpreterAndInvalidate();
+            return executeAndSpecialize(frame, receiver, arg1, arg2, arg3);
         }
 
-        @ReportPolymorphism.Megamorphic
-        @Specialization(replaces = "doDirect")
-        @HostCompilerDirectives.InliningCutoff
-        @SuppressWarnings("truffle-static-method")
-        protected final Object doIndirect(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3,
-                        @Cached final DispatchIndirect3Node dispatchNode) {
-            return dispatchNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3);
+        private Object executeAndSpecialize(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3) {
+            /*
+             * Guard against lagging recursive frames. If multiple frames of this method are on the
+             * stack executing compiled code, a deeper frame may have already deoptimized and
+             * transitioned this node to the indirect tier. This intercepts older deoptimized frames
+             * to prevent redundant specialization.
+             */
+            if (indirectNode != null) {
+                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3);
+            }
+
+            final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
+            final Object lookupResult = getContext().lookup(receiverClass, selector);
+
+            // Node creation handles method resolution, including DNU and OAM fallbacks.
+            final DispatchDirect3Node newDirectNode = DispatchDirect3Node.create(selector, receiverClass, canPrimFail);
+
+            final DispatchDirect3Node executor = cache.specialize(receiver, lookupResult, newDirectNode);
+
+            if (executor != null) {
+                return executor.execute(frame, receiver, arg1, arg2, arg3);
+            } else {
+                this.reportPolymorphicSpecialize();
+                indirectNode = insert(DispatchIndirect3NodeGen.create());
+                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3);
+            }
         }
     }
 
@@ -94,7 +146,7 @@ public final class DispatchSelector3Node extends AbstractDispatchSelectorNode {
 
         @NeverDefault
         protected static final DispatchDirect3Node create(final NativeObject selector, final LookupClassGuard guard) {
-            return create(selector, guard, true);
+            return create(selector, guard, false);
         }
 
         @NeverDefault

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector3Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector3Node.java
@@ -101,13 +101,9 @@ public final class DispatchSelector3Node extends AbstractDispatchSelectorNode {
                         }
                     }
                 }
-
-                // Wide Cache Miss: Delegate to Manager for Specialization
-                CompilerDirectives.transferToInterpreterAndInvalidate();
-                return executeAndSpecialize(frame, receiverClass, lookupResult, receiver, arg1, arg2, arg3);
             }
 
-            // Fast Cache Miss: Delegate to Manager for Specialization
+            // Cache Miss: Delegate to Manager for Specialization
             CompilerDirectives.transferToInterpreterAndInvalidate();
             return executeAndSpecialize(frame, receiver, arg1, arg2, arg3);
         }
@@ -125,15 +121,6 @@ public final class DispatchSelector3Node extends AbstractDispatchSelectorNode {
 
             final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
             final Object lookupResult = getContext().lookup(receiverClass, selector);
-            return executeAndSpecialize(frame, receiverClass, lookupResult, receiver, arg1, arg2, arg3);
-        }
-
-        private Object executeAndSpecialize(final VirtualFrame frame, final ClassObject receiverClass, final Object lookupResult, final Object receiver, final Object arg1, final Object arg2,
-                        final Object arg3) {
-            // Guard against lagging recursive frames.
-            if (indirectNode != null) {
-                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3);
-            }
 
             // Node creation handles method resolution, including DNU and OAM fallbacks.
             final DispatchDirect3Node executor = cache.specialize(receiver, receiverClass, lookupResult,
@@ -142,7 +129,7 @@ public final class DispatchSelector3Node extends AbstractDispatchSelectorNode {
             if (executor != null) {
                 return executor.execute(frame, receiver, arg1, arg2, arg3);
             } else {
-                this.reportPolymorphicSpecialize();
+                reportPolymorphicSpecialize();
                 indirectNode = insert(DispatchIndirect3NodeGen.create());
                 return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3);
             }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector3Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector3Node.java
@@ -71,6 +71,13 @@ public final class DispatchSelector3Node extends AbstractDispatchSelectorNode {
         public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3) {
             final byte currentState = state;
 
+            // TIER 0: Pure Monomorphic Fast Path
+            if ((currentState & HAS_MONO) != 0) {
+                if (Assumption.isValidAssumption(monoExecutor.getAssumptions()) && monoGuard.check(receiver)) {
+                    return monoExecutor.execute(frame, receiver, arg1, arg2, arg3);
+                }
+            }
+
             // TIER 3: Megamorphic Fallback (Indirect Execution)
             if ((currentState & HAS_INDIRECT) != 0) {
                 return indirectNode.execute(frame, (currentState & FLAG_PRIM_FAIL) != 0, selector, receiver, arg1, arg2, arg3);
@@ -87,13 +94,17 @@ public final class DispatchSelector3Node extends AbstractDispatchSelectorNode {
 
             // TIER 2: Wide Execution (Class Polymorphism)
             if ((currentState & HAS_WIDE) != 0) {
-                final ClassObject receiverClass = classNode.executeLookup(this, receiver);
-                final Object lookupResult = getContext().lookup(receiverClass, selector);
+                /* Local snapshot guards against stale compiled code during invalidation. */
+                final SqueakObjectClassNode node = classNode;
+                if (node != null) {
+                    final ClassObject receiverClass = node.executeLookup(this, receiver);
+                    final Object lookupResult = getContext().lookup(receiverClass, selector);
 
-                if (lookupResult instanceof CompiledCodeObject targetMethod) {
-                    for (final DispatchEntry<DispatchDirect3Node> entry : wideEntries) {
-                        if (entry.isWideCacheHit(targetMethod)) {
-                            return entry.executor.execute(frame, receiver, arg1, arg2, arg3);
+                    if (lookupResult instanceof CompiledCodeObject targetMethod) {
+                        for (final DispatchEntry<DispatchDirect3Node> entry : wideEntries) {
+                            if (entry.isWideCacheHit(targetMethod)) {
+                                return entry.executor.execute(frame, receiver, arg1, arg2, arg3);
+                            }
                         }
                     }
                 }
@@ -125,6 +136,7 @@ public final class DispatchSelector3Node extends AbstractDispatchSelectorNode {
             } else {
                 reportPolymorphicSpecialize();
                 indirectNode = insert(DispatchIndirect3NodeGen.create());
+                convertToIndirect();
                 return indirectNode.execute(frame, canPrimFail(), selector, receiver, arg1, arg2, arg3);
             }
         }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector3Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector3Node.java
@@ -128,16 +128,16 @@ public final class DispatchSelector3Node extends AbstractDispatchSelectorNode {
             return executeAndSpecialize(frame, receiverClass, lookupResult, receiver, arg1, arg2, arg3);
         }
 
-        private Object executeAndSpecialize(final VirtualFrame frame, final ClassObject receiverClass, final Object lookupResult, final Object receiver, final Object arg1, final Object arg2, final Object arg3) {
+        private Object executeAndSpecialize(final VirtualFrame frame, final ClassObject receiverClass, final Object lookupResult, final Object receiver, final Object arg1, final Object arg2,
+                        final Object arg3) {
             // Guard against lagging recursive frames.
             if (indirectNode != null) {
                 return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3);
             }
 
             // Node creation handles method resolution, including DNU and OAM fallbacks.
-            final DispatchDirect3Node newDirectNode = DispatchDirect3Node.create(selector, receiverClass, canPrimFail);
-
-            final DispatchDirect3Node executor = cache.specialize(receiver, lookupResult, newDirectNode);
+            final DispatchDirect3Node executor = cache.specialize(receiver, receiverClass, lookupResult,
+                            () -> DispatchDirect3Node.create(selector, receiverClass, canPrimFail));
 
             if (executor != null) {
                 return executor.execute(frame, receiver, arg1, arg2, arg3);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector4Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector4Node.java
@@ -106,9 +106,16 @@ public final class DispatchSelector4Node extends DispatchSelectorNode {
             return new DispatchDirectMethod4Node(assumptions, method);
         }
 
-        private static DispatchDirectMessageFallback4Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
-            final CompiledCodeObject fallbackMethod = receiverClass.resolveDispatchFailure(selector);
-            return new DispatchDirectMessageFallback4Node(assumptions, selector, fallbackMethod);
+        private static DispatchDirect4Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
+            final ClassObject.DispatchFailureResult result = receiverClass.resolveDispatchFailure(selector, 4);
+            final Assumption[] finalAssumptions = DispatchUtils.getAssumptionsForMessageFallback(assumptions, selector, result.fallbackMethod());
+
+            if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
+                return new DispatchDirectCannotInterpretFallback4Node(finalAssumptions, selector, result.fallbackMethod(), result.fallbackDepth(), result.fallbackSelector());
+            } else {
+                assert result.convention() == ClassObject.FallbackConvention.STANDARD_DNU : "DNU shortcuts are not supported for arity 4+";
+                return new DispatchDirectDNUFallback4Node(finalAssumptions, selector, result.fallbackMethod());
+            }
         }
     }
 
@@ -188,20 +195,55 @@ public final class DispatchSelector4Node extends DispatchSelectorNode {
         }
     }
 
-    static final class DispatchDirectMessageFallback4Node extends DispatchDirectWithSender4Node {
-        private final NativeObject selector;
-        @Child private DirectCallNode callNode;
-        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+    abstract static class AbstractDispatchDirectFallback4Node extends DispatchDirectWithSender4Node {
+        protected final NativeObject selector;
+        @Child protected DirectCallNode callNode;
 
-        DispatchDirectMessageFallback4Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+        AbstractDispatchDirectFallback4Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject targetMethod) {
             super(assumptions);
             this.selector = selector;
-            callNode = DirectCallNode.create(dnuMethod.getCallTarget());
+            this.callNode = DirectCallNode.create(targetMethod.getCallTarget());
+        }
+
+        @Override
+        public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2, Object arg3, Object arg4);
+    }
+
+    static final class DispatchDirectDNUFallback4Node extends AbstractDispatchDirectFallback4Node {
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectDNUFallback4Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+            super(assumptions, selector, dnuMethod);
         }
 
         @Override
         public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4) {
             final PointersObject message = createMessageNode.execute(selector, receiver, new Object[]{arg1, arg2, arg3, arg4});
+            return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
+        }
+    }
+
+    static final class DispatchDirectCannotInterpretFallback4Node extends AbstractDispatchDirectFallback4Node {
+        private final int fallbackDepth;
+        private final NativeObject ciSelector;
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectCannotInterpretFallback4Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject ciMethod, final int fallbackDepth,
+                        final NativeObject ciSelector) {
+            super(assumptions, selector, ciMethod);
+            this.fallbackDepth = fallbackDepth;
+            this.ciSelector = ciSelector;
+        }
+
+        @Override
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4) {
+            final PointersObject message = DispatchUtils.buildNestedMessage(
+                            createMessageNode,
+                            selector,
+                            ciSelector,
+                            receiver,
+                            new Object[]{arg1, arg2, arg3, arg4},
+                            fallbackDepth);
             return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
         }
     }
@@ -242,7 +284,14 @@ public final class DispatchSelector4Node extends DispatchSelectorNode {
             final ClassObject receiverClass = classNode.executeLookup(node, receiver);
             final Object lookupResult = getContext(node).lookup(receiverClass, selector);
             final CompiledCodeObject method = methodNode.execute(node, getContext(node), 4, canPrimFail, selector, receiverClass, lookupResult);
-            final Object result = tryPrimitiveNode.execute(frame, method, receiver, arg1, arg2, arg3, arg4);
+
+            final Object result;
+            if (lookupResult instanceof CompiledCodeObject) {
+                result = tryPrimitiveNode.execute(frame, method, receiver, arg1, arg2, arg3, arg4);
+            } else {
+                result = null;
+            }
+
             if (result != null) {
                 return result;
             } else {
@@ -319,9 +368,17 @@ public final class DispatchSelector4Node extends DispatchSelectorNode {
             @Specialization(guards = "lookupResult == null")
             protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final Object arg2, final Object arg3,
                             final Object arg4, final ClassObject receiverClass, @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
-                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode) {
+                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(4);
                 final Object[] arguments = new Object[]{arg1, arg2, arg3, arg4};
-                final PointersObject message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+
+                final PointersObject message;
+                if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
+                    message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
+                } else {
+                    message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                }
                 return FrameAccess.newMessageFallbackWith(sender, receiver, message);
             }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector4Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector4Node.java
@@ -100,9 +100,13 @@ public final class DispatchSelector4Node extends AbstractDispatchSelectorNode {
                         }
                     }
                 }
+
+                // Wide Cache Miss: Delegate to Manager for Specialization
+                CompilerDirectives.transferToInterpreterAndInvalidate();
+                return executeAndSpecialize(frame, receiverClass, lookupResult, receiver, arg1, arg2, arg3, arg4);
             }
 
-            // Cache Miss: Delegate to Manager for Specialization
+            // Fast Cache Miss: Delegate to Manager for Specialization
             CompilerDirectives.transferToInterpreterAndInvalidate();
             return executeAndSpecialize(frame, receiver, arg1, arg2, arg3, arg4);
         }
@@ -120,6 +124,14 @@ public final class DispatchSelector4Node extends AbstractDispatchSelectorNode {
 
             final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
             final Object lookupResult = getContext().lookup(receiverClass, selector);
+            return executeAndSpecialize(frame, receiverClass, lookupResult, receiver, arg1, arg2, arg3, arg4);
+        }
+
+        private Object executeAndSpecialize(final VirtualFrame frame, final ClassObject receiverClass, final Object lookupResult, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4) {
+            // Guard against lagging recursive frames.
+            if (indirectNode != null) {
+                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3, arg4);
+            }
 
             // Node creation handles method resolution, including DNU and OAM fallbacks.
             final DispatchDirect4Node newDirectNode = DispatchDirect4Node.create(selector, receiverClass, canPrimFail);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector4Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector4Node.java
@@ -100,13 +100,9 @@ public final class DispatchSelector4Node extends AbstractDispatchSelectorNode {
                         }
                     }
                 }
-
-                // Wide Cache Miss: Delegate to Manager for Specialization
-                CompilerDirectives.transferToInterpreterAndInvalidate();
-                return executeAndSpecialize(frame, receiverClass, lookupResult, receiver, arg1, arg2, arg3, arg4);
             }
 
-            // Fast Cache Miss: Delegate to Manager for Specialization
+            // Cache Miss: Delegate to Manager for Specialization
             CompilerDirectives.transferToInterpreterAndInvalidate();
             return executeAndSpecialize(frame, receiver, arg1, arg2, arg3, arg4);
         }
@@ -124,15 +120,6 @@ public final class DispatchSelector4Node extends AbstractDispatchSelectorNode {
 
             final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
             final Object lookupResult = getContext().lookup(receiverClass, selector);
-            return executeAndSpecialize(frame, receiverClass, lookupResult, receiver, arg1, arg2, arg3, arg4);
-        }
-
-        private Object executeAndSpecialize(final VirtualFrame frame, final ClassObject receiverClass, final Object lookupResult, final Object receiver, final Object arg1, final Object arg2,
-                        final Object arg3, final Object arg4) {
-            // Guard against lagging recursive frames.
-            if (indirectNode != null) {
-                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3, arg4);
-            }
 
             // Node creation handles method resolution, including DNU and OAM fallbacks.
             final DispatchDirect4Node executor = cache.specialize(receiver, receiverClass, lookupResult,
@@ -141,7 +128,7 @@ public final class DispatchSelector4Node extends AbstractDispatchSelectorNode {
             if (executor != null) {
                 return executor.execute(frame, receiver, arg1, arg2, arg3, arg4);
             } else {
-                this.reportPolymorphicSpecialize();
+                reportPolymorphicSpecialize();
                 indirectNode = insert(DispatchIndirect4NodeGen.create());
                 return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3, arg4);
             }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector4Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector4Node.java
@@ -48,14 +48,11 @@ import de.hpi.swa.trufflesqueak.nodes.primitives.PrimitiveNodeFactory;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
 public final class DispatchSelector4Node extends AbstractDispatchSelectorNode {
-    public static final class Dispatch4Node extends AbstractDispatchNode {
-        protected final boolean canPrimFail;
-        @Child private DispatchCacheManager<DispatchDirect4Node> cache;
+    public static final class Dispatch4Node extends AbstractDispatchNode<DispatchDirect4Node> {
         @Child private DispatchIndirect4Node indirectNode;
 
         private Dispatch4Node(final NativeObject selector, final boolean canPrimFail) {
-            super(selector);
-            this.canPrimFail = canPrimFail;
+            super(selector, canPrimFail);
         }
 
         @NeverDefault
@@ -71,30 +68,29 @@ public final class DispatchSelector4Node extends AbstractDispatchSelectorNode {
         @ExplodeLoop
         @InliningCutoff
         public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4) {
-            // TIER 3: Megamorphic Fallback (Indirect Execution)
-            if (indirectNode != null) {
-                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3, arg4);
-            }
+            final byte currentState = state;
 
-            if (cache == null) {
-                CompilerDirectives.transferToInterpreterAndInvalidate();
-                cache = insert(new DispatchCacheManager<>());
+            // TIER 3: Megamorphic Fallback (Indirect Execution)
+            if ((currentState & HAS_INDIRECT) != 0) {
+                return indirectNode.execute(frame, (currentState & FLAG_PRIM_FAIL) != 0, selector, receiver, arg1, arg2, arg3, arg4);
             }
 
             // TIER 1: Direct Execution Fast Path
-            for (final DispatchEntry<DispatchDirect4Node> entry : cache.fastEntries) {
-                if (entry.isFastCacheHit(receiver)) {
-                    return entry.executor.execute(frame, receiver, arg1, arg2, arg3, arg4);
+            if ((currentState & HAS_FAST) != 0) {
+                for (final DispatchEntry<DispatchDirect4Node> entry : fastEntries) {
+                    if (entry.isFastCacheHit(receiver)) {
+                        return entry.executor.execute(frame, receiver, arg1, arg2, arg3, arg4);
+                    }
                 }
             }
 
             // TIER 2: Wide Execution (Class Polymorphism)
-            if (cache.wideEntries.length > 0) {
-                final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
+            if ((currentState & HAS_WIDE) != 0) {
+                final ClassObject receiverClass = classNode.executeLookup(this, receiver);
                 final Object lookupResult = getContext().lookup(receiverClass, selector);
 
                 if (lookupResult instanceof CompiledCodeObject targetMethod) {
-                    for (final DispatchEntry<DispatchDirect4Node> entry : cache.wideEntries) {
+                    for (final DispatchEntry<DispatchDirect4Node> entry : wideEntries) {
                         if (entry.isWideCacheHit(targetMethod)) {
                             return entry.executor.execute(frame, receiver, arg1, arg2, arg3, arg4);
                         }
@@ -102,35 +98,33 @@ public final class DispatchSelector4Node extends AbstractDispatchSelectorNode {
                 }
             }
 
-            // Cache Miss: Delegate to Manager for Specialization
+            // Cache Miss: Delegate to superclass for Specialization
             CompilerDirectives.transferToInterpreterAndInvalidate();
             return executeAndSpecialize(frame, receiver, arg1, arg2, arg3, arg4);
         }
 
         private Object executeAndSpecialize(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4) {
             /*
-             * Guard against lagging recursive frames. If multiple frames of this method are on the
-             * stack executing compiled code, a deeper frame may have already deoptimized and
-             * transitioned this node to the indirect tier. This intercepts older deoptimized frames
-             * to prevent redundant specialization.
+             * Guard against lagging recursive frames.
              */
-            if (indirectNode != null) {
-                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3, arg4);
+            if ((state & HAS_INDIRECT) != 0) {
+                return indirectNode.execute(frame, canPrimFail(), selector, receiver, arg1, arg2, arg3, arg4);
             }
 
-            final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
+            ensureClassNode();
+            final ClassObject receiverClass = classNode.executeLookup(this, receiver);
             final Object lookupResult = getContext().lookup(receiverClass, selector);
 
             // Node creation handles method resolution, including DNU and OAM fallbacks.
-            final DispatchDirect4Node executor = cache.specialize(receiver, receiverClass, lookupResult,
-                            () -> DispatchDirect4Node.create(selector, receiverClass, canPrimFail));
+            final DispatchDirect4Node executor = specialize(receiver, receiverClass, lookupResult,
+                            () -> DispatchDirect4Node.create(selector, receiverClass, canPrimFail()));
 
             if (executor != null) {
                 return executor.execute(frame, receiver, arg1, arg2, arg3, arg4);
             } else {
                 reportPolymorphicSpecialize();
                 indirectNode = insert(DispatchIndirect4NodeGen.create());
-                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3, arg4);
+                return indirectNode.execute(frame, canPrimFail(), selector, receiver, arg1, arg2, arg3, arg4);
             }
         }
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector4Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector4Node.java
@@ -10,18 +10,18 @@ import com.oracle.truffle.api.Assumption;
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
-import com.oracle.truffle.api.HostCompilerDirectives;
+import com.oracle.truffle.api.HostCompilerDirectives.InliningCutoff;
 import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.GenerateCached;
 import com.oracle.truffle.api.dsl.GenerateInline;
 import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.NeverDefault;
-import com.oracle.truffle.api.dsl.ReportPolymorphism;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.DirectCallNode;
+import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.IndirectCallNode;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.InlinedBranchProfile;
@@ -40,6 +40,7 @@ import de.hpi.swa.trufflesqueak.nodes.accessing.AbstractPointersObjectNodes.Abst
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectClassNode;
 import de.hpi.swa.trufflesqueak.nodes.context.GetOrCreateContextWithoutFrameNode;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector4NodeFactory.DispatchDirectPrimitiveFallback4NodeGen;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector4NodeFactory.DispatchIndirect4NodeGen;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNode.DispatchPrimitiveNode;
 import de.hpi.swa.trufflesqueak.nodes.primitives.AbstractPrimitiveNode;
 import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive4;
@@ -47,40 +48,91 @@ import de.hpi.swa.trufflesqueak.nodes.primitives.PrimitiveNodeFactory;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
 public final class DispatchSelector4Node extends AbstractDispatchSelectorNode {
-    public abstract static class Dispatch4Node extends AbstractDispatchNode {
+    public static final class Dispatch4Node extends AbstractDispatchNode {
         protected final boolean canPrimFail;
+        @Child private DispatchCacheManager<DispatchDirect4Node> cache;
+        @Child private DispatchIndirect4Node indirectNode;
 
-        Dispatch4Node(final NativeObject selector, final boolean canPrimFail) {
+        private Dispatch4Node(final NativeObject selector, final boolean canPrimFail) {
             super(selector);
             this.canPrimFail = canPrimFail;
         }
 
         @NeverDefault
         public static Dispatch4Node create(final NativeObject selector) {
-            return DispatchSelector4NodeFactory.Dispatch4NodeGen.create(selector, false);
+            return new Dispatch4Node(selector, false);
         }
 
         @NeverDefault
         public static Dispatch4Node create(final NativeObject selector, final boolean canPrimFail) {
-            return DispatchSelector4NodeFactory.Dispatch4NodeGen.create(selector, canPrimFail);
+            return new Dispatch4Node(selector, canPrimFail);
         }
 
-        public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2, Object arg3, Object arg4);
+        @ExplodeLoop
+        @InliningCutoff
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4) {
+            // TIER 3: Megamorphic Fallback (Indirect Execution)
+            if (indirectNode != null) {
+                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3, arg4);
+            }
 
-        @Specialization(guards = "guard.check(receiver)", assumptions = "dispatchDirectNode.getAssumptions()", limit = "INLINE_METHOD_CACHE_LIMIT")
-        protected static final Object doDirect(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4,
-                        @SuppressWarnings("unused") @Cached("create(receiver)") final LookupClassGuard guard,
-                        @Cached("create(selector, guard)") final DispatchDirect4Node dispatchDirectNode) {
-            return dispatchDirectNode.execute(frame, receiver, arg1, arg2, arg3, arg4);
+            if (cache == null) {
+                CompilerDirectives.transferToInterpreterAndInvalidate();
+                cache = insert(new DispatchCacheManager<>());
+            }
+
+            // TIER 1: Direct Execution Fast Path
+            for (final DispatchEntry<DispatchDirect4Node> entry : cache.fastEntries) {
+                if (entry.isFastCacheHit(receiver)) {
+                    return entry.executor.execute(frame, receiver, arg1, arg2, arg3, arg4);
+                }
+            }
+
+            // TIER 2: Wide Execution (Class Polymorphism)
+            if (cache.wideEntries.length > 0) {
+                final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
+                final Object lookupResult = getContext().lookup(receiverClass, selector);
+
+                if (lookupResult instanceof CompiledCodeObject targetMethod) {
+                    for (final DispatchEntry<DispatchDirect4Node> entry : cache.wideEntries) {
+                        if (entry.isWideCacheHit(targetMethod)) {
+                            return entry.executor.execute(frame, receiver, arg1, arg2, arg3, arg4);
+                        }
+                    }
+                }
+            }
+
+            // Cache Miss: Delegate to Manager for Specialization
+            CompilerDirectives.transferToInterpreterAndInvalidate();
+            return executeAndSpecialize(frame, receiver, arg1, arg2, arg3, arg4);
         }
 
-        @ReportPolymorphism.Megamorphic
-        @Specialization(replaces = "doDirect")
-        @HostCompilerDirectives.InliningCutoff
-        @SuppressWarnings("truffle-static-method")
-        protected final Object doIndirect(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4,
-                        @Cached final DispatchIndirect4Node dispatchNode) {
-            return dispatchNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3, arg4);
+        private Object executeAndSpecialize(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4) {
+            /*
+             * Guard against lagging recursive frames. If multiple frames of this method are on the
+             * stack executing compiled code, a deeper frame may have already deoptimized and
+             * transitioned this node to the indirect tier. This intercepts older deoptimized frames
+             * to prevent redundant specialization.
+             */
+            if (indirectNode != null) {
+                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3, arg4);
+            }
+
+            final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
+            final Object lookupResult = getContext().lookup(receiverClass, selector);
+
+            // Node creation handles method resolution, including DNU and OAM fallbacks.
+            final DispatchDirect4Node newDirectNode = DispatchDirect4Node.create(selector, receiverClass, canPrimFail);
+
+            final DispatchDirect4Node executor = cache.specialize(receiver, lookupResult, newDirectNode);
+
+            if (executor != null) {
+                return executor.execute(frame, receiver, arg1, arg2, arg3, arg4);
+            } else {
+                this.reportPolymorphicSpecialize();
+                indirectNode = insert(DispatchIndirect4NodeGen.create());
+                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3, arg4);
+            }
         }
     }
 
@@ -93,7 +145,7 @@ public final class DispatchSelector4Node extends AbstractDispatchSelectorNode {
 
         @NeverDefault
         protected static final DispatchDirect4Node create(final NativeObject selector, final LookupClassGuard guard) {
-            return create(selector, guard, true);
+            return create(selector, guard, false);
         }
 
         @NeverDefault

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector4Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector4Node.java
@@ -10,12 +10,14 @@ import com.oracle.truffle.api.Assumption;
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.HostCompilerDirectives;
 import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.GenerateCached;
 import com.oracle.truffle.api.dsl.GenerateInline;
 import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.NeverDefault;
+import com.oracle.truffle.api.dsl.ReportPolymorphism;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
@@ -44,13 +46,47 @@ import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive4;
 import de.hpi.swa.trufflesqueak.nodes.primitives.PrimitiveNodeFactory;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
-public final class DispatchSelector4Node extends DispatchSelectorNode {
+public final class DispatchSelector4Node extends AbstractDispatchSelectorNode {
+    public abstract static class Dispatch4Node extends AbstractDispatchNode {
+        Dispatch4Node(final NativeObject selector) {
+            super(selector);
+        }
+
+        @NeverDefault
+        public static Dispatch4Node create(final NativeObject selector) {
+            return DispatchSelector4NodeFactory.Dispatch4NodeGen.create(selector);
+        }
+
+        public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2, Object arg3, Object arg4);
+
+        @Specialization(guards = "guard.check(receiver)", assumptions = "dispatchDirectNode.getAssumptions()", limit = "INLINE_METHOD_CACHE_LIMIT")
+        protected static final Object doDirect(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4,
+                        @SuppressWarnings("unused") @Cached("create(receiver)") final LookupClassGuard guard,
+                        @Cached("create(selector, guard)") final DispatchDirect4Node dispatchDirectNode) {
+            return dispatchDirectNode.execute(frame, receiver, arg1, arg2, arg3, arg4);
+        }
+
+        @ReportPolymorphism.Megamorphic
+        @Specialization(replaces = "doDirect")
+        @HostCompilerDirectives.InliningCutoff
+        @SuppressWarnings("truffle-static-method")
+        protected final Object doIndirect(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4,
+                        @Cached final DispatchIndirect4Node dispatchNode) {
+            return dispatchNode.execute(frame, false, selector, receiver, arg1, arg2, arg3, arg4);
+        }
+    }
+
     public abstract static class DispatchDirect4Node extends AbstractDispatchDirectNode {
         DispatchDirect4Node(final Assumption[] assumptions) {
             super(assumptions);
         }
 
         public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2, Object arg3, Object arg4);
+
+        @NeverDefault
+        protected static final DispatchDirect4Node create(final NativeObject selector, final LookupClassGuard guard) {
+            return create(selector, guard, true);
+        }
 
         @NeverDefault
         public static final DispatchDirect4Node create(final NativeObject selector, final LookupClassGuard guard, final boolean canPrimFail) {
@@ -354,7 +390,7 @@ public final class DispatchSelector4Node extends DispatchSelectorNode {
 
         @GenerateInline
         @GenerateCached(false)
-        protected abstract static class CreateFrameArgumentsForIndirectCall4Node extends AbstractNode {
+        protected abstract static class CreateFrameArgumentsForIndirectCall4Node extends AbstractCreateFrameArgumentsForIndirectCallNode {
             abstract Object[] execute(Node node, AbstractSqueakObject sender, Object receiver, Object arg1, Object arg2, Object arg3, Object arg4, ClassObject receiverClass, Object lookupResult,
                             NativeObject selector);
 
@@ -368,18 +404,13 @@ public final class DispatchSelector4Node extends DispatchSelectorNode {
             @Specialization(guards = "lookupResult == null")
             protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final Object arg2, final Object arg3,
                             final Object arg4, final ClassObject receiverClass, @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
+                            @Bind final SqueakImageContext image,
+                            @Cached final InlinedConditionProfile isCannotInterpretProfile,
                             @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
                             @Cached(inline = false) final CreateMessageNode createMessageNode) {
-                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(4);
+                final ClassObject.DispatchFailureResult result = image.findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(4);
                 final Object[] arguments = new Object[]{arg1, arg2, arg3, arg4};
-
-                final PointersObject message;
-                if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
-                    message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
-                } else {
-                    message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
-                }
-                return FrameAccess.newMessageFallbackWith(sender, receiver, message);
+                return newMessage(node, sender, receiver, arguments, receiverClass, selector, result, image, isCannotInterpretProfile, writeNode, createMessageNode);
             }
 
             @Specialization(guards = {"targetObject != null", "!isCompiledCodeObject(targetObject)"})

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector4Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector4Node.java
@@ -48,13 +48,21 @@ import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
 public final class DispatchSelector4Node extends AbstractDispatchSelectorNode {
     public abstract static class Dispatch4Node extends AbstractDispatchNode {
-        Dispatch4Node(final NativeObject selector) {
+        protected final boolean canPrimFail;
+
+        Dispatch4Node(final NativeObject selector, final boolean canPrimFail) {
             super(selector);
+            this.canPrimFail = canPrimFail;
         }
 
         @NeverDefault
         public static Dispatch4Node create(final NativeObject selector) {
-            return DispatchSelector4NodeFactory.Dispatch4NodeGen.create(selector);
+            return DispatchSelector4NodeFactory.Dispatch4NodeGen.create(selector, false);
+        }
+
+        @NeverDefault
+        public static Dispatch4Node create(final NativeObject selector, final boolean canPrimFail) {
+            return DispatchSelector4NodeFactory.Dispatch4NodeGen.create(selector, canPrimFail);
         }
 
         public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2, Object arg3, Object arg4);
@@ -72,7 +80,7 @@ public final class DispatchSelector4Node extends AbstractDispatchSelectorNode {
         @SuppressWarnings("truffle-static-method")
         protected final Object doIndirect(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4,
                         @Cached final DispatchIndirect4Node dispatchNode) {
-            return dispatchNode.execute(frame, false, selector, receiver, arg1, arg2, arg3, arg4);
+            return dispatchNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3, arg4);
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector4Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector4Node.java
@@ -127,16 +127,16 @@ public final class DispatchSelector4Node extends AbstractDispatchSelectorNode {
             return executeAndSpecialize(frame, receiverClass, lookupResult, receiver, arg1, arg2, arg3, arg4);
         }
 
-        private Object executeAndSpecialize(final VirtualFrame frame, final ClassObject receiverClass, final Object lookupResult, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4) {
+        private Object executeAndSpecialize(final VirtualFrame frame, final ClassObject receiverClass, final Object lookupResult, final Object receiver, final Object arg1, final Object arg2,
+                        final Object arg3, final Object arg4) {
             // Guard against lagging recursive frames.
             if (indirectNode != null) {
                 return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3, arg4);
             }
 
             // Node creation handles method resolution, including DNU and OAM fallbacks.
-            final DispatchDirect4Node newDirectNode = DispatchDirect4Node.create(selector, receiverClass, canPrimFail);
-
-            final DispatchDirect4Node executor = cache.specialize(receiver, lookupResult, newDirectNode);
+            final DispatchDirect4Node executor = cache.specialize(receiver, receiverClass, lookupResult,
+                            () -> DispatchDirect4Node.create(selector, receiverClass, canPrimFail));
 
             if (executor != null) {
                 return executor.execute(frame, receiver, arg1, arg2, arg3, arg4);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector4Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector4Node.java
@@ -70,6 +70,13 @@ public final class DispatchSelector4Node extends AbstractDispatchSelectorNode {
         public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4) {
             final byte currentState = state;
 
+            // TIER 0: Pure Monomorphic Fast Path
+            if ((currentState & HAS_MONO) != 0) {
+                if (Assumption.isValidAssumption(monoExecutor.getAssumptions()) && monoGuard.check(receiver)) {
+                    return monoExecutor.execute(frame, receiver, arg1, arg2, arg3, arg4);
+                }
+            }
+
             // TIER 3: Megamorphic Fallback (Indirect Execution)
             if ((currentState & HAS_INDIRECT) != 0) {
                 return indirectNode.execute(frame, (currentState & FLAG_PRIM_FAIL) != 0, selector, receiver, arg1, arg2, arg3, arg4);
@@ -86,13 +93,17 @@ public final class DispatchSelector4Node extends AbstractDispatchSelectorNode {
 
             // TIER 2: Wide Execution (Class Polymorphism)
             if ((currentState & HAS_WIDE) != 0) {
-                final ClassObject receiverClass = classNode.executeLookup(this, receiver);
-                final Object lookupResult = getContext().lookup(receiverClass, selector);
+                /* Local snapshot guards against stale compiled code during invalidation. */
+                final SqueakObjectClassNode node = classNode;
+                if (node != null) {
+                    final ClassObject receiverClass = node.executeLookup(this, receiver);
+                    final Object lookupResult = getContext().lookup(receiverClass, selector);
 
-                if (lookupResult instanceof CompiledCodeObject targetMethod) {
-                    for (final DispatchEntry<DispatchDirect4Node> entry : wideEntries) {
-                        if (entry.isWideCacheHit(targetMethod)) {
-                            return entry.executor.execute(frame, receiver, arg1, arg2, arg3, arg4);
+                    if (lookupResult instanceof CompiledCodeObject targetMethod) {
+                        for (final DispatchEntry<DispatchDirect4Node> entry : wideEntries) {
+                            if (entry.isWideCacheHit(targetMethod)) {
+                                return entry.executor.execute(frame, receiver, arg1, arg2, arg3, arg4);
+                            }
                         }
                     }
                 }
@@ -124,6 +135,7 @@ public final class DispatchSelector4Node extends AbstractDispatchSelectorNode {
             } else {
                 reportPolymorphicSpecialize();
                 indirectNode = insert(DispatchIndirect4NodeGen.create());
+                convertToIndirect();
                 return indirectNode.execute(frame, canPrimFail(), selector, receiver, arg1, arg2, arg3, arg4);
             }
         }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector5Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector5Node.java
@@ -99,9 +99,16 @@ public final class DispatchSelector5Node extends DispatchSelectorNode {
             return new DispatchDirectMethod5Node(assumptions, method);
         }
 
-        private static DispatchDirectMessageFallback5Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
-            final CompiledCodeObject fallbackMethod = receiverClass.resolveDispatchFailure(selector);
-            return new DispatchDirectMessageFallback5Node(assumptions, selector, fallbackMethod);
+        private static DispatchDirect5Node createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
+            final ClassObject.DispatchFailureResult result = receiverClass.resolveDispatchFailure(selector, 5);
+            final Assumption[] finalAssumptions = DispatchUtils.getAssumptionsForMessageFallback(assumptions, selector, result.fallbackMethod());
+
+            if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
+                return new DispatchDirectCannotInterpretFallback5Node(finalAssumptions, selector, result.fallbackMethod(), result.fallbackDepth(), result.fallbackSelector());
+            } else {
+                assert result.convention() == ClassObject.FallbackConvention.STANDARD_DNU : "DNU shortcuts are not supported for arity 4+";
+                return new DispatchDirectDNUFallback5Node(finalAssumptions, selector, result.fallbackMethod());
+            }
         }
     }
 
@@ -181,20 +188,55 @@ public final class DispatchSelector5Node extends DispatchSelectorNode {
         }
     }
 
-    static final class DispatchDirectMessageFallback5Node extends DispatchDirectWithSender5Node {
-        private final NativeObject selector;
-        @Child private DirectCallNode callNode;
-        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+    abstract static class AbstractDispatchDirectFallback5Node extends DispatchDirectWithSender5Node {
+        protected final NativeObject selector;
+        @Child protected DirectCallNode callNode;
 
-        DispatchDirectMessageFallback5Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+        AbstractDispatchDirectFallback5Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject targetMethod) {
             super(assumptions);
             this.selector = selector;
-            callNode = DirectCallNode.create(dnuMethod.getCallTarget());
+            this.callNode = DirectCallNode.create(targetMethod.getCallTarget());
+        }
+
+        @Override
+        public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5);
+    }
+
+    static final class DispatchDirectDNUFallback5Node extends AbstractDispatchDirectFallback5Node {
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectDNUFallback5Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+            super(assumptions, selector, dnuMethod);
         }
 
         @Override
         public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5) {
             final PointersObject message = createMessageNode.execute(selector, receiver, new Object[]{arg1, arg2, arg3, arg4, arg5});
+            return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
+        }
+    }
+
+    static final class DispatchDirectCannotInterpretFallback5Node extends AbstractDispatchDirectFallback5Node {
+        private final int fallbackDepth;
+        private final NativeObject ciSelector;
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectCannotInterpretFallback5Node(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject ciMethod, final int fallbackDepth,
+                        final NativeObject ciSelector) {
+            super(assumptions, selector, ciMethod);
+            this.fallbackDepth = fallbackDepth;
+            this.ciSelector = ciSelector;
+        }
+
+        @Override
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5) {
+            final PointersObject message = DispatchUtils.buildNestedMessage(
+                            createMessageNode,
+                            selector,
+                            ciSelector,
+                            receiver,
+                            new Object[]{arg1, arg2, arg3, arg4, arg5},
+                            fallbackDepth);
             return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
         }
     }
@@ -235,7 +277,14 @@ public final class DispatchSelector5Node extends DispatchSelectorNode {
             final ClassObject receiverClass = classNode.executeLookup(node, receiver);
             final Object lookupResult = getContext(node).lookup(receiverClass, selector);
             final CompiledCodeObject method = methodNode.execute(node, getContext(node), 5, canPrimFail, selector, receiverClass, lookupResult);
-            final Object result = tryPrimitiveNode.execute(frame, method, receiver, arg1, arg2, arg3, arg4, arg5);
+
+            final Object result;
+            if (lookupResult instanceof CompiledCodeObject) {
+                result = tryPrimitiveNode.execute(frame, method, receiver, arg1, arg2, arg3, arg4, arg5);
+            } else {
+                result = null;
+            }
+
             if (result != null) {
                 return result;
             } else {
@@ -314,9 +363,17 @@ public final class DispatchSelector5Node extends DispatchSelectorNode {
             @Specialization(guards = "lookupResult == null")
             protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final Object arg2, final Object arg3,
                             final Object arg4, final Object arg5, final ClassObject receiverClass, @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
-                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode) {
+                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(5);
                 final Object[] arguments = new Object[]{arg1, arg2, arg3, arg4, arg5};
-                final PointersObject message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+
+                final PointersObject message;
+                if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
+                    message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
+                } else {
+                    message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                }
                 return FrameAccess.newMessageFallbackWith(sender, receiver, message);
             }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector5Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector5Node.java
@@ -10,12 +10,14 @@ import com.oracle.truffle.api.Assumption;
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.HostCompilerDirectives;
 import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.GenerateCached;
 import com.oracle.truffle.api.dsl.GenerateInline;
 import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.NeverDefault;
+import com.oracle.truffle.api.dsl.ReportPolymorphism;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
@@ -44,13 +46,47 @@ import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive5;
 import de.hpi.swa.trufflesqueak.nodes.primitives.PrimitiveNodeFactory;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
-public final class DispatchSelector5Node extends DispatchSelectorNode {
+public final class DispatchSelector5Node extends AbstractDispatchSelectorNode {
+    public abstract static class Dispatch5Node extends AbstractDispatchNode {
+        Dispatch5Node(final NativeObject selector) {
+            super(selector);
+        }
+
+        @NeverDefault
+        public static Dispatch5Node create(final NativeObject selector) {
+            return DispatchSelector5NodeFactory.Dispatch5NodeGen.create(selector);
+        }
+
+        public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5);
+
+        @Specialization(guards = "guard.check(receiver)", assumptions = "dispatchDirectNode.getAssumptions()", limit = "INLINE_METHOD_CACHE_LIMIT")
+        protected static final Object doDirect(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5,
+                        @SuppressWarnings("unused") @Cached("create(receiver)") final LookupClassGuard guard,
+                        @Cached("create(selector, guard)") final DispatchDirect5Node dispatchDirectNode) {
+            return dispatchDirectNode.execute(frame, receiver, arg1, arg2, arg3, arg4, arg5);
+        }
+
+        @ReportPolymorphism.Megamorphic
+        @Specialization(replaces = "doDirect")
+        @HostCompilerDirectives.InliningCutoff
+        @SuppressWarnings("truffle-static-method")
+        protected final Object doIndirect(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5,
+                        @Cached final DispatchIndirect5Node dispatchNode) {
+            return dispatchNode.execute(frame, false, selector, receiver, arg1, arg2, arg3, arg4, arg5);
+        }
+    }
+
     public abstract static class DispatchDirect5Node extends AbstractDispatchDirectNode {
         DispatchDirect5Node(final Assumption[] assumptions) {
             super(assumptions);
         }
 
         public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5);
+
+        @NeverDefault
+        protected static final DispatchDirect5Node create(final NativeObject selector, final LookupClassGuard guard) {
+            return create(selector, guard, true);
+        }
 
         @NeverDefault
         public static final DispatchDirect5Node create(final NativeObject selector, final LookupClassGuard guard, final boolean canPrimFail) {
@@ -349,7 +385,7 @@ public final class DispatchSelector5Node extends DispatchSelectorNode {
 
         @GenerateInline
         @GenerateCached(false)
-        protected abstract static class CreateFrameArgumentsForIndirectCall5Node extends AbstractNode {
+        protected abstract static class CreateFrameArgumentsForIndirectCall5Node extends AbstractCreateFrameArgumentsForIndirectCallNode {
             abstract Object[] execute(Node node, AbstractSqueakObject sender, Object receiver, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5, ClassObject receiverClass,
                             Object lookupResult, NativeObject selector);
 
@@ -363,18 +399,13 @@ public final class DispatchSelector5Node extends DispatchSelectorNode {
             @Specialization(guards = "lookupResult == null")
             protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object arg1, final Object arg2, final Object arg3,
                             final Object arg4, final Object arg5, final ClassObject receiverClass, @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
+                            @Bind final SqueakImageContext image,
+                            @Cached final InlinedConditionProfile isCannotInterpretProfile,
                             @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
                             @Cached(inline = false) final CreateMessageNode createMessageNode) {
-                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(5);
+                final ClassObject.DispatchFailureResult result = image.findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(5);
                 final Object[] arguments = new Object[]{arg1, arg2, arg3, arg4, arg5};
-
-                final PointersObject message;
-                if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
-                    message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
-                } else {
-                    message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
-                }
-                return FrameAccess.newMessageFallbackWith(sender, receiver, message);
+                return newMessage(node, sender, receiver, arguments, receiverClass, selector, result, image, isCannotInterpretProfile, writeNode, createMessageNode);
             }
 
             @Specialization(guards = {"targetObject != null", "!isCompiledCodeObject(targetObject)"})

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector5Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector5Node.java
@@ -100,13 +100,9 @@ public final class DispatchSelector5Node extends AbstractDispatchSelectorNode {
                         }
                     }
                 }
-
-                // Wide Cache Miss: Delegate to Manager for Specialization
-                CompilerDirectives.transferToInterpreterAndInvalidate();
-                return executeAndSpecialize(frame, receiverClass, lookupResult, receiver, arg1, arg2, arg3, arg4, arg5);
             }
 
-            // Fast Cache Miss: Delegate to Manager for Specialization
+            // Cache Miss: Delegate to Manager for Specialization
             CompilerDirectives.transferToInterpreterAndInvalidate();
             return executeAndSpecialize(frame, receiver, arg1, arg2, arg3, arg4, arg5);
         }
@@ -124,15 +120,6 @@ public final class DispatchSelector5Node extends AbstractDispatchSelectorNode {
 
             final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
             final Object lookupResult = getContext().lookup(receiverClass, selector);
-            return executeAndSpecialize(frame, receiverClass, lookupResult, receiver, arg1, arg2, arg3, arg4, arg5);
-        }
-
-        private Object executeAndSpecialize(final VirtualFrame frame, final ClassObject receiverClass, final Object lookupResult, final Object receiver, final Object arg1, final Object arg2,
-                        final Object arg3, final Object arg4, final Object arg5) {
-            // Guard against lagging recursive frames.
-            if (indirectNode != null) {
-                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3, arg4, arg5);
-            }
 
             // Node creation handles method resolution, including DNU and OAM fallbacks.
             final DispatchDirect5Node executor = cache.specialize(receiver, receiverClass, lookupResult,

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector5Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector5Node.java
@@ -48,13 +48,21 @@ import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
 public final class DispatchSelector5Node extends AbstractDispatchSelectorNode {
     public abstract static class Dispatch5Node extends AbstractDispatchNode {
-        Dispatch5Node(final NativeObject selector) {
+        protected final boolean canPrimFail;
+
+        Dispatch5Node(final NativeObject selector, final boolean canPrimFail) {
             super(selector);
+            this.canPrimFail = canPrimFail;
         }
 
         @NeverDefault
         public static Dispatch5Node create(final NativeObject selector) {
-            return DispatchSelector5NodeFactory.Dispatch5NodeGen.create(selector);
+            return DispatchSelector5NodeFactory.Dispatch5NodeGen.create(selector, false);
+        }
+
+        @NeverDefault
+        public static Dispatch5Node create(final NativeObject selector, final boolean canPrimFail) {
+            return DispatchSelector5NodeFactory.Dispatch5NodeGen.create(selector, canPrimFail);
         }
 
         public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5);
@@ -72,7 +80,7 @@ public final class DispatchSelector5Node extends AbstractDispatchSelectorNode {
         @SuppressWarnings("truffle-static-method")
         protected final Object doIndirect(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5,
                         @Cached final DispatchIndirect5Node dispatchNode) {
-            return dispatchNode.execute(frame, false, selector, receiver, arg1, arg2, arg3, arg4, arg5);
+            return dispatchNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3, arg4, arg5);
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector5Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector5Node.java
@@ -10,18 +10,18 @@ import com.oracle.truffle.api.Assumption;
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
-import com.oracle.truffle.api.HostCompilerDirectives;
+import com.oracle.truffle.api.HostCompilerDirectives.InliningCutoff;
 import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.GenerateCached;
 import com.oracle.truffle.api.dsl.GenerateInline;
 import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.NeverDefault;
-import com.oracle.truffle.api.dsl.ReportPolymorphism;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.DirectCallNode;
+import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.IndirectCallNode;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.InlinedBranchProfile;
@@ -40,6 +40,7 @@ import de.hpi.swa.trufflesqueak.nodes.accessing.AbstractPointersObjectNodes.Abst
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectClassNode;
 import de.hpi.swa.trufflesqueak.nodes.context.GetOrCreateContextWithoutFrameNode;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector5NodeFactory.DispatchDirectPrimitiveFallback5NodeGen;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector5NodeFactory.DispatchIndirect5NodeGen;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNode.DispatchPrimitiveNode;
 import de.hpi.swa.trufflesqueak.nodes.primitives.AbstractPrimitiveNode;
 import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive5;
@@ -47,40 +48,91 @@ import de.hpi.swa.trufflesqueak.nodes.primitives.PrimitiveNodeFactory;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
 public final class DispatchSelector5Node extends AbstractDispatchSelectorNode {
-    public abstract static class Dispatch5Node extends AbstractDispatchNode {
+    public static final class Dispatch5Node extends AbstractDispatchNode {
         protected final boolean canPrimFail;
+        @Child private DispatchCacheManager<DispatchDirect5Node> cache;
+        @Child private DispatchIndirect5Node indirectNode;
 
-        Dispatch5Node(final NativeObject selector, final boolean canPrimFail) {
+        private Dispatch5Node(final NativeObject selector, final boolean canPrimFail) {
             super(selector);
             this.canPrimFail = canPrimFail;
         }
 
         @NeverDefault
         public static Dispatch5Node create(final NativeObject selector) {
-            return DispatchSelector5NodeFactory.Dispatch5NodeGen.create(selector, false);
+            return new Dispatch5Node(selector, false);
         }
 
         @NeverDefault
         public static Dispatch5Node create(final NativeObject selector, final boolean canPrimFail) {
-            return DispatchSelector5NodeFactory.Dispatch5NodeGen.create(selector, canPrimFail);
+            return new Dispatch5Node(selector, canPrimFail);
         }
 
-        public abstract Object execute(VirtualFrame frame, Object receiver, Object arg1, Object arg2, Object arg3, Object arg4, Object arg5);
+        @ExplodeLoop
+        @InliningCutoff
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5) {
+            // TIER 3: Megamorphic Fallback (Indirect Execution)
+            if (indirectNode != null) {
+                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3, arg4, arg5);
+            }
 
-        @Specialization(guards = "guard.check(receiver)", assumptions = "dispatchDirectNode.getAssumptions()", limit = "INLINE_METHOD_CACHE_LIMIT")
-        protected static final Object doDirect(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5,
-                        @SuppressWarnings("unused") @Cached("create(receiver)") final LookupClassGuard guard,
-                        @Cached("create(selector, guard)") final DispatchDirect5Node dispatchDirectNode) {
-            return dispatchDirectNode.execute(frame, receiver, arg1, arg2, arg3, arg4, arg5);
+            if (cache == null) {
+                CompilerDirectives.transferToInterpreterAndInvalidate();
+                cache = insert(new DispatchCacheManager<>());
+            }
+
+            // TIER 1: Direct Execution Fast Path
+            for (final DispatchEntry<DispatchDirect5Node> entry : cache.fastEntries) {
+                if (entry.isFastCacheHit(receiver)) {
+                    return entry.executor.execute(frame, receiver, arg1, arg2, arg3, arg4, arg5);
+                }
+            }
+
+            // TIER 2: Wide Execution (Class Polymorphism)
+            if (cache.wideEntries.length > 0) {
+                final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
+                final Object lookupResult = getContext().lookup(receiverClass, selector);
+
+                if (lookupResult instanceof CompiledCodeObject targetMethod) {
+                    for (final DispatchEntry<DispatchDirect5Node> entry : cache.wideEntries) {
+                        if (entry.isWideCacheHit(targetMethod)) {
+                            return entry.executor.execute(frame, receiver, arg1, arg2, arg3, arg4, arg5);
+                        }
+                    }
+                }
+            }
+
+            // Cache Miss: Delegate to Manager for Specialization
+            CompilerDirectives.transferToInterpreterAndInvalidate();
+            return executeAndSpecialize(frame, receiver, arg1, arg2, arg3, arg4, arg5);
         }
 
-        @ReportPolymorphism.Megamorphic
-        @Specialization(replaces = "doDirect")
-        @HostCompilerDirectives.InliningCutoff
-        @SuppressWarnings("truffle-static-method")
-        protected final Object doIndirect(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5,
-                        @Cached final DispatchIndirect5Node dispatchNode) {
-            return dispatchNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3, arg4, arg5);
+        private Object executeAndSpecialize(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5) {
+            /*
+             * Guard against lagging recursive frames. If multiple frames of this method are on the
+             * stack executing compiled code, a deeper frame may have already deoptimized and
+             * transitioned this node to the indirect tier. This intercepts older deoptimized frames
+             * to prevent redundant specialization.
+             */
+            if (indirectNode != null) {
+                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3, arg4, arg5);
+            }
+
+            final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
+            final Object lookupResult = getContext().lookup(receiverClass, selector);
+
+            // Node creation handles method resolution, including DNU and OAM fallbacks.
+            final DispatchDirect5Node newDirectNode = DispatchDirect5Node.create(selector, receiverClass, canPrimFail);
+
+            final DispatchDirect5Node executor = cache.specialize(receiver, lookupResult, newDirectNode);
+
+            if (executor != null) {
+                return executor.execute(frame, receiver, arg1, arg2, arg3, arg4, arg5);
+            } else {
+                this.reportPolymorphicSpecialize();
+                indirectNode = insert(DispatchIndirect5NodeGen.create());
+                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3, arg4, arg5);
+            }
         }
     }
 
@@ -93,7 +145,7 @@ public final class DispatchSelector5Node extends AbstractDispatchSelectorNode {
 
         @NeverDefault
         protected static final DispatchDirect5Node create(final NativeObject selector, final LookupClassGuard guard) {
-            return create(selector, guard, true);
+            return create(selector, guard, false);
         }
 
         @NeverDefault

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector5Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector5Node.java
@@ -100,9 +100,13 @@ public final class DispatchSelector5Node extends AbstractDispatchSelectorNode {
                         }
                     }
                 }
+
+                // Wide Cache Miss: Delegate to Manager for Specialization
+                CompilerDirectives.transferToInterpreterAndInvalidate();
+                return executeAndSpecialize(frame, receiverClass, lookupResult, receiver, arg1, arg2, arg3, arg4, arg5);
             }
 
-            // Cache Miss: Delegate to Manager for Specialization
+            // Fast Cache Miss: Delegate to Manager for Specialization
             CompilerDirectives.transferToInterpreterAndInvalidate();
             return executeAndSpecialize(frame, receiver, arg1, arg2, arg3, arg4, arg5);
         }
@@ -120,6 +124,14 @@ public final class DispatchSelector5Node extends AbstractDispatchSelectorNode {
 
             final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
             final Object lookupResult = getContext().lookup(receiverClass, selector);
+            return executeAndSpecialize(frame, receiverClass, lookupResult, receiver, arg1, arg2, arg3, arg4, arg5);
+        }
+
+        private Object executeAndSpecialize(final VirtualFrame frame, final ClassObject receiverClass, final Object lookupResult, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5) {
+            // Guard against lagging recursive frames.
+            if (indirectNode != null) {
+                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3, arg4, arg5);
+            }
 
             // Node creation handles method resolution, including DNU and OAM fallbacks.
             final DispatchDirect5Node newDirectNode = DispatchDirect5Node.create(selector, receiverClass, canPrimFail);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector5Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector5Node.java
@@ -48,14 +48,11 @@ import de.hpi.swa.trufflesqueak.nodes.primitives.PrimitiveNodeFactory;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
 
 public final class DispatchSelector5Node extends AbstractDispatchSelectorNode {
-    public static final class Dispatch5Node extends AbstractDispatchNode {
-        protected final boolean canPrimFail;
-        @Child private DispatchCacheManager<DispatchDirect5Node> cache;
+    public static final class Dispatch5Node extends AbstractDispatchNode<DispatchDirect5Node> {
         @Child private DispatchIndirect5Node indirectNode;
 
         private Dispatch5Node(final NativeObject selector, final boolean canPrimFail) {
-            super(selector);
-            this.canPrimFail = canPrimFail;
+            super(selector, canPrimFail);
         }
 
         @NeverDefault
@@ -71,30 +68,29 @@ public final class DispatchSelector5Node extends AbstractDispatchSelectorNode {
         @ExplodeLoop
         @InliningCutoff
         public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5) {
-            // TIER 3: Megamorphic Fallback (Indirect Execution)
-            if (indirectNode != null) {
-                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3, arg4, arg5);
-            }
+            final byte currentState = state;
 
-            if (cache == null) {
-                CompilerDirectives.transferToInterpreterAndInvalidate();
-                cache = insert(new DispatchCacheManager<>());
+            // TIER 3: Megamorphic Fallback (Indirect Execution)
+            if ((currentState & HAS_INDIRECT) != 0) {
+                return indirectNode.execute(frame, (currentState & FLAG_PRIM_FAIL) != 0, selector, receiver, arg1, arg2, arg3, arg4, arg5);
             }
 
             // TIER 1: Direct Execution Fast Path
-            for (final DispatchEntry<DispatchDirect5Node> entry : cache.fastEntries) {
-                if (entry.isFastCacheHit(receiver)) {
-                    return entry.executor.execute(frame, receiver, arg1, arg2, arg3, arg4, arg5);
+            if ((currentState & HAS_FAST) != 0) {
+                for (final DispatchEntry<DispatchDirect5Node> entry : fastEntries) {
+                    if (entry.isFastCacheHit(receiver)) {
+                        return entry.executor.execute(frame, receiver, arg1, arg2, arg3, arg4, arg5);
+                    }
                 }
             }
 
             // TIER 2: Wide Execution (Class Polymorphism)
-            if (cache.wideEntries.length > 0) {
-                final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
+            if ((currentState & HAS_WIDE) != 0) {
+                final ClassObject receiverClass = classNode.executeLookup(this, receiver);
                 final Object lookupResult = getContext().lookup(receiverClass, selector);
 
                 if (lookupResult instanceof CompiledCodeObject targetMethod) {
-                    for (final DispatchEntry<DispatchDirect5Node> entry : cache.wideEntries) {
+                    for (final DispatchEntry<DispatchDirect5Node> entry : wideEntries) {
                         if (entry.isWideCacheHit(targetMethod)) {
                             return entry.executor.execute(frame, receiver, arg1, arg2, arg3, arg4, arg5);
                         }
@@ -102,35 +98,33 @@ public final class DispatchSelector5Node extends AbstractDispatchSelectorNode {
                 }
             }
 
-            // Cache Miss: Delegate to Manager for Specialization
+            // Cache Miss: Delegate to superclass for Specialization
             CompilerDirectives.transferToInterpreterAndInvalidate();
             return executeAndSpecialize(frame, receiver, arg1, arg2, arg3, arg4, arg5);
         }
 
         private Object executeAndSpecialize(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5) {
             /*
-             * Guard against lagging recursive frames. If multiple frames of this method are on the
-             * stack executing compiled code, a deeper frame may have already deoptimized and
-             * transitioned this node to the indirect tier. This intercepts older deoptimized frames
-             * to prevent redundant specialization.
+             * Guard against lagging recursive frames.
              */
-            if (indirectNode != null) {
-                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3, arg4, arg5);
+            if ((state & HAS_INDIRECT) != 0) {
+                return indirectNode.execute(frame, canPrimFail(), selector, receiver, arg1, arg2, arg3, arg4, arg5);
             }
 
-            final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
+            ensureClassNode();
+            final ClassObject receiverClass = classNode.executeLookup(this, receiver);
             final Object lookupResult = getContext().lookup(receiverClass, selector);
 
             // Node creation handles method resolution, including DNU and OAM fallbacks.
-            final DispatchDirect5Node executor = cache.specialize(receiver, receiverClass, lookupResult,
-                            () -> DispatchDirect5Node.create(selector, receiverClass, canPrimFail));
+            final DispatchDirect5Node executor = specialize(receiver, receiverClass, lookupResult,
+                    () -> DispatchDirect5Node.create(selector, receiverClass, canPrimFail()));
 
             if (executor != null) {
                 return executor.execute(frame, receiver, arg1, arg2, arg3, arg4, arg5);
             } else {
-                this.reportPolymorphicSpecialize();
+                reportPolymorphicSpecialize();
                 indirectNode = insert(DispatchIndirect5NodeGen.create());
-                return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3, arg4, arg5);
+                return indirectNode.execute(frame, canPrimFail(), selector, receiver, arg1, arg2, arg3, arg4, arg5);
             }
         }
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector5Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector5Node.java
@@ -70,6 +70,13 @@ public final class DispatchSelector5Node extends AbstractDispatchSelectorNode {
         public Object execute(final VirtualFrame frame, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5) {
             final byte currentState = state;
 
+            // TIER 0: Pure Monomorphic Fast Path
+            if ((currentState & HAS_MONO) != 0) {
+                if (Assumption.isValidAssumption(monoExecutor.getAssumptions()) && monoGuard.check(receiver)) {
+                    return monoExecutor.execute(frame, receiver, arg1, arg2, arg3, arg4, arg5);
+                }
+            }
+
             // TIER 3: Megamorphic Fallback (Indirect Execution)
             if ((currentState & HAS_INDIRECT) != 0) {
                 return indirectNode.execute(frame, (currentState & FLAG_PRIM_FAIL) != 0, selector, receiver, arg1, arg2, arg3, arg4, arg5);
@@ -86,13 +93,17 @@ public final class DispatchSelector5Node extends AbstractDispatchSelectorNode {
 
             // TIER 2: Wide Execution (Class Polymorphism)
             if ((currentState & HAS_WIDE) != 0) {
-                final ClassObject receiverClass = classNode.executeLookup(this, receiver);
-                final Object lookupResult = getContext().lookup(receiverClass, selector);
+                /* Local snapshot guards against stale compiled code during invalidation. */
+                final SqueakObjectClassNode node = classNode;
+                if (node != null) {
+                    final ClassObject receiverClass = node.executeLookup(this, receiver);
+                    final Object lookupResult = getContext().lookup(receiverClass, selector);
 
-                if (lookupResult instanceof CompiledCodeObject targetMethod) {
-                    for (final DispatchEntry<DispatchDirect5Node> entry : wideEntries) {
-                        if (entry.isWideCacheHit(targetMethod)) {
-                            return entry.executor.execute(frame, receiver, arg1, arg2, arg3, arg4, arg5);
+                    if (lookupResult instanceof CompiledCodeObject targetMethod) {
+                        for (final DispatchEntry<DispatchDirect5Node> entry : wideEntries) {
+                            if (entry.isWideCacheHit(targetMethod)) {
+                                return entry.executor.execute(frame, receiver, arg1, arg2, arg3, arg4, arg5);
+                            }
                         }
                     }
                 }
@@ -117,13 +128,14 @@ public final class DispatchSelector5Node extends AbstractDispatchSelectorNode {
 
             // Node creation handles method resolution, including DNU and OAM fallbacks.
             final DispatchDirect5Node executor = specialize(receiver, receiverClass, lookupResult,
-                    () -> DispatchDirect5Node.create(selector, receiverClass, canPrimFail()));
+                            () -> DispatchDirect5Node.create(selector, receiverClass, canPrimFail()));
 
             if (executor != null) {
                 return executor.execute(frame, receiver, arg1, arg2, arg3, arg4, arg5);
             } else {
                 reportPolymorphicSpecialize();
                 indirectNode = insert(DispatchIndirect5NodeGen.create());
+                convertToIndirect();
                 return indirectNode.execute(frame, canPrimFail(), selector, receiver, arg1, arg2, arg3, arg4, arg5);
             }
         }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector5Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelector5Node.java
@@ -127,16 +127,16 @@ public final class DispatchSelector5Node extends AbstractDispatchSelectorNode {
             return executeAndSpecialize(frame, receiverClass, lookupResult, receiver, arg1, arg2, arg3, arg4, arg5);
         }
 
-        private Object executeAndSpecialize(final VirtualFrame frame, final ClassObject receiverClass, final Object lookupResult, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5) {
+        private Object executeAndSpecialize(final VirtualFrame frame, final ClassObject receiverClass, final Object lookupResult, final Object receiver, final Object arg1, final Object arg2,
+                        final Object arg3, final Object arg4, final Object arg5) {
             // Guard against lagging recursive frames.
             if (indirectNode != null) {
                 return indirectNode.execute(frame, canPrimFail, selector, receiver, arg1, arg2, arg3, arg4, arg5);
             }
 
             // Node creation handles method resolution, including DNU and OAM fallbacks.
-            final DispatchDirect5Node newDirectNode = DispatchDirect5Node.create(selector, receiverClass, canPrimFail);
-
-            final DispatchDirect5Node executor = cache.specialize(receiver, lookupResult, newDirectNode);
+            final DispatchDirect5Node executor = cache.specialize(receiver, receiverClass, lookupResult,
+                            () -> DispatchDirect5Node.create(selector, receiverClass, canPrimFail));
 
             if (executor != null) {
                 return executor.execute(frame, receiver, arg1, arg2, arg3, arg4, arg5);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
@@ -82,10 +82,11 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
             return DispatchSelectorNaryNodeFactory.DispatchNaryNodeGen.create(selector);
         }
 
-        @Specialization(guards = "guard.check(receiver)", assumptions = "dispatchDirectNode.getAssumptions()", limit = "INLINE_METHOD_CACHE_LIMIT")
+        @Specialization(guards = {"guard.check(receiver)", "arguments.length == cachedArity"}, assumptions = "dispatchDirectNode.getAssumptions()", limit = "INLINE_METHOD_CACHE_LIMIT")
         protected static final Object doDirect(final VirtualFrame frame, final Object receiver, final Object[] arguments,
                         @SuppressWarnings("unused") @Cached("create(receiver)") final LookupClassGuard guard,
-                        @Cached("create(selector, guard, arguments.length)") final DispatchDirectNaryNode dispatchDirectNode) {
+                        @SuppressWarnings("unused") @Cached("arguments.length") final int cachedArity,
+                        @Cached("create(selector, guard, cachedArity)") final DispatchDirectNaryNode dispatchDirectNode) {
             return dispatchDirectNode.execute(frame, receiver, arguments);
         }
 
@@ -109,10 +110,11 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
             return DispatchSelectorNaryNodeFactory.DispatchPerformNaryNodeGen.create(selector);
         }
 
-        @Specialization(guards = "guard.check(receiver)", assumptions = "dispatchDirectNode.getAssumptions()", limit = "INLINE_METHOD_CACHE_LIMIT")
+        @Specialization(guards = {"guard.check(receiver)", "arguments.length == cachedArity"}, assumptions = "dispatchDirectNode.getAssumptions()", limit = "INLINE_METHOD_CACHE_LIMIT")
         protected static final Object doDirect(final VirtualFrame frame, final Object receiver, final Object[] arguments,
                         @SuppressWarnings("unused") @Cached("create(receiver)") final LookupClassGuard guard,
-                        @Cached("create(selector, guard, arguments.length)") final DispatchDirectNaryNode dispatchDirectNode) {
+                        @SuppressWarnings("unused") @Cached("arguments.length") final int cachedArity,
+                        @Cached("create(selector, guard, cachedArity)") final DispatchDirectNaryNode dispatchDirectNode) {
             return dispatchDirectNode.executeWithCheckedArguments(frame, receiver, arguments);
         }
 
@@ -122,7 +124,7 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
         @SuppressWarnings("truffle-static-method")
         protected final Object doIndirect(final VirtualFrame frame, final Object receiver, final Object[] arguments,
                         @Cached final DispatchIndirectNaryNode dispatchNode) {
-            return dispatchNode.execute(frame, false, selector, receiver, arguments);
+            return dispatchNode.execute(frame, true, selector, receiver, arguments);
         }
     }
 
@@ -597,18 +599,17 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
         }
 
         @Override
-        @ExplodeLoop
         public Object execute(final VirtualFrame frame, final Object receiver, final Object[] arguments) {
             assert arguments.length == arity : "Shortcut arity mismatch!";
+            final AbstractSqueakObject sender = senderNode.execute(frame);
 
-            // Build the shortcut arguments: [arg0, arg1, ..., argN, selector]
-            final Object[] shortcutArgs = new Object[arity + 1];
-            for (int i = 0; i < arity; i++) {
-                shortcutArgs[i] = arguments[i];
-            }
-            shortcutArgs[arity] = selector;
-
-            return callNode.call(FrameAccess.newWith(senderNode.execute(frame), null, receiver, shortcutArgs));
+            return switch (arity) {
+                case 0 -> callNode.call(FrameAccess.newWith(sender, null, receiver, selector));
+                case 1 -> callNode.call(FrameAccess.newWith(sender, null, receiver, arguments[0], selector));
+                case 2 -> callNode.call(FrameAccess.newWith(sender, null, receiver, arguments[0], arguments[1], selector));
+                case 3 -> callNode.call(FrameAccess.newWith(sender, null, receiver, arguments[0], arguments[1], arguments[2], selector));
+                default -> throw CompilerDirectives.shouldNotReachHere("Shortcuts have a maximum arity of 3");
+            };
         }
     }
 
@@ -802,14 +803,13 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
                             final CreateMessageNode createMessageNode) {
                 final ClassObject.DispatchFailureResult result = image.findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(arity);
                 if (isShortcutProfile.profile(node, result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU)) {
-                    final Object[] shortcutArgs = new Object[arity + 1];
-                    if (CompilerDirectives.isPartialEvaluationConstant(arity)) {
-                        ArrayUtils.copyExploded(arguments, shortcutArgs, arity);
-                    } else {
-                        ArrayUtils.arraycopy(arguments, 0, shortcutArgs, 0, arity);
-                    }
-                    shortcutArgs[arity] = selector;
-                    return FrameAccess.newWith(sender, null, receiver, shortcutArgs);
+                    return switch (arity) {
+                        case 0 -> FrameAccess.newWith(sender, null, receiver, selector);
+                        case 1 -> FrameAccess.newWith(sender, null, receiver, arguments[0], selector);
+                        case 2 -> FrameAccess.newWith(sender, null, receiver, arguments[0], arguments[1], selector);
+                        case 3 -> FrameAccess.newWith(sender, null, receiver, arguments[0], arguments[1], arguments[2], selector);
+                        default -> throw CompilerDirectives.shouldNotReachHere("Shortcuts have a maximum arity of 3");
+                    };
                 } else {
                     return newMessage(node, sender, receiver, arguments, receiverClass, selector, result, image, isCannotInterpretProfile, writeNode, createMessageNode);
                 }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
@@ -59,10 +59,11 @@ import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive7;
 import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive8;
 import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive9;
 import de.hpi.swa.trufflesqueak.nodes.primitives.PrimitiveNodeFactory;
+import de.hpi.swa.trufflesqueak.util.ArrayUtils;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
 import de.hpi.swa.trufflesqueak.util.MiscUtils;
 
-public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
+public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode {
     protected abstract static class AbstractDispatchNaryNode extends AbstractDispatchNode {
         AbstractDispatchNaryNode(final NativeObject selector) {
             super(selector);
@@ -76,11 +77,43 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
             super(selector);
         }
 
+        @NeverDefault
+        public static DispatchNaryNode create(final NativeObject selector) {
+            return DispatchSelectorNaryNodeFactory.DispatchNaryNodeGen.create(selector);
+        }
+
         @Specialization(guards = "guard.check(receiver)", assumptions = "dispatchDirectNode.getAssumptions()", limit = "INLINE_METHOD_CACHE_LIMIT")
         protected static final Object doDirect(final VirtualFrame frame, final Object receiver, final Object[] arguments,
                         @SuppressWarnings("unused") @Cached("create(receiver)") final LookupClassGuard guard,
                         @Cached("create(selector, guard, arguments.length)") final DispatchDirectNaryNode dispatchDirectNode) {
             return dispatchDirectNode.execute(frame, receiver, arguments);
+        }
+
+        @ReportPolymorphism.Megamorphic
+        @Specialization(replaces = "doDirect")
+        @HostCompilerDirectives.InliningCutoff
+        @SuppressWarnings("truffle-static-method")
+        protected final Object doIndirect(final VirtualFrame frame, final Object receiver, final Object[] arguments,
+                        @Cached final DispatchIndirectNaryNode dispatchNode) {
+            return dispatchNode.execute(frame, false, selector, receiver, arguments);
+        }
+    }
+
+    public abstract static class DispatchPerformNaryNode extends AbstractDispatchNaryNode {
+        DispatchPerformNaryNode(final NativeObject selector) {
+            super(selector);
+        }
+
+        @NeverDefault
+        public static DispatchPerformNaryNode create(final NativeObject selector) {
+            return DispatchSelectorNaryNodeFactory.DispatchPerformNaryNodeGen.create(selector);
+        }
+
+        @Specialization(guards = "guard.check(receiver)", assumptions = "dispatchDirectNode.getAssumptions()", limit = "INLINE_METHOD_CACHE_LIMIT")
+        protected static final Object doDirect(final VirtualFrame frame, final Object receiver, final Object[] arguments,
+                        @SuppressWarnings("unused") @Cached("create(receiver)") final LookupClassGuard guard,
+                        @Cached("create(selector, guard, arguments.length)") final DispatchDirectNaryNode dispatchDirectNode) {
+            return dispatchDirectNode.executeWithCheckedArguments(frame, receiver, arguments);
         }
 
         @ReportPolymorphism.Megamorphic
@@ -185,7 +218,7 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
                 if (primitiveNode != null) {
                     return new DispatchDirectPrimitiveNaryNode(assumptions, method, primitiveNode);
                 }
-                DispatchUtils.logMissingPrimitive(primitiveNode, method);
+                DispatchUtils.logMissingPrimitive(null, method);
             }
             return new DispatchDirectMethodNaryNode(assumptions, method);
         }
@@ -693,7 +726,7 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
 
         @GenerateInline
         @GenerateCached(false)
-        public abstract static class CreateFrameArgumentsForIndirectCallNaryNode extends AbstractNode {
+        public abstract static class CreateFrameArgumentsForIndirectCallNaryNode extends AbstractCreateFrameArgumentsForIndirectCallNode {
             public abstract Object[] execute(Node node, AbstractSqueakObject sender, Object receiver, Object[] arguments, ClassObject receiverClass, Object lookupResult, NativeObject selector);
 
             @Specialization
@@ -703,55 +736,82 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
                 return FrameAccess.newWith(sender, null, receiver, arguments);
             }
 
-            @Specialization(guards = {"lookupResult == null", "arguments.length == cachedArity"}, limit = "1")
-            @ExplodeLoop
+            @Specialization(guards = {"lookupResult == null", "arguments.length == cachedArity"}, limit = "1", assumptions = {"image.getDnuShortcutsAbsent()"})
             protected static final Object[] doMessageFallbackCached(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object[] arguments,
                             final ClassObject receiverClass,
                             @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
+                            @Bind final SqueakImageContext image,
+                            @Shared("isCannotInterpret") @Cached final InlinedConditionProfile isCannotInterpretProfile,
                             @Cached("arguments.length") final int cachedArity,
                             @Shared("writeNode") @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
                             @Shared("createNode") @Cached(inline = false) final CreateMessageNode createMessageNode) {
-                return doMessageFallbackShared(node, sender, receiver, arguments, receiverClass, selector, cachedArity, writeNode, createMessageNode);
+                return doMessageFallbackShared(node, sender, receiver, arguments, receiverClass, selector, cachedArity, image, isCannotInterpretProfile, writeNode, createMessageNode);
             }
 
-            @Specialization(guards = "lookupResult == null", replaces = "doMessageFallbackCached")
+            @Specialization(guards = "lookupResult == null", replaces = "doMessageFallbackCached", assumptions = {"image.getDnuShortcutsAbsent()"})
             protected static final Object[] doMessageFallbackGeneric(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object[] arguments,
                             final ClassObject receiverClass,
                             @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
+                            @Bind final SqueakImageContext image,
+                            @Shared("isCannotInterpret") @Cached final InlinedConditionProfile isCannotInterpretProfile,
                             @Shared("writeNode") @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
                             @Shared("createNode") @Cached(inline = false) final CreateMessageNode createMessageNode) {
-                return doMessageFallbackShared(node, sender, receiver, arguments, receiverClass, selector, arguments.length, writeNode, createMessageNode);
+                return doMessageFallbackShared(node, sender, receiver, arguments, receiverClass, selector, arguments.length, image, isCannotInterpretProfile, writeNode, createMessageNode);
             }
 
-            private static Object[] doMessageFallbackShared(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object[] arguments, final ClassObject receiverClass,
-                            final NativeObject selector, final int arity, final AbstractPointersObjectWriteNode writeNode, final CreateMessageNode createMessageNode) {
+            private static Object[] doMessageFallbackShared(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object[] arguments,
+                            final ClassObject receiverClass,
+                            final NativeObject selector, final int arity, final SqueakImageContext image,
+                            final InlinedConditionProfile isCannotInterpretProfile, final AbstractPointersObjectWriteNode writeNode, final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = image.findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(arity);
+                return newMessage(node, sender, receiver, arguments, receiverClass, selector, result, image, isCannotInterpretProfile, writeNode, createMessageNode);
+            }
 
-                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(arity);
+            @Specialization(guards = {"lookupResult == null", "arguments.length == cachedArity"}, limit = "1", replaces = {"doMessageFallbackCached", "doMessageFallbackGeneric"})
+            @ExplodeLoop
+            protected static final Object[] doMessageFallbackWithShortcutsCached(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object[] arguments,
+                            final ClassObject receiverClass,
+                            @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
+                            @Bind final SqueakImageContext image,
+                            @Shared("isShortcut") @Cached final InlinedConditionProfile isShortcutProfile,
+                            @Shared("isCannotInterpret") @Cached final InlinedConditionProfile isCannotInterpretProfile,
+                            @Cached("arguments.length") final int cachedArity,
+                            @Shared("writeNode") @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Shared("createNode") @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                return doMessageFallbackWithShortcutsShared(node, sender, receiver, arguments, receiverClass, selector, cachedArity, image, isShortcutProfile, isCannotInterpretProfile, writeNode,
+                                createMessageNode);
+            }
 
-                if (result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU) {
+            @Specialization(guards = "lookupResult == null", replaces = {"doMessageFallbackCached", "doMessageFallbackGeneric", "doMessageFallbackWithShortcutsCached"})
+            protected static final Object[] doMessageFallbackWithShortcutsGeneric(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object[] arguments,
+                            final ClassObject receiverClass,
+                            @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
+                            @Bind final SqueakImageContext image,
+                            @Shared("isShortcut") @Cached final InlinedConditionProfile isShortcutProfile,
+                            @Shared("isCannotInterpret") @Cached final InlinedConditionProfile isCannotInterpretProfile,
+                            @Shared("writeNode") @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Shared("createNode") @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                return doMessageFallbackWithShortcutsShared(node, sender, receiver, arguments, receiverClass, selector, arguments.length, image, isShortcutProfile, isCannotInterpretProfile, writeNode,
+                                createMessageNode);
+            }
+
+            private static Object[] doMessageFallbackWithShortcutsShared(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object[] arguments,
+                            final ClassObject receiverClass,
+                            final NativeObject selector, final int arity, final SqueakImageContext image,
+                            final InlinedConditionProfile isShortcutProfile, final InlinedConditionProfile isCannotInterpretProfile, final AbstractPointersObjectWriteNode writeNode,
+                            final CreateMessageNode createMessageNode) {
+                final ClassObject.DispatchFailureResult result = image.findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(arity);
+                if (isShortcutProfile.profile(node, result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU)) {
                     final Object[] shortcutArgs = new Object[arity + 1];
                     if (CompilerDirectives.isPartialEvaluationConstant(arity)) {
-                        copyExploded(arguments, shortcutArgs, arity);
+                        ArrayUtils.copyExploded(arguments, shortcutArgs, arity);
                     } else {
-                        System.arraycopy(arguments, 0, shortcutArgs, 0, arity);
+                        ArrayUtils.arraycopy(arguments, 0, shortcutArgs, 0, arity);
                     }
                     shortcutArgs[arity] = selector;
                     return FrameAccess.newWith(sender, null, receiver, shortcutArgs);
-                }
-
-                final PointersObject message;
-                if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
-                    message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
                 } else {
-                    message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
-                }
-                return FrameAccess.newMessageFallbackWith(sender, receiver, message);
-            }
-
-            @ExplodeLoop
-            private static void copyExploded(final Object[] source, final Object[] dest, final int length) {
-                for (int i = 0; i < length; i++) {
-                    dest[i] = source[i];
+                    return newMessage(node, sender, receiver, arguments, receiverClass, selector, result, image, isCannotInterpretProfile, writeNode, createMessageNode);
                 }
             }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
@@ -13,6 +13,7 @@ import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.HostCompilerDirectives;
 import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Cached.Shared;
 import com.oracle.truffle.api.dsl.GenerateCached;
 import com.oracle.truffle.api.dsl.GenerateInline;
 import com.oracle.truffle.api.dsl.GenerateUncached;
@@ -23,6 +24,7 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.DirectCallNode;
+import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.IndirectCallNode;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.InlinedBranchProfile;
@@ -77,7 +79,7 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
         @Specialization(guards = "guard.check(receiver)", assumptions = "dispatchDirectNode.getAssumptions()", limit = "INLINE_METHOD_CACHE_LIMIT")
         protected static final Object doDirect(final VirtualFrame frame, final Object receiver, final Object[] arguments,
                         @SuppressWarnings("unused") @Cached("create(receiver)") final LookupClassGuard guard,
-                        @Cached("create(selector, guard)") final DispatchDirectNaryNode dispatchDirectNode) {
+                        @Cached("create(selector, guard, arguments.length)") final DispatchDirectNaryNode dispatchDirectNode) {
             return dispatchDirectNode.execute(frame, receiver, arguments);
         }
 
@@ -102,7 +104,7 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
         @Specialization(assumptions = {"cachedMethodClass.getClassHierarchyAndMethodDictStable()", "dispatchDirectNode.getAssumptions()"})
         protected static final Object doCached(final VirtualFrame frame, final Object receiver, final Object[] arguments,
                         @SuppressWarnings("unused") @Cached("method.getMethodClassSlow()") final ClassObject cachedMethodClass,
-                        @Cached("create(selector, cachedMethodClass.getResolvedSuperclass())") final DispatchDirectNaryNode dispatchDirectNode) {
+                        @Cached("create(selector, cachedMethodClass.getResolvedSuperclass(), arguments.length)") final DispatchDirectNaryNode dispatchDirectNode) {
             return dispatchDirectNode.execute(frame, receiver, arguments);
         }
     }
@@ -118,7 +120,7 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
                         "dispatchDirectNode.getAssumptions()"}, limit = "3")
         protected static final Object doCached(final VirtualFrame frame, @SuppressWarnings("unused") final ClassObject lookupClass, final Object receiver, final Object[] arguments,
                         @SuppressWarnings("unused") @Cached("lookupClass") final ClassObject cachedLookupClass,
-                        @Cached("create(selector, cachedLookupClass)") final DispatchDirectNaryNode dispatchDirectNode) {
+                        @Cached("create(selector, cachedLookupClass, arguments.length)") final DispatchDirectNaryNode dispatchDirectNode) {
             return dispatchDirectNode.execute(frame, receiver, arguments);
         }
     }
@@ -145,9 +147,9 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
         }
 
         @NeverDefault
-        public static final DispatchDirectNaryNode create(final NativeObject selector, final LookupClassGuard guard) {
+        public static final DispatchDirectNaryNode create(final NativeObject selector, final LookupClassGuard guard, final int arity) {
             final ClassObject receiverClass = guard.getSqueakClassInternal(null);
-            return create(selector, receiverClass);
+            return create(selector, receiverClass, arity);
         }
 
         @NeverDefault
@@ -158,13 +160,13 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
         }
 
         @NeverDefault
-        public static final DispatchDirectNaryNode create(final NativeObject selector, final ClassObject lookupClass) {
+        public static final DispatchDirectNaryNode create(final NativeObject selector, final ClassObject lookupClass, final int arity) {
             final Object lookupResult = lookupClass.lookupInMethodDictSlow(selector);
             final Assumption[] assumptions = DispatchUtils.createAssumptions(lookupClass, lookupResult);
             if (lookupResult instanceof final CompiledCodeObject lookupMethod) {
                 return create(assumptions, lookupMethod);
             } else if (lookupResult == null) {
-                return createMessageFallbackNode(selector, assumptions, lookupClass);
+                return createMessageFallbackNode(selector, assumptions, lookupClass, arity);
             } else {
                 final ClassObject lookupResultClass = SqueakObjectClassNode.executeUncached(lookupResult);
                 final Object runWithInLookupResult = LookupMethodNode.executeUncached(lookupResultClass, SqueakImageContext.getSlow().runWithInSelector);
@@ -172,26 +174,31 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
                     return new DispatchDirectObjectAsMethodNaryNode(assumptions, selector, runWithInMethod, lookupResult);
                 } else {
                     assert runWithInLookupResult == null : "runWithInLookupResult should not be another Object";
-                    return createMessageFallbackNode(selector, assumptions, lookupResultClass);
+                    return createMessageFallbackNode(selector, assumptions, lookupResultClass, arity);
                 }
             }
         }
 
         private static DispatchDirectNaryNode create(final Assumption[] assumptions, final CompiledCodeObject method) {
-            // Cannot check argument count here (actual count of arguments only known when called).
             if (method.hasPrimitive()) {
                 final AbstractPrimitiveNode primitiveNode = PrimitiveNodeFactory.getOrCreateIndexedOrNamed(method);
                 if (primitiveNode != null) {
                     return new DispatchDirectPrimitiveNaryNode(assumptions, method, primitiveNode);
                 }
-                DispatchUtils.logMissingPrimitive(null, method);
+                DispatchUtils.logMissingPrimitive(primitiveNode, method);
             }
             return new DispatchDirectMethodNaryNode(assumptions, method);
         }
 
-        private static DispatchDirectMessageFallbackNaryNode createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass) {
-            final CompiledCodeObject fallbackMethod = receiverClass.resolveDispatchFailure(selector);
-            return new DispatchDirectMessageFallbackNaryNode(assumptions, selector, fallbackMethod);
+        private static DispatchDirectNaryNode createMessageFallbackNode(final NativeObject selector, final Assumption[] assumptions, final ClassObject receiverClass, final int arity) {
+            final ClassObject.DispatchFailureResult result = receiverClass.resolveDispatchFailure(selector, arity);
+            final Assumption[] finalAssumptions = DispatchUtils.getAssumptionsForMessageFallback(assumptions, selector, result.fallbackMethod());
+
+            return switch (result.convention()) {
+                case SHORTCUT_DNU -> new DispatchDirectShortcutFallbackNaryNode(finalAssumptions, selector, result.fallbackMethod(), arity);
+                case STANDARD_DNU -> new DispatchDirectDNUFallbackNaryNode(finalAssumptions, selector, result.fallbackMethod());
+                case CANNOT_INTERPRET -> new DispatchDirectCannotInterpretFallbackNaryNode(finalAssumptions, selector, result.fallbackMethod(), result.fallbackDepth(), result.fallbackSelector());
+            };
         }
     }
 
@@ -490,26 +497,85 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
         }
     }
 
-    static final class DispatchDirectMessageFallbackNaryNode extends DispatchDirectWithSenderNaryNode {
-        private final NativeObject selector;
-        @Child private DirectCallNode callNode;
-        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+    abstract static class AbstractDispatchDirectFallbackNaryNode extends DispatchDirectWithSenderNaryNode {
+        protected final NativeObject selector;
+        @Child protected DirectCallNode callNode;
 
-        DispatchDirectMessageFallbackNaryNode(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+        AbstractDispatchDirectFallbackNaryNode(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject targetMethod) {
             super(assumptions);
             this.selector = selector;
-            callNode = DirectCallNode.create(dnuMethod.getCallTarget());
+            this.callNode = DirectCallNode.create(targetMethod.getCallTarget());
         }
 
         @Override
         protected void checkNumArguments(final Object[] arguments) {
-            // nothing to do
+            // Nothing to do; fallback message creation handles arbitrary arrays
+        }
+
+        @Override
+        public abstract Object execute(VirtualFrame frame, Object receiver, Object[] arguments);
+    }
+
+    static final class DispatchDirectDNUFallbackNaryNode extends AbstractDispatchDirectFallbackNaryNode {
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectDNUFallbackNaryNode(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject dnuMethod) {
+            super(assumptions, selector, dnuMethod);
         }
 
         @Override
         public Object execute(final VirtualFrame frame, final Object receiver, final Object[] arguments) {
             final PointersObject message = createMessageNode.execute(selector, receiver, arguments);
             return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
+        }
+    }
+
+    static final class DispatchDirectCannotInterpretFallbackNaryNode extends AbstractDispatchDirectFallbackNaryNode {
+        private final int fallbackDepth;
+        private final NativeObject ciSelector;
+        @Child private CreateMessageNode createMessageNode = CreateMessageNodeGen.create();
+
+        DispatchDirectCannotInterpretFallbackNaryNode(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject ciMethod, final int fallbackDepth,
+                        final NativeObject ciSelector) {
+            super(assumptions, selector, ciMethod);
+            this.fallbackDepth = fallbackDepth;
+            this.ciSelector = ciSelector;
+        }
+
+        @Override
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object[] arguments) {
+            final PointersObject message = DispatchUtils.buildNestedMessage(
+                            createMessageNode,
+                            selector,
+                            ciSelector,
+                            receiver,
+                            arguments,
+                            fallbackDepth);
+            return callNode.call(FrameAccess.newMessageFallbackWith(senderNode.execute(frame), receiver, message));
+        }
+    }
+
+    static final class DispatchDirectShortcutFallbackNaryNode extends AbstractDispatchDirectFallbackNaryNode {
+        private final int arity;
+
+        DispatchDirectShortcutFallbackNaryNode(final Assumption[] assumptions, final NativeObject selector, final CompiledCodeObject shortcutMethod, final int arity) {
+            super(assumptions, selector, shortcutMethod);
+            this.arity = arity;
+        }
+
+        @Override
+        @ExplodeLoop
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object[] arguments) {
+            assert arguments.length == arity : "Shortcut arity mismatch!";
+
+            // Build the shortcut arguments: [arg0, arg1, ..., argN, selector]
+            final Object[] shortcutArgs = new Object[arity + 1];
+            for (int i = 0; i < arity; i++) {
+                shortcutArgs[i] = arguments[i];
+            }
+            shortcutArgs[arity] = selector;
+
+            return callNode.call(FrameAccess.newWith(senderNode.execute(frame), null, receiver, shortcutArgs));
         }
     }
 
@@ -553,7 +619,14 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
             final ClassObject receiverClass = classNode.executeLookup(node, receiver);
             final Object lookupResult = getContext(node).lookup(receiverClass, selector);
             final CompiledCodeObject method = methodNode.execute(node, getContext(node), arguments.length, canPrimFail, selector, receiverClass, lookupResult);
-            final Object result = tryPrimitiveNode.execute(frame, method, receiver, arguments);
+
+            final Object result;
+            if (lookupResult instanceof CompiledCodeObject) {
+                result = tryPrimitiveNode.execute(frame, method, receiver, arguments);
+            } else {
+                result = null;
+            }
+
             if (result != null) {
                 return result;
             } else {
@@ -630,12 +703,56 @@ public final class DispatchSelectorNaryNode extends DispatchSelectorNode {
                 return FrameAccess.newWith(sender, null, receiver, arguments);
             }
 
-            @Specialization(guards = "lookupResult == null")
-            protected static final Object[] doMessageFallback(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object[] arguments, final ClassObject receiverClass,
+            @Specialization(guards = {"lookupResult == null", "arguments.length == cachedArity"}, limit = "1")
+            @ExplodeLoop
+            protected static final Object[] doMessageFallbackCached(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object[] arguments,
+                            final ClassObject receiverClass,
                             @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
-                            @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode) {
-                final PointersObject message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                            @Cached("arguments.length") final int cachedArity,
+                            @Shared("writeNode") @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Shared("createNode") @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                return doMessageFallbackShared(node, sender, receiver, arguments, receiverClass, selector, cachedArity, writeNode, createMessageNode);
+            }
+
+            @Specialization(guards = "lookupResult == null", replaces = "doMessageFallbackCached")
+            protected static final Object[] doMessageFallbackGeneric(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object[] arguments,
+                            final ClassObject receiverClass,
+                            @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,
+                            @Shared("writeNode") @Cached(inline = false) final AbstractPointersObjectWriteNode writeNode,
+                            @Shared("createNode") @Cached(inline = false) final CreateMessageNode createMessageNode) {
+                return doMessageFallbackShared(node, sender, receiver, arguments, receiverClass, selector, arguments.length, writeNode, createMessageNode);
+            }
+
+            private static Object[] doMessageFallbackShared(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object[] arguments, final ClassObject receiverClass,
+                            final NativeObject selector, final int arity, final AbstractPointersObjectWriteNode writeNode, final CreateMessageNode createMessageNode) {
+
+                final ClassObject.DispatchFailureResult result = getContext(node).findMethodCacheEntry(receiverClass, selector).getOrCreateDispatchFailureResult(arity);
+
+                if (result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU) {
+                    final Object[] shortcutArgs = new Object[arity + 1];
+                    if (CompilerDirectives.isPartialEvaluationConstant(arity)) {
+                        copyExploded(arguments, shortcutArgs, arity);
+                    } else {
+                        System.arraycopy(arguments, 0, shortcutArgs, 0, arity);
+                    }
+                    shortcutArgs[arity] = selector;
+                    return FrameAccess.newWith(sender, null, receiver, shortcutArgs);
+                }
+
+                final PointersObject message;
+                if (result.convention() == ClassObject.FallbackConvention.CANNOT_INTERPRET) {
+                    message = DispatchUtils.buildNestedMessage(createMessageNode, selector, result.fallbackSelector(), receiver, arguments, result.fallbackDepth());
+                } else {
+                    message = getContext(node).newMessage(writeNode, selector, receiverClass, arguments);
+                }
                 return FrameAccess.newMessageFallbackWith(sender, receiver, message);
+            }
+
+            @ExplodeLoop
+            private static void copyExploded(final Object[] source, final Object[] dest, final int length) {
+                for (int i = 0; i < length; i++) {
+                    dest[i] = source[i];
+                }
             }
 
             @Specialization(guards = {"targetObject != null", "!isCompiledCodeObject(targetObject)"})

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
@@ -117,9 +117,13 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
                         }
                     }
                 }
+
+                // Wide Cache Miss: Delegate to Manager for Specialization
+                CompilerDirectives.transferToInterpreterAndInvalidate();
+                return executeAndSpecialize(frame, receiverClass, lookupResult, receiver, arguments);
             }
 
-            // Cache Miss: Delegate to Manager for Specialization
+            // Fast Cache Miss: Delegate to Manager for Specialization
             CompilerDirectives.transferToInterpreterAndInvalidate();
             return executeAndSpecialize(frame, receiver, arguments);
         }
@@ -137,6 +141,14 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
 
             final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
             final Object lookupResult = getContext().lookup(receiverClass, selector);
+            return executeAndSpecialize(frame, receiverClass, lookupResult, receiver, arguments);
+        }
+
+        private Object executeAndSpecialize(final VirtualFrame frame, final ClassObject receiverClass, final Object lookupResult, final Object receiver, final Object[] arguments) {
+            // Guard against lagging recursive frames.
+            if (indirectNode != null) {
+                return indirectNode.execute(frame, true, selector, receiver, arguments);
+            }
 
             // Node creation handles method resolution, including DNU and OAM fallbacks.
             final DispatchDirectNaryNode newDirectNode = DispatchDirectNaryNode.create(selector, receiverClass, arguments.length);
@@ -198,9 +210,13 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
                         }
                     }
                 }
+
+                // Wide Cache Miss: Delegate to Manager for Specialization
+                CompilerDirectives.transferToInterpreterAndInvalidate();
+                return executeAndSpecialize(frame, receiverClass, lookupResult, receiver, arguments);
             }
 
-            // Cache Miss: Delegate to Manager for Specialization
+            // Fast Cache Miss: Delegate to Manager for Specialization
             CompilerDirectives.transferToInterpreterAndInvalidate();
             return executeAndSpecialize(frame, receiver, arguments);
         }
@@ -218,6 +234,15 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
 
             final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
             final Object lookupResult = getContext().lookup(receiverClass, selector);
+            return executeAndSpecialize(frame, receiverClass, lookupResult, receiver, arguments);
+
+        }
+
+        private Object executeAndSpecialize(final VirtualFrame frame, final ClassObject receiverClass, final Object lookupResult, final Object receiver, final Object[] arguments) {
+            // Guard against lagging recursive frames.
+            if (indirectNode != null) {
+                return indirectNode.execute(frame, true, selector, receiver, arguments);
+            }
 
             // Node creation handles method resolution, including DNU and OAM fallbacks.
             final DispatchDirectNaryNode newDirectNode = DispatchDirectNaryNode.create(selector, receiverClass, arguments.length);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
@@ -89,6 +89,13 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
         public Object execute(final VirtualFrame frame, final Object receiver, final Object[] arguments) {
             final byte currentState = state;
 
+            // TIER 0: Pure Monomorphic Fast Path
+            if ((currentState & HAS_MONO) != 0) {
+                if (Assumption.isValidAssumption(monoExecutor.getAssumptions()) && monoGuard.check(receiver)) {
+                    return monoExecutor.execute(frame, receiver, arguments);
+                }
+            }
+
             // TIER 3: Megamorphic Fallback (Indirect Execution)
             if ((currentState & HAS_INDIRECT) != 0) {
                 return indirectNode.execute(frame, canPrimFail(), selector, receiver, arguments);
@@ -105,13 +112,17 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
 
             // TIER 2: Wide Execution (Class Polymorphism)
             if ((currentState & HAS_WIDE) != 0) {
-                final ClassObject receiverClass = classNode.executeLookup(this, receiver);
-                final Object lookupResult = getContext().lookup(receiverClass, selector);
+                /* Local snapshot guards against stale compiled code during invalidation. */
+                final SqueakObjectClassNode node = classNode;
+                if (node != null) {
+                    final ClassObject receiverClass = node.executeLookup(this, receiver);
+                    final Object lookupResult = getContext().lookup(receiverClass, selector);
 
-                if (lookupResult instanceof CompiledCodeObject targetMethod) {
-                    for (final DispatchEntry<DispatchDirectNaryNode> entry : wideEntries) {
-                        if (entry.isWideCacheHit(targetMethod)) {
-                            return entry.executor.execute(frame, receiver, arguments);
+                    if (lookupResult instanceof CompiledCodeObject targetMethod) {
+                        for (final DispatchEntry<DispatchDirectNaryNode> entry : wideEntries) {
+                            if (entry.isWideCacheHit(targetMethod)) {
+                                return entry.executor.execute(frame, receiver, arguments);
+                            }
                         }
                     }
                 }
@@ -142,6 +153,7 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
             } else {
                 reportPolymorphicSpecialize();
                 indirectNode = insert(DispatchIndirectNaryNodeGen.create());
+                convertToIndirect();
                 return indirectNode.execute(frame, canPrimFail(), selector, receiver, arguments);
             }
         }
@@ -164,6 +176,13 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
         public Object execute(final VirtualFrame frame, final Object receiver, final Object[] arguments) {
             final byte currentState = state;
 
+            // TIER 0: Pure Monomorphic Fast Path
+            if ((currentState & HAS_MONO) != 0) {
+                if (Assumption.isValidAssumption(monoExecutor.getAssumptions()) && monoGuard.check(receiver)) {
+                    return monoExecutor.executeWithCheckedArguments(frame, receiver, arguments);
+                }
+            }
+
             // TIER 3: Megamorphic Fallback (Indirect Execution)
             if ((currentState & HAS_INDIRECT) != 0) {
                 return indirectNode.execute(frame, canPrimFail(), selector, receiver, arguments);
@@ -180,13 +199,17 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
 
             // TIER 2: Wide Execution (Class Polymorphism)
             if ((currentState & HAS_WIDE) != 0) {
-                final ClassObject receiverClass = classNode.executeLookup(this, receiver);
-                final Object lookupResult = getContext().lookup(receiverClass, selector);
+                /* Local snapshot guards against stale compiled code during invalidation. */
+                final SqueakObjectClassNode node = classNode;
+                if (node != null) {
+                    final ClassObject receiverClass = node.executeLookup(this, receiver);
+                    final Object lookupResult = getContext().lookup(receiverClass, selector);
 
-                if (lookupResult instanceof CompiledCodeObject targetMethod) {
-                    for (final DispatchEntry<DispatchDirectNaryNode> entry : wideEntries) {
-                        if (entry.isWideCacheHit(targetMethod)) {
-                            return entry.executor.executeWithCheckedArguments(frame, receiver, arguments); // Checked Execution
+                    if (lookupResult instanceof CompiledCodeObject targetMethod) {
+                        for (final DispatchEntry<DispatchDirectNaryNode> entry : wideEntries) {
+                            if (entry.isWideCacheHit(targetMethod)) {
+                                return entry.executor.executeWithCheckedArguments(frame, receiver, arguments); // Checked Execution
+                            }
                         }
                     }
                 }
@@ -217,6 +240,7 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
             } else {
                 reportPolymorphicSpecialize();
                 indirectNode = insert(DispatchIndirectNaryNodeGen.create());
+                convertToIndirect();
                 return indirectNode.execute(frame, canPrimFail(), selector, receiver, arguments);
             }
         }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
@@ -24,7 +24,6 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.DirectCallNode;
-import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.IndirectCallNode;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.InlinedBranchProfile;
@@ -769,7 +768,6 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
             }
 
             @Specialization(guards = {"lookupResult == null", "arguments.length == cachedArity"}, limit = "1", replaces = {"doMessageFallbackCached", "doMessageFallbackGeneric"})
-            @ExplodeLoop
             protected static final Object[] doMessageFallbackWithShortcutsCached(final Node node, final AbstractSqueakObject sender, final Object receiver, final Object[] arguments,
                             final ClassObject receiverClass,
                             @SuppressWarnings("unused") final Object lookupResult, final NativeObject selector,

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
@@ -63,20 +63,19 @@ import de.hpi.swa.trufflesqueak.util.FrameAccess;
 import de.hpi.swa.trufflesqueak.util.MiscUtils;
 
 public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode {
-    protected abstract static class AbstractDispatchNaryNode extends AbstractDispatchNode {
-        AbstractDispatchNaryNode(final NativeObject selector) {
-            super(selector);
+    protected abstract static class AbstractDispatchNaryNode<T extends AbstractDispatchDirectNode> extends AbstractDispatchNode<T> {
+        AbstractDispatchNaryNode(final NativeObject selector, final boolean canPrimFail) {
+            super(selector, canPrimFail);
         }
 
         public abstract Object execute(VirtualFrame frame, Object receiver, Object[] arguments);
     }
 
-    public static final class DispatchNaryNode extends AbstractDispatchNaryNode {
-        @Child private DispatchCacheManager<DispatchDirectNaryNode> cache;
+    public static final class DispatchNaryNode extends AbstractDispatchNaryNode<DispatchDirectNaryNode> {
         @Child private DispatchIndirectNaryNode indirectNode;
 
         private DispatchNaryNode(final NativeObject selector) {
-            super(selector);
+            super(selector, false);
         }
 
         @NeverDefault
@@ -88,30 +87,29 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
         @ExplodeLoop
         @InliningCutoff
         public Object execute(final VirtualFrame frame, final Object receiver, final Object[] arguments) {
-            // TIER 3: Megamorphic Fallback (Indirect Execution)
-            if (indirectNode != null) {
-                return indirectNode.execute(frame, false, selector, receiver, arguments);
-            }
+            final byte currentState = state;
 
-            if (cache == null) {
-                CompilerDirectives.transferToInterpreterAndInvalidate();
-                cache = insert(new DispatchCacheManager<>());
+            // TIER 3: Megamorphic Fallback (Indirect Execution)
+            if ((currentState & HAS_INDIRECT) != 0) {
+                return indirectNode.execute(frame, canPrimFail(), selector, receiver, arguments);
             }
 
             // TIER 1: Direct Execution Fast Path
-            for (final DispatchEntry<DispatchDirectNaryNode> entry : cache.fastEntries) {
-                if (entry.isFastCacheHit(receiver)) {
-                    return entry.executor.execute(frame, receiver, arguments);
+            if ((currentState & HAS_FAST) != 0) {
+                for (final DispatchEntry<DispatchDirectNaryNode> entry : fastEntries) {
+                    if (entry.isFastCacheHit(receiver)) {
+                        return entry.executor.execute(frame, receiver, arguments);
+                    }
                 }
             }
 
             // TIER 2: Wide Execution (Class Polymorphism)
-            if (cache.wideEntries.length > 0) {
-                final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
+            if ((currentState & HAS_WIDE) != 0) {
+                final ClassObject receiverClass = classNode.executeLookup(this, receiver);
                 final Object lookupResult = getContext().lookup(receiverClass, selector);
 
                 if (lookupResult instanceof CompiledCodeObject targetMethod) {
-                    for (final DispatchEntry<DispatchDirectNaryNode> entry : cache.wideEntries) {
+                    for (final DispatchEntry<DispatchDirectNaryNode> entry : wideEntries) {
                         if (entry.isWideCacheHit(targetMethod)) {
                             return entry.executor.execute(frame, receiver, arguments);
                         }
@@ -119,27 +117,24 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
                 }
             }
 
-            // Cache Miss: Delegate to Manager for Specialization
+            // Cache Miss: Delegate to superclass for Specialization
             CompilerDirectives.transferToInterpreterAndInvalidate();
             return executeAndSpecialize(frame, receiver, arguments);
         }
 
         private Object executeAndSpecialize(final VirtualFrame frame, final Object receiver, final Object[] arguments) {
             /*
-             * Guard against lagging recursive frames. If multiple frames of this method are on the
-             * stack executing compiled code, a deeper frame may have already deoptimized and
-             * transitioned this node to the indirect tier. This intercepts older deoptimized frames
-             * to prevent redundant specialization.
+             * Guard against lagging recursive frames.
              */
-            if (indirectNode != null) {
-                return indirectNode.execute(frame, true, selector, receiver, arguments);
+            if ((state & HAS_INDIRECT) != 0) {
+                return indirectNode.execute(frame, canPrimFail(), selector, receiver, arguments);
             }
 
-            final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
+            ensureClassNode();
+            final ClassObject receiverClass = classNode.executeLookup(this, receiver);
             final Object lookupResult = getContext().lookup(receiverClass, selector);
 
-            // Node creation handles method resolution, including DNU and OAM fallbacks.
-            final DispatchDirectNaryNode executor = cache.specialize(receiver, receiverClass, lookupResult,
+            final DispatchDirectNaryNode executor = specialize(receiver, receiverClass, lookupResult,
                             () -> DispatchDirectNaryNode.create(selector, receiverClass, arguments.length));
 
             if (executor != null) {
@@ -147,17 +142,16 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
             } else {
                 reportPolymorphicSpecialize();
                 indirectNode = insert(DispatchIndirectNaryNodeGen.create());
-                return indirectNode.execute(frame, false, selector, receiver, arguments);
+                return indirectNode.execute(frame, canPrimFail(), selector, receiver, arguments);
             }
         }
     }
 
-    public static final class DispatchPerformNaryNode extends AbstractDispatchNaryNode {
-        @Child private DispatchCacheManager<DispatchDirectNaryNode> cache;
+    public static final class DispatchPerformNaryNode extends AbstractDispatchNaryNode<DispatchDirectNaryNode> {
         @Child private DispatchIndirectNaryNode indirectNode;
 
         private DispatchPerformNaryNode(final NativeObject selector) {
-            super(selector);
+            super(selector, true);
         }
 
         @NeverDefault
@@ -168,58 +162,54 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
         @Override
         @ExplodeLoop
         public Object execute(final VirtualFrame frame, final Object receiver, final Object[] arguments) {
-            // TIER 3: Megamorphic Fallback (Indirect Execution)
-            if (indirectNode != null) {
-                return indirectNode.execute(frame, true, selector, receiver, arguments);
-            }
+            final byte currentState = state;
 
-            if (cache == null) {
-                CompilerDirectives.transferToInterpreterAndInvalidate();
-                cache = insert(new DispatchCacheManager<>());
+            // TIER 3: Megamorphic Fallback (Indirect Execution)
+            if ((currentState & HAS_INDIRECT) != 0) {
+                return indirectNode.execute(frame, canPrimFail(), selector, receiver, arguments);
             }
 
             // TIER 1: Direct Execution Fast Path
-            for (final DispatchEntry<DispatchDirectNaryNode> entry : cache.fastEntries) {
-                if (entry.isFastCacheHit(receiver)) {
-                    return entry.executor.executeWithCheckedArguments(frame, receiver, arguments);
+            if ((currentState & HAS_FAST) != 0) {
+                for (final DispatchEntry<DispatchDirectNaryNode> entry : fastEntries) {
+                    if (entry.isFastCacheHit(receiver)) {
+                        return entry.executor.executeWithCheckedArguments(frame, receiver, arguments); // Checked Execution
+                    }
                 }
             }
 
             // TIER 2: Wide Execution (Class Polymorphism)
-            if (cache.wideEntries.length > 0) {
-                final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
+            if ((currentState & HAS_WIDE) != 0) {
+                final ClassObject receiverClass = classNode.executeLookup(this, receiver);
                 final Object lookupResult = getContext().lookup(receiverClass, selector);
 
                 if (lookupResult instanceof CompiledCodeObject targetMethod) {
-                    for (final DispatchEntry<DispatchDirectNaryNode> entry : cache.wideEntries) {
+                    for (final DispatchEntry<DispatchDirectNaryNode> entry : wideEntries) {
                         if (entry.isWideCacheHit(targetMethod)) {
-                            return entry.executor.executeWithCheckedArguments(frame, receiver, arguments);
+                            return entry.executor.executeWithCheckedArguments(frame, receiver, arguments); // Checked Execution
                         }
                     }
                 }
             }
 
-            // Cache Miss: Delegate to Manager for Specialization
+            // Cache Miss: Delegate to superclass for Specialization
             CompilerDirectives.transferToInterpreterAndInvalidate();
             return executeAndSpecialize(frame, receiver, arguments);
         }
 
         private Object executeAndSpecialize(final VirtualFrame frame, final Object receiver, final Object[] arguments) {
             /*
-             * Guard against lagging recursive frames. If multiple frames of this method are on the
-             * stack executing compiled code, a deeper frame may have already deoptimized and
-             * transitioned this node to the indirect tier. This intercepts older deoptimized frames
-             * to prevent redundant specialization.
+             * Guard against lagging recursive frames.
              */
-            if (indirectNode != null) {
-                return indirectNode.execute(frame, true, selector, receiver, arguments);
+            if ((state & HAS_INDIRECT) != 0) {
+                return indirectNode.execute(frame, canPrimFail(), selector, receiver, arguments);
             }
 
-            final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
+            ensureClassNode();
+            final ClassObject receiverClass = classNode.executeLookup(this, receiver);
             final Object lookupResult = getContext().lookup(receiverClass, selector);
 
-            // Node creation handles method resolution, including DNU and OAM fallbacks.
-            final DispatchDirectNaryNode executor = cache.specialize(receiver, receiverClass, lookupResult,
+            final DispatchDirectNaryNode executor = specialize(receiver, receiverClass, lookupResult,
                             () -> DispatchDirectNaryNode.create(selector, receiverClass, arguments.length));
 
             if (executor != null) {
@@ -227,16 +217,16 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
             } else {
                 reportPolymorphicSpecialize();
                 indirectNode = insert(DispatchIndirectNaryNodeGen.create());
-                return indirectNode.execute(frame, true, selector, receiver, arguments);
+                return indirectNode.execute(frame, canPrimFail(), selector, receiver, arguments);
             }
         }
     }
 
-    public abstract static class DispatchSuperNaryNode extends AbstractDispatchNaryNode {
+    public abstract static class DispatchSuperNaryNode extends AbstractDispatchNaryNode<DispatchDirectNaryNode> {
         protected final CompiledCodeObject method;
 
         DispatchSuperNaryNode(final CompiledCodeObject codeObject, final NativeObject selector) {
-            super(selector);
+            super(selector, false);
             method = codeObject.getMethod();
         }
 
@@ -248,9 +238,9 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
         }
     }
 
-    public abstract static class DispatchDirectedSuperNaryNode extends AbstractDispatchNode {
+    public abstract static class DispatchDirectedSuperNaryNode extends AbstractDispatchNode<DispatchDirectNaryNode> {
         DispatchDirectedSuperNaryNode(final NativeObject selector) {
-            super(selector);
+            super(selector, false);
         }
 
         public abstract Object execute(VirtualFrame frame, ClassObject lookupClass, Object receiver, Object[] arguments);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
@@ -117,13 +117,9 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
                         }
                     }
                 }
-
-                // Wide Cache Miss: Delegate to Manager for Specialization
-                CompilerDirectives.transferToInterpreterAndInvalidate();
-                return executeAndSpecialize(frame, receiverClass, lookupResult, receiver, arguments);
             }
 
-            // Fast Cache Miss: Delegate to Manager for Specialization
+            // Cache Miss: Delegate to Manager for Specialization
             CompilerDirectives.transferToInterpreterAndInvalidate();
             return executeAndSpecialize(frame, receiver, arguments);
         }
@@ -141,14 +137,6 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
 
             final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
             final Object lookupResult = getContext().lookup(receiverClass, selector);
-            return executeAndSpecialize(frame, receiverClass, lookupResult, receiver, arguments);
-        }
-
-        private Object executeAndSpecialize(final VirtualFrame frame, final ClassObject receiverClass, final Object lookupResult, final Object receiver, final Object[] arguments) {
-            // Guard against lagging recursive frames.
-            if (indirectNode != null) {
-                return indirectNode.execute(frame, true, selector, receiver, arguments);
-            }
 
             // Node creation handles method resolution, including DNU and OAM fallbacks.
             final DispatchDirectNaryNode executor = cache.specialize(receiver, receiverClass, lookupResult,
@@ -157,7 +145,7 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
             if (executor != null) {
                 return executor.execute(frame, receiver, arguments);
             } else {
-                this.reportPolymorphicSpecialize();
+                reportPolymorphicSpecialize();
                 indirectNode = insert(DispatchIndirectNaryNodeGen.create());
                 return indirectNode.execute(frame, false, selector, receiver, arguments);
             }
@@ -209,13 +197,9 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
                         }
                     }
                 }
-
-                // Wide Cache Miss: Delegate to Manager for Specialization
-                CompilerDirectives.transferToInterpreterAndInvalidate();
-                return executeAndSpecialize(frame, receiverClass, lookupResult, receiver, arguments);
             }
 
-            // Fast Cache Miss: Delegate to Manager for Specialization
+            // Cache Miss: Delegate to Manager for Specialization
             CompilerDirectives.transferToInterpreterAndInvalidate();
             return executeAndSpecialize(frame, receiver, arguments);
         }
@@ -233,15 +217,6 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
 
             final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
             final Object lookupResult = getContext().lookup(receiverClass, selector);
-            return executeAndSpecialize(frame, receiverClass, lookupResult, receiver, arguments);
-
-        }
-
-        private Object executeAndSpecialize(final VirtualFrame frame, final ClassObject receiverClass, final Object lookupResult, final Object receiver, final Object[] arguments) {
-            // Guard against lagging recursive frames.
-            if (indirectNode != null) {
-                return indirectNode.execute(frame, true, selector, receiver, arguments);
-            }
 
             // Node creation handles method resolution, including DNU and OAM fallbacks.
             final DispatchDirectNaryNode executor = cache.specialize(receiver, receiverClass, lookupResult,
@@ -250,7 +225,7 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
             if (executor != null) {
                 return executor.executeWithCheckedArguments(frame, receiver, arguments);
             } else {
-                this.reportPolymorphicSpecialize();
+                reportPolymorphicSpecialize();
                 indirectNode = insert(DispatchIndirectNaryNodeGen.create());
                 return indirectNode.execute(frame, true, selector, receiver, arguments);
             }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
@@ -10,7 +10,7 @@ import com.oracle.truffle.api.Assumption;
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
-import com.oracle.truffle.api.HostCompilerDirectives;
+import com.oracle.truffle.api.HostCompilerDirectives.InliningCutoff;
 import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Cached.Shared;
@@ -19,7 +19,6 @@ import com.oracle.truffle.api.dsl.GenerateInline;
 import com.oracle.truffle.api.dsl.GenerateUncached;
 import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.NeverDefault;
-import com.oracle.truffle.api.dsl.ReportPolymorphism;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
@@ -43,6 +42,7 @@ import de.hpi.swa.trufflesqueak.nodes.accessing.AbstractPointersObjectNodes.Abst
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectClassNode;
 import de.hpi.swa.trufflesqueak.nodes.context.GetOrCreateContextWithoutFrameNode;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNodeFactory.DispatchDirectPrimitiveFallbackNaryNodeGen;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNodeFactory.DispatchIndirectNaryNodeGen;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNodeFactory.DispatchIndirectNaryNodeGen.TryPrimitiveNaryNodeGen;
 import de.hpi.swa.trufflesqueak.nodes.primitives.AbstractPrimitiveNode;
 import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive0;
@@ -71,59 +71,165 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
         public abstract Object execute(VirtualFrame frame, Object receiver, Object[] arguments);
     }
 
-    public abstract static class DispatchNaryNode extends AbstractDispatchNaryNode {
-        DispatchNaryNode(final NativeObject selector) {
+    public static final class DispatchNaryNode extends AbstractDispatchNaryNode {
+        @Child private DispatchCacheManager<DispatchDirectNaryNode> cache;
+        @Child private DispatchIndirectNaryNode indirectNode;
+
+        private DispatchNaryNode(final NativeObject selector) {
             super(selector);
         }
 
         @NeverDefault
         public static DispatchNaryNode create(final NativeObject selector) {
-            return DispatchSelectorNaryNodeFactory.DispatchNaryNodeGen.create(selector);
+            return new DispatchNaryNode(selector);
         }
 
-        @Specialization(guards = {"guard.check(receiver)", "arguments.length == cachedArity"}, assumptions = "dispatchDirectNode.getAssumptions()", limit = "INLINE_METHOD_CACHE_LIMIT")
-        protected static final Object doDirect(final VirtualFrame frame, final Object receiver, final Object[] arguments,
-                        @SuppressWarnings("unused") @Cached("create(receiver)") final LookupClassGuard guard,
-                        @SuppressWarnings("unused") @Cached("arguments.length") final int cachedArity,
-                        @Cached("create(selector, guard, cachedArity)") final DispatchDirectNaryNode dispatchDirectNode) {
-            return dispatchDirectNode.execute(frame, receiver, arguments);
+        @Override
+        @ExplodeLoop
+        @InliningCutoff
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object[] arguments) {
+            // TIER 3: Megamorphic Fallback (Indirect Execution)
+            if (indirectNode != null) {
+                return indirectNode.execute(frame, false, selector, receiver, arguments);
+            }
+
+            if (cache == null) {
+                CompilerDirectives.transferToInterpreterAndInvalidate();
+                cache = insert(new DispatchCacheManager<>());
+            }
+
+            // TIER 1: Direct Execution Fast Path
+            for (final DispatchEntry<DispatchDirectNaryNode> entry : cache.fastEntries) {
+                if (entry.isFastCacheHit(receiver)) {
+                    return entry.executor.execute(frame, receiver, arguments);
+                }
+            }
+
+            // TIER 2: Wide Execution (Class Polymorphism)
+            if (cache.wideEntries.length > 0) {
+                final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
+                final Object lookupResult = getContext().lookup(receiverClass, selector);
+
+                if (lookupResult instanceof CompiledCodeObject targetMethod) {
+                    for (final DispatchEntry<DispatchDirectNaryNode> entry : cache.wideEntries) {
+                        if (entry.isWideCacheHit(targetMethod)) {
+                            return entry.executor.execute(frame, receiver, arguments);
+                        }
+                    }
+                }
+            }
+
+            // Cache Miss: Delegate to Manager for Specialization
+            CompilerDirectives.transferToInterpreterAndInvalidate();
+            return executeAndSpecialize(frame, receiver, arguments);
         }
 
-        @ReportPolymorphism.Megamorphic
-        @Specialization(replaces = "doDirect")
-        @HostCompilerDirectives.InliningCutoff
-        @SuppressWarnings("truffle-static-method")
-        protected final Object doIndirect(final VirtualFrame frame, final Object receiver, final Object[] arguments,
-                        @Cached final DispatchIndirectNaryNode dispatchNode) {
-            return dispatchNode.execute(frame, false, selector, receiver, arguments);
+        private Object executeAndSpecialize(final VirtualFrame frame, final Object receiver, final Object[] arguments) {
+            /*
+             * Guard against lagging recursive frames. If multiple frames of this method are on the
+             * stack executing compiled code, a deeper frame may have already deoptimized and
+             * transitioned this node to the indirect tier. This intercepts older deoptimized frames
+             * to prevent redundant specialization.
+             */
+            if (indirectNode != null) {
+                return indirectNode.execute(frame, true, selector, receiver, arguments);
+            }
+
+            final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
+            final Object lookupResult = getContext().lookup(receiverClass, selector);
+
+            // Node creation handles method resolution, including DNU and OAM fallbacks.
+            final DispatchDirectNaryNode newDirectNode = DispatchDirectNaryNode.create(selector, receiverClass, arguments.length);
+
+            final DispatchDirectNaryNode executor = cache.specialize(receiver, lookupResult, newDirectNode);
+
+            if (executor != null) {
+                return executor.execute(frame, receiver, arguments);
+            } else {
+                this.reportPolymorphicSpecialize();
+                indirectNode = insert(DispatchIndirectNaryNodeGen.create());
+                return indirectNode.execute(frame, false, selector, receiver, arguments);
+            }
         }
     }
 
-    public abstract static class DispatchPerformNaryNode extends AbstractDispatchNaryNode {
-        DispatchPerformNaryNode(final NativeObject selector) {
+    public static final class DispatchPerformNaryNode extends AbstractDispatchNaryNode {
+        @Child private DispatchCacheManager<DispatchDirectNaryNode> cache;
+        @Child private DispatchIndirectNaryNode indirectNode;
+
+        private DispatchPerformNaryNode(final NativeObject selector) {
             super(selector);
         }
 
         @NeverDefault
         public static DispatchPerformNaryNode create(final NativeObject selector) {
-            return DispatchSelectorNaryNodeFactory.DispatchPerformNaryNodeGen.create(selector);
+            return new DispatchPerformNaryNode(selector);
         }
 
-        @Specialization(guards = {"guard.check(receiver)", "arguments.length == cachedArity"}, assumptions = "dispatchDirectNode.getAssumptions()", limit = "INLINE_METHOD_CACHE_LIMIT")
-        protected static final Object doDirect(final VirtualFrame frame, final Object receiver, final Object[] arguments,
-                        @SuppressWarnings("unused") @Cached("create(receiver)") final LookupClassGuard guard,
-                        @SuppressWarnings("unused") @Cached("arguments.length") final int cachedArity,
-                        @Cached("create(selector, guard, cachedArity)") final DispatchDirectNaryNode dispatchDirectNode) {
-            return dispatchDirectNode.executeWithCheckedArguments(frame, receiver, arguments);
+        @Override
+        @ExplodeLoop
+        public Object execute(final VirtualFrame frame, final Object receiver, final Object[] arguments) {
+            // TIER 3: Megamorphic Fallback (Indirect Execution)
+            if (indirectNode != null) {
+                return indirectNode.execute(frame, true, selector, receiver, arguments);
+            }
+
+            if (cache == null) {
+                CompilerDirectives.transferToInterpreterAndInvalidate();
+                cache = insert(new DispatchCacheManager<>());
+            }
+
+            // TIER 1: Direct Execution Fast Path
+            for (final DispatchEntry<DispatchDirectNaryNode> entry : cache.fastEntries) {
+                if (entry.isFastCacheHit(receiver)) {
+                    return entry.executor.executeWithCheckedArguments(frame, receiver, arguments);
+                }
+            }
+
+            // TIER 2: Wide Execution (Class Polymorphism)
+            if (cache.wideEntries.length > 0) {
+                final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
+                final Object lookupResult = getContext().lookup(receiverClass, selector);
+
+                if (lookupResult instanceof CompiledCodeObject targetMethod) {
+                    for (final DispatchEntry<DispatchDirectNaryNode> entry : cache.wideEntries) {
+                        if (entry.isWideCacheHit(targetMethod)) {
+                            return entry.executor.executeWithCheckedArguments(frame, receiver, arguments);
+                        }
+                    }
+                }
+            }
+
+            // Cache Miss: Delegate to Manager for Specialization
+            CompilerDirectives.transferToInterpreterAndInvalidate();
+            return executeAndSpecialize(frame, receiver, arguments);
         }
 
-        @ReportPolymorphism.Megamorphic
-        @Specialization(replaces = "doDirect")
-        @HostCompilerDirectives.InliningCutoff
-        @SuppressWarnings("truffle-static-method")
-        protected final Object doIndirect(final VirtualFrame frame, final Object receiver, final Object[] arguments,
-                        @Cached final DispatchIndirectNaryNode dispatchNode) {
-            return dispatchNode.execute(frame, true, selector, receiver, arguments);
+        private Object executeAndSpecialize(final VirtualFrame frame, final Object receiver, final Object[] arguments) {
+            /*
+             * Guard against lagging recursive frames. If multiple frames of this method are on the
+             * stack executing compiled code, a deeper frame may have already deoptimized and
+             * transitioned this node to the indirect tier. This intercepts older deoptimized frames
+             * to prevent redundant specialization.
+             */
+            if (indirectNode != null) {
+                return indirectNode.execute(frame, true, selector, receiver, arguments);
+            }
+
+            final ClassObject receiverClass = cache.classNode.executeLookup(cache, receiver);
+            final Object lookupResult = getContext().lookup(receiverClass, selector);
+
+            // Node creation handles method resolution, including DNU and OAM fallbacks.
+            final DispatchDirectNaryNode newDirectNode = DispatchDirectNaryNode.create(selector, receiverClass, arguments.length);
+            final DispatchDirectNaryNode executor = cache.specialize(receiver, lookupResult, newDirectNode);
+
+            if (executor != null) {
+                return executor.executeWithCheckedArguments(frame, receiver, arguments);
+            } else {
+                this.reportPolymorphicSpecialize();
+                indirectNode = insert(DispatchIndirectNaryNodeGen.create());
+                return indirectNode.execute(frame, true, selector, receiver, arguments);
+            }
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
@@ -23,6 +23,7 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.DirectCallNode;
+import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.IndirectCallNode;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.InlinedBranchProfile;
@@ -58,7 +59,6 @@ import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive7;
 import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive8;
 import de.hpi.swa.trufflesqueak.nodes.primitives.Primitive.Primitive9;
 import de.hpi.swa.trufflesqueak.nodes.primitives.PrimitiveNodeFactory;
-import de.hpi.swa.trufflesqueak.util.ArrayUtils;
 import de.hpi.swa.trufflesqueak.util.FrameAccess;
 import de.hpi.swa.trufflesqueak.util.MiscUtils;
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchSelectorNaryNode.java
@@ -151,9 +151,8 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
             }
 
             // Node creation handles method resolution, including DNU and OAM fallbacks.
-            final DispatchDirectNaryNode newDirectNode = DispatchDirectNaryNode.create(selector, receiverClass, arguments.length);
-
-            final DispatchDirectNaryNode executor = cache.specialize(receiver, lookupResult, newDirectNode);
+            final DispatchDirectNaryNode executor = cache.specialize(receiver, receiverClass, lookupResult,
+                            () -> DispatchDirectNaryNode.create(selector, receiverClass, arguments.length));
 
             if (executor != null) {
                 return executor.execute(frame, receiver, arguments);
@@ -245,8 +244,8 @@ public final class DispatchSelectorNaryNode extends AbstractDispatchSelectorNode
             }
 
             // Node creation handles method resolution, including DNU and OAM fallbacks.
-            final DispatchDirectNaryNode newDirectNode = DispatchDirectNaryNode.create(selector, receiverClass, arguments.length);
-            final DispatchDirectNaryNode executor = cache.specialize(receiver, lookupResult, newDirectNode);
+            final DispatchDirectNaryNode executor = cache.specialize(receiver, receiverClass, lookupResult,
+                            () -> DispatchDirectNaryNode.create(selector, receiverClass, arguments.length));
 
             if (executor != null) {
                 return executor.executeWithCheckedArguments(frame, receiver, arguments);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchUtils.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchUtils.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 
 import com.oracle.truffle.api.Assumption;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.NodeInterface;
 
@@ -17,6 +18,8 @@ import de.hpi.swa.trufflesqueak.exceptions.PrimitiveFailed;
 import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
 import de.hpi.swa.trufflesqueak.model.ClassObject;
 import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
+import de.hpi.swa.trufflesqueak.model.NativeObject;
+import de.hpi.swa.trufflesqueak.model.PointersObject;
 import de.hpi.swa.trufflesqueak.nodes.primitives.AbstractPrimitiveNode;
 import de.hpi.swa.trufflesqueak.nodes.primitives.PrimitiveNodeFactory;
 import de.hpi.swa.trufflesqueak.util.LogUtils;
@@ -63,6 +66,38 @@ public final class DispatchUtils {
             // be avoided.
             return list.toArray(new Assumption[0]);
         }
+    }
+
+    /**
+     * Creates the complete assumption array for a message fallback node (DNU or CI). On top of the
+     * standard class hierarchy stability, it registers two assumptions:
+     *
+     * Fallback Method Stability: Tracks the `callTargetStable` of the resolved fallback method
+     * itself. This ensures the AST node is invalidated if the actual #doesNotUnderstand: or
+     * #cannotInterpret: method is later modified or recompiled.
+     *
+     * Absent Selector Stability: Tracks an image-global assumption that the specific failing
+     * selector does not exist. If a method for this missing selector is compiled, the VM's cache
+     * flush (primitive 119) will trip this assumption globally. This prevents "stranded DNU" nodes
+     * by forcing them to drop and re-resolve to the newly added method.
+     */
+    static Assumption[] getAssumptionsForMessageFallback(final Assumption[] classAssumptions, final NativeObject selector, final CompiledCodeObject fallbackMethod) {
+        final Assumption[] finalAssumptions = new Assumption[classAssumptions.length + 2];
+        System.arraycopy(classAssumptions, 0, finalAssumptions, 0, classAssumptions.length);
+        finalAssumptions[classAssumptions.length] = fallbackMethod.getCallTargetStable();
+        finalAssumptions[classAssumptions.length + 1] = SqueakImageContext.getSlow().getAbsentSelectorAssumption(selector);
+        return finalAssumptions;
+    }
+
+    @ExplodeLoop
+    static PointersObject buildNestedMessage(final CreateMessageNode createMessageNode,
+                    final NativeObject originalSelector, final NativeObject cannotInterpretSelector,
+                    final Object receiver, final Object[] arguments, final int fallbackDepth) {
+        PointersObject message = createMessageNode.execute(originalSelector, receiver, arguments);
+        for (int i = 1; i < fallbackDepth; i++) {
+            message = createMessageNode.execute(cannotInterpretSelector, receiver, new Object[]{message});
+        }
+        return message;
     }
 
     static void logMissingPrimitive(final AbstractPrimitiveNode primitiveNode, final CompiledCodeObject code) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchUtils.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchUtils.java
@@ -71,11 +71,11 @@ public final class DispatchUtils {
     /**
      * Creates the complete assumption array for a message fallback node (DNU or CI). On top of the
      * standard class hierarchy stability, it registers two assumptions:
-     *
+     * <p>
      * Fallback Method Stability: Tracks the `callTargetStable` of the resolved fallback method
      * itself. This ensures the AST node is invalidated if the actual #doesNotUnderstand: or
      * #cannotInterpret: method is later modified or recompiled.
-     *
+     * <p>
      * Absent Selector Stability: Tracks an image-global assumption that the specific failing
      * selector does not exist. If a method for this missing selector is compiled, the VM's cache
      * flush (primitive 119) will trip this assumption globally. This prevents "stranded DNU" nodes

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchUtils.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchUtils.java
@@ -6,8 +6,6 @@
  */
 package de.hpi.swa.trufflesqueak.nodes.dispatch;
 
-import java.util.ArrayList;
-
 import com.oracle.truffle.api.Assumption;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
@@ -48,23 +46,34 @@ public final class DispatchUtils {
                 return new Assumption[]{startClass.getClassHierarchyAndMethodDictStable(), callTargetStable};
             }
         } else {
-            final ArrayList<Assumption> list = new ArrayList<>();
-            if (callTargetStable != null) {
-                list.add(callTargetStable);
-            }
+            // Count the required array size
+            int depth = (callTargetStable != null) ? 1 : 0;
             ClassObject currentClass = startClass;
             while (currentClass != null) {
-                list.add(currentClass.getClassHierarchyAndMethodDictStable());
+                depth++;
                 if (currentClass == targetClass) {
                     break;
-                } else {
-                    currentClass = currentClass.getSuperclassOrNull();
                 }
+                currentClass = currentClass.getSuperclassOrNull();
             }
-            // TODO: the receiverClass can be an outdated version of methodClass. In this case, a
-            // list of assumptions for the entire class hierarchy is returned. Maybe this can/should
-            // be avoided.
-            return list.toArray(new Assumption[0]);
+
+            // Allocate exactly sized array and populate
+            final Assumption[] assumptions = new Assumption[depth];
+            int index = 0;
+            if (callTargetStable != null) {
+                assumptions[index++] = callTargetStable;
+            }
+
+            currentClass = startClass;
+            while (currentClass != null) {
+                assumptions[index++] = currentClass.getClassHierarchyAndMethodDictStable();
+                if (currentClass == targetClass) {
+                    break;
+                }
+                currentClass = currentClass.getSuperclassOrNull();
+            }
+
+            return assumptions;
         }
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchValueWithArgNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/DispatchValueWithArgNode.java
@@ -70,11 +70,11 @@ public abstract class DispatchValueWithArgNode extends AbstractNode {
 
     @Fallback
     protected static final Object doSend(final VirtualFrame frame, final Object receiver, final Object arg1,
-                    @Cached("create(getValueWitArgSelector())") final DispatchSelector1Node.Dispatch1Node genericDispatchNode) {
+                    @Cached("create(getValueWithArgSelector())") final DispatchSelector1Node.Dispatch1Node genericDispatchNode) {
         return genericDispatchNode.execute(frame, receiver, arg1);
     }
 
-    protected static final NativeObject getValueWitArgSelector() {
+    protected static final NativeObject getValueWithArgSelector() {
         return SqueakImageContext.getSlow().getSpecialSelector(SPECIAL_SELECTOR.VALUE_WITH_ARG);
     }
 }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/LookupClassGuard.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/LookupClassGuard.java
@@ -32,28 +32,61 @@ public abstract class LookupClassGuard {
 
     protected abstract ClassObject getSqueakClassInternal(Node node);
 
+    /**
+     * Creates a specialized guard for the given receiver.
+     * <p>
+     * Note: The order of the if-else chain is strictly optimized for interpreter
+     * warmup performance using Smith's Rule (Probability / Cost). Because these
+     * checks evaluate sequentially during guard creation, we rank them by their
+     * expected CPU yield rather than pure statistical frequency.
+     * <p>
+     * Empirical data collected across standard Squeak and Cuis test suites
+     * (N = 683,434 creation calls) shows that while constants like NilObject
+     * are rare, their ultra-cheap reference equality checks (cost ~1) push
+     * them higher in the optimal evaluation sequence than slightly more
+     * frequent, but heavier, instanceof checks (cost ~5).
+     *
+     * <pre>
+     * | Receiver Type                        |      Count | Frequency | Cost |  Yield |
+     * |--------------------------------------|------------|-----------|------|--------|
+     * | AbstractSqueakObjectWithClassAndHash |    627,928 |    91.88% |    5 | 18.38% |
+     * | Long (SmallInteger)                  |     26,126 |     3.82% |    5 |  0.76% |
+     * | NilObject                            |      2,894 |     0.42% |    1 |  0.42% |
+     * | Double                               |     10,934 |     1.60% |    5 |  0.32% |
+     * | Boolean.FALSE                        |      1,856 |     0.27% |    1 |  0.27% |
+     * | Boolean.TRUE                         |      1,802 |     0.26% |    1 |  0.26% |
+     * | BlockClosureObject                   |      3,394 |     0.50% |    5 |  0.10% |
+     * | Character / CharacterObject          |      3,054 |     0.45% |    5 |  0.09% |
+     * | ContextObject                        |      2,675 |     0.39% |    5 |  0.08% |
+     * | FloatObject                          |      2,587 |     0.38% |    5 |  0.08% |
+     * | ForeignObject                        |        184 |     0.03% |    5 |  0.01% |
+     * </pre>
+     *
+     * @param receiver The object requiring a class guard
+     * @return A specialized LookupClassGuard instance
+     */
     @NeverDefault
     public static LookupClassGuard create(final Object receiver) {
-        if (receiver == NilObject.SINGLETON) {
-            return NilGuard.SINGLETON;
-        } else if (receiver == Boolean.TRUE) {
-            return TrueGuard.SINGLETON;
-        } else if (receiver == Boolean.FALSE) {
-            return FalseGuard.SINGLETON;
+        if (receiver instanceof final AbstractSqueakObjectWithClassAndHash o) {
+            return new AbstractSqueakObjectWithClassAndHashGuard((AbstractSqueakObjectWithClassAndHash) o.resolveForwardingPointer());
         } else if (receiver instanceof Long) {
             return SmallIntegerGuard.SINGLETON;
-        } else if (receiver instanceof Character || receiver instanceof CharacterObject) {
-            return CharacterGuard.SINGLETON;
+        } else if (receiver == NilObject.SINGLETON) {
+            return NilGuard.SINGLETON;
         } else if (receiver instanceof Double) {
             return DoubleGuard.SINGLETON;
-        } else if (receiver instanceof ContextObject) {
-            return ContextObjectGuard.SINGLETON;
+        } else if (receiver == Boolean.FALSE) {
+            return FalseGuard.SINGLETON;
+        } else if (receiver == Boolean.TRUE) {
+            return TrueGuard.SINGLETON;
         } else if (receiver instanceof final BlockClosureObject closure) {
             return closure.isABlockClosure() ? BlockClosureGuard.SINGLETON : FullBlockClosureGuard.SINGLETON;
+        } else if (receiver instanceof Character || receiver instanceof CharacterObject) {
+            return CharacterGuard.SINGLETON;
+        } else if (receiver instanceof ContextObject) {
+            return ContextObjectGuard.SINGLETON;
         } else if (receiver instanceof FloatObject) {
             return FloatObjectGuard.SINGLETON;
-        } else if (receiver instanceof final AbstractSqueakObjectWithClassAndHash o) {
-            return new AbstractSqueakObjectWithClassAndHashGuard((AbstractSqueakObjectWithClassAndHash) o.resolveForwardingPointer());
         } else {
             assert !(receiver instanceof AbstractSqueakObject);
             return ForeignObjectGuard.SINGLETON;

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/ResolveMethodNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/dispatch/ResolveMethodNode.java
@@ -48,12 +48,15 @@ public abstract class ResolveMethodNode extends AbstractNode {
 
     @SuppressWarnings("unused")
     @Specialization(guards = "lookupResult == null")
-    protected static final CompiledCodeObject doDispatchFailure(final SqueakImageContext image, final int expectedNumArgs, final boolean canPrimFail, final NativeObject selector,
+    protected static final CompiledCodeObject doDispatchFailure(final SqueakImageContext image, final int expectedNumArgs, final boolean canPrimFail,
+                    final NativeObject selector,
                     final ClassObject receiverClass,
                     final Object lookupResult) {
         final MethodCacheEntry cacheEntry = image.findMethodCacheEntry(receiverClass, selector);
-        final CompiledCodeObject fallbackMethod = cacheEntry.getOrCreateFallbackMethod();
-        assert fallbackMethod.getNumArgs() == 1 : "Fallback method with unexpected number of arguments, got " + fallbackMethod.getNumArgs();
+        final ClassObject.DispatchFailureResult result = cacheEntry.getOrCreateDispatchFailureResult(expectedNumArgs);
+        final CompiledCodeObject fallbackMethod = result.fallbackMethod();
+        assert fallbackMethod.getNumArgs() == 1 || (result.convention() == ClassObject.FallbackConvention.SHORTCUT_DNU &&
+                        fallbackMethod.getNumArgs() == expectedNumArgs + 1) : "Fallback method with unexpected number of arguments";
         return fallbackMethod;
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractInterpreterNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractInterpreterNode.java
@@ -182,7 +182,7 @@ public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrum
         return new BlockClosureObject(true, block, block.getShadowBlockNumArgs(), copiedValues, FrameAccess.getReceiver(frame), outerContext);
     }
 
-    protected static final AbstractDispatchNode createDispatchNode(final int numArgs, final NativeObject selector) {
+    protected static final AbstractDispatchNode<?> createDispatchNode(final int numArgs, final NativeObject selector) {
         return switch (numArgs) {
             case 0 -> Dispatch0Node.create(selector);
             case 1 -> Dispatch1Node.create(selector);

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractInterpreterNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/AbstractInterpreterNode.java
@@ -40,6 +40,7 @@ import de.hpi.swa.trufflesqueak.model.BlockClosureObject;
 import de.hpi.swa.trufflesqueak.model.ClassObject;
 import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
 import de.hpi.swa.trufflesqueak.model.ContextObject;
+import de.hpi.swa.trufflesqueak.model.NativeObject;
 import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.ASSOCIATION;
 import de.hpi.swa.trufflesqueak.model.layout.ObjectLayouts.PROCESS;
 import de.hpi.swa.trufflesqueak.nodes.AbstractNode;
@@ -47,10 +48,13 @@ import de.hpi.swa.trufflesqueak.nodes.accessing.AbstractPointersObjectNodes.Abst
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectAt0NodeGen;
 import de.hpi.swa.trufflesqueak.nodes.context.GetOrCreateContextWithFrameNode;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.AbstractDispatchNode;
-import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector0NodeFactory.Dispatch0NodeGen;
-import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector1NodeFactory.Dispatch1NodeGen;
-import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector2NodeFactory.Dispatch2NodeGen;
-import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNodeFactory.DispatchNaryNodeGen;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector0Node.Dispatch0Node;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector1Node.Dispatch1Node;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector2Node.Dispatch2Node;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector3Node.Dispatch3Node;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector4Node.Dispatch4Node;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector5Node.Dispatch5Node;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNode.DispatchNaryNode;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchValueNodeGen;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchValueWithArgNodeGen;
 import de.hpi.swa.trufflesqueak.nodes.interrupts.CheckForInterruptsNode.CheckForInterruptsInLoopNode;
@@ -178,52 +182,81 @@ public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrum
         return new BlockClosureObject(true, block, block.getShadowBlockNumArgs(), copiedValues, FrameAccess.getReceiver(frame), outerContext);
     }
 
-    protected final Object send(final VirtualFrame frame, final int currentPC, final Object receiver) {
-        return followForwarded(currentPC, dispatch(frame, currentPC, receiver));
+    protected static final AbstractDispatchNode createDispatchNode(final int numArgs, final NativeObject selector) {
+        return switch (numArgs) {
+            case 0 -> Dispatch0Node.create(selector);
+            case 1 -> Dispatch1Node.create(selector);
+            case 2 -> Dispatch2Node.create(selector);
+            case 3 -> Dispatch3Node.create(selector);
+            case 4 -> Dispatch4Node.create(selector);
+            case 5 -> Dispatch5Node.create(selector);
+            default -> DispatchNaryNode.create(selector);
+        };
     }
 
-    private Object dispatch(final VirtualFrame frame, final int currentPC, final Object receiver) {
+    protected final Object send(final VirtualFrame frame, final int currentPC, final Object receiver) {
+        return followForwarded(currentPC, dispatchHandled(frame, currentPC, receiver));
+    }
+
+    private Object dispatchHandled(final VirtualFrame frame, final int currentPC, final Object receiver) {
         try {
-            return ACCESS.uncheckedCast(getData(currentPC), Dispatch0NodeGen.class).execute(frame, receiver);
+            return dispatch(frame, currentPC, receiver);
         } catch (final AbstractStandardSendReturn r) {
             return handleReturnException(frame, currentPC, r);
         }
+    }
+
+    protected final Object dispatch(final VirtualFrame frame, final int currentPC, final Object receiver) {
+        return ACCESS.uncheckedCast(getData(currentPC), Dispatch0Node.class).execute(frame, receiver);
     }
 
     protected final Object send(final VirtualFrame frame, final int currentPC, final Object receiver, final Object arg) {
-        return followForwarded(currentPC, dispatch(frame, currentPC, receiver, arg));
+        return followForwarded(currentPC, dispatchHandled(frame, currentPC, receiver, arg));
     }
 
-    private Object dispatch(final VirtualFrame frame, final int currentPC, final Object receiver, final Object arg) {
+    private Object dispatchHandled(final VirtualFrame frame, final int currentPC, final Object receiver, final Object arg) {
         try {
-            return ACCESS.uncheckedCast(getData(currentPC), Dispatch1NodeGen.class).execute(frame, receiver, arg);
+            return dispatch(frame, currentPC, receiver, arg);
         } catch (final AbstractStandardSendReturn r) {
             return handleReturnException(frame, currentPC, r);
         }
+    }
+
+    protected final Object dispatch(final VirtualFrame frame, final int currentPC, final Object receiver, final Object arg) {
+        return ACCESS.uncheckedCast(getData(currentPC), Dispatch1Node.class).execute(frame, receiver, arg);
     }
 
     protected final Object send(final VirtualFrame frame, final int currentPC, final Object receiver, final Object arg1, final Object arg2) {
-        return followForwarded(currentPC, dispatch(frame, currentPC, receiver, arg1, arg2));
+        return followForwarded(currentPC, dispatchHandled(frame, currentPC, receiver, arg1, arg2));
     }
 
-    private Object dispatch(final VirtualFrame frame, final int currentPC, final Object receiver, final Object arg1, final Object arg2) {
+    private Object dispatchHandled(final VirtualFrame frame, final int currentPC, final Object receiver, final Object arg1, final Object arg2) {
         try {
-            return ACCESS.uncheckedCast(getData(currentPC), Dispatch2NodeGen.class).execute(frame, receiver, arg1, arg2);
+            return dispatch(frame, currentPC, receiver, arg1, arg2);
         } catch (final AbstractStandardSendReturn r) {
             return handleReturnException(frame, currentPC, r);
         }
     }
 
-    protected final Object sendNary(final VirtualFrame frame, final int currentPC, final Object receiver, final Object[] arguments) {
-        return followForwarded(currentPC, dispatchNary(frame, currentPC, receiver, arguments));
+    protected final Object dispatch(final VirtualFrame frame, final int currentPC, final Object receiver, final Object arg1, final Object arg2) {
+        return ACCESS.uncheckedCast(getData(currentPC), Dispatch2Node.class).execute(frame, receiver, arg1, arg2);
     }
 
-    private Object dispatchNary(final VirtualFrame frame, final int currentPC, final Object receiver, final Object[] arguments) {
-        try {
-            return ACCESS.uncheckedCast(getData(currentPC), DispatchNaryNodeGen.class).execute(frame, receiver, arguments);
-        } catch (final AbstractStandardSendReturn r) {
-            return handleReturnException(frame, currentPC, r);
-        }
+    protected final Object dispatch(final VirtualFrame frame, final int currentPC, final Object receiver, final Object arg1, final Object arg2, final Object arg3) {
+        return ACCESS.uncheckedCast(getData(currentPC), Dispatch3Node.class).execute(frame, receiver, arg1, arg2, arg3);
+    }
+
+    protected final Object dispatch(final VirtualFrame frame, final int currentPC, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4) {
+        return ACCESS.uncheckedCast(getData(currentPC), Dispatch4Node.class).execute(frame, receiver, arg1, arg2, arg3, arg4);
+    }
+
+    protected final Object dispatch(final VirtualFrame frame, final int currentPC, final Object receiver, final Object arg1, final Object arg2, final Object arg3, final Object arg4,
+                    final Object arg5) {
+        return ACCESS.uncheckedCast(getData(currentPC), Dispatch5Node.class).execute(frame, receiver, arg1, arg2, arg3, arg4, arg5);
+    }
+
+    protected final Object dispatchNary(final VirtualFrame frame, final int currentPC, final Object receiver, final Object[] arguments) {
+        return ACCESS.uncheckedCast(getData(currentPC), DispatchNaryNode.class).execute(frame, receiver, arguments);
     }
 
     protected final Object sendValue(final VirtualFrame frame, final int currentPC, final Object receiver) {
@@ -396,9 +429,9 @@ public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrum
                 FrameAccess.externalizePCAndSP(frame, pc, sp);
                 if (getData(currentPC) == null) {
                     CompilerDirectives.transferToInterpreterAndInvalidate();
-                    setData(currentPC, insert(Dispatch2NodeGen.create(getContext().aboutToReturnSelector)));
+                    setData(currentPC, insert(Dispatch2Node.create(getContext().aboutToReturnSelector)));
                 }
-                ((Dispatch2NodeGen) getData(currentPC)).execute(frame, getOrCreateContext(frame, currentPC), result, firstMarkedContext);
+                ((Dispatch2Node) getData(currentPC)).execute(frame, getOrCreateContext(frame, currentPC), result, firstMarkedContext);
             }
         }
         throw cannotReturn(frame, pc, sp, result);
@@ -459,7 +492,7 @@ public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrum
     /*
      * Handling of forwarding pointers
      */
-    private Object followForwarded(final int currentPC, final Object value) {
+    protected final Object followForwarded(final int currentPC, final Object value) {
         final byte profile = getProfile(currentPC);
         if (value instanceof final AbstractSqueakObjectWithClassAndHash object) {
             enter(currentPC, profile, BRANCH6);
@@ -546,7 +579,8 @@ public abstract class AbstractInterpreterNode extends AbstractInterpreterInstrum
             if (data[i] instanceof AbstractDispatchNode) {
                 final int bytecode = getUnsignedInt(bc, i);
                 if (isFastPathedMessageSend(bytecode)) {
-                    // The interpreter could handle this directly and might not check for interrupts.
+                    // The interpreter could handle this directly and might not check for
+                    // interrupts.
                     continue;
                 }
                 return null;

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterSistaV1Node.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterSistaV1Node.java
@@ -48,11 +48,10 @@ import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectAtPut0Node;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectAtPut0NodeGen;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectClassNodeGen;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectIdentityNodeGen;
-import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector0NodeFactory.Dispatch0NodeGen;
-import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector1NodeFactory.Dispatch1NodeGen;
-import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector2NodeFactory.Dispatch2NodeGen;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector0Node.Dispatch0Node;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector1Node.Dispatch1Node;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector2Node.Dispatch2Node;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNodeFactory.DispatchDirectedSuperNaryNodeGen;
-import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNodeFactory.DispatchNaryNodeGen;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNodeFactory.DispatchSuperNaryNodeGen;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchValueNodeGen;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchValueWithArgNodeGen;
@@ -227,7 +226,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                     vstate.resetExtAB();
                     break;
                 case BC.BYTECODE_PRIM_SIZE, BC.BYTECODE_PRIM_NEXT, BC.BYTECODE_PRIM_AT_END, BC.BYTECODE_PRIM_NEW, BC.BYTECODE_PRIM_POINT_X, BC.BYTECODE_PRIM_POINT_Y: {
-                    setData(currentPC, insert(Dispatch0NodeGen.create(image.getSpecialSelector(b - BC.BYTECODE_PRIM_ADD))));
+                    setData(currentPC, insert(Dispatch0Node.create(image.getSpecialSelector(b - BC.BYTECODE_PRIM_ADD))));
                     break;
                 }
                 case BC.BYTECODE_PRIM_CLASS: {
@@ -241,7 +240,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                 case BC.BYTECODE_PRIM_ADD, BC.BYTECODE_PRIM_SUBTRACT, BC.BYTECODE_PRIM_LESS_THAN, BC.BYTECODE_PRIM_GREATER_THAN, BC.BYTECODE_PRIM_LESS_OR_EQUAL, BC.BYTECODE_PRIM_GREATER_OR_EQUAL, //
                     BC.BYTECODE_PRIM_EQUAL, BC.BYTECODE_PRIM_NOT_EQUAL, BC.BYTECODE_PRIM_MULTIPLY, BC.BYTECODE_PRIM_DIVIDE, BC.BYTECODE_PRIM_MOD, BC.BYTECODE_PRIM_MAKE_POINT, BC.BYTECODE_PRIM_BIT_SHIFT, BC.BYTECODE_PRIM_DIV, //
                     BC.BYTECODE_PRIM_BIT_AND, BC.BYTECODE_PRIM_BIT_OR, BC.BYTECODE_PRIM_AT, BC.BYTECODE_PRIM_NEXT_PUT, BC.BYTECODE_PRIM_DO, BC.BYTECODE_PRIM_NEW_WITH_ARG: {
-                    setData(currentPC, insert(Dispatch1NodeGen.create(image.getSpecialSelector(b - BC.BYTECODE_PRIM_ADD))));
+                    setData(currentPC, insert(Dispatch1Node.create(image.getSpecialSelector(b - BC.BYTECODE_PRIM_ADD))));
                     break;
                 }
                 case BC.BYTECODE_PRIM_IDENTICAL, BC.BYTECODE_PRIM_NOT_IDENTICAL: {
@@ -253,25 +252,25 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                     break;
                 }
                 case BC.BYTECODE_PRIM_AT_PUT: {
-                    setData(currentPC, insert(Dispatch2NodeGen.create(image.getSpecialSelector(b - BC.BYTECODE_PRIM_ADD))));
+                    setData(currentPC, insert(Dispatch2Node.create(image.getSpecialSelector(b - BC.BYTECODE_PRIM_ADD))));
                     break;
                 }
                 case BC.SEND_LIT_SEL0_0, BC.SEND_LIT_SEL0_1, BC.SEND_LIT_SEL0_2, BC.SEND_LIT_SEL0_3, BC.SEND_LIT_SEL0_4, BC.SEND_LIT_SEL0_5, BC.SEND_LIT_SEL0_6, BC.SEND_LIT_SEL0_7, //
                     BC.SEND_LIT_SEL0_8, BC.SEND_LIT_SEL0_9, BC.SEND_LIT_SEL0_A, BC.SEND_LIT_SEL0_B, BC.SEND_LIT_SEL0_C, BC.SEND_LIT_SEL0_D, BC.SEND_LIT_SEL0_E, BC.SEND_LIT_SEL0_F: {
                     final NativeObject selector = (NativeObject) code.getAndResolveLiteral(b & 0xF);
-                    setData(currentPC, insert(Dispatch0NodeGen.create(selector)));
+                    setData(currentPC, insert(Dispatch0Node.create(selector)));
                     break;
                 }
                 case BC.SEND_LIT_SEL1_0, BC.SEND_LIT_SEL1_1, BC.SEND_LIT_SEL1_2, BC.SEND_LIT_SEL1_3, BC.SEND_LIT_SEL1_4, BC.SEND_LIT_SEL1_5, BC.SEND_LIT_SEL1_6, BC.SEND_LIT_SEL1_7, //
                     BC.SEND_LIT_SEL1_8, BC.SEND_LIT_SEL1_9, BC.SEND_LIT_SEL1_A, BC.SEND_LIT_SEL1_B, BC.SEND_LIT_SEL1_C, BC.SEND_LIT_SEL1_D, BC.SEND_LIT_SEL1_E, BC.SEND_LIT_SEL1_F: {
                     final NativeObject selector = (NativeObject) code.getAndResolveLiteral(b & 0xF);
-                    setData(currentPC, insert(Dispatch1NodeGen.create(selector)));
+                    setData(currentPC, insert(Dispatch1Node.create(selector)));
                     break;
                 }
                 case BC.SEND_LIT_SEL2_0, BC.SEND_LIT_SEL2_1, BC.SEND_LIT_SEL2_2, BC.SEND_LIT_SEL2_3, BC.SEND_LIT_SEL2_4, BC.SEND_LIT_SEL2_5, BC.SEND_LIT_SEL2_6, BC.SEND_LIT_SEL2_7, //
                     BC.SEND_LIT_SEL2_8, BC.SEND_LIT_SEL2_9, BC.SEND_LIT_SEL2_A, BC.SEND_LIT_SEL2_B, BC.SEND_LIT_SEL2_C, BC.SEND_LIT_SEL2_D, BC.SEND_LIT_SEL2_E, BC.SEND_LIT_SEL2_F: {
                     final NativeObject selector = (NativeObject) code.getAndResolveLiteral(b & 0xF);
-                    setData(currentPC, insert(Dispatch2NodeGen.create(selector)));
+                    setData(currentPC, insert(Dispatch2Node.create(selector)));
                     break;
                 }
                 case BC.SHORT_UJUMP_0, BC.SHORT_UJUMP_1, BC.SHORT_UJUMP_2, BC.SHORT_UJUMP_3, BC.SHORT_UJUMP_4, BC.SHORT_UJUMP_5, BC.SHORT_UJUMP_6, BC.SHORT_UJUMP_7: {
@@ -314,7 +313,7 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                     vstate.resetExtAB();
                     break;
                 }
-                case BC.EXT_PUSH_LITERAL, BC.EXT_PUSH_CHARACTER: {
+                case BC.EXT_PUSH_LITERAL, BC.EXT_PUSH_INTEGER, BC.EXT_PUSH_CHARACTER: {
                     pc++;
                     vstate.resetExtAB();
                     break;
@@ -323,16 +322,12 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
                     pc++;
                     break;
                 }
-                case BC.EXT_PUSH_INTEGER: {
-                    pc++;
-                    vstate.resetExtAB();
-                    break;
-                }
                 case BC.EXT_SEND: {
                     final int byte1 = getUnsignedInt(bc, pc++);
                     final int literalIndex = (byte1 >> 3) + (vstate.getExtA() << 5);
                     final NativeObject selector = (NativeObject) code.getAndResolveLiteral(literalIndex);
-                    setData(currentPC, insert(DispatchNaryNodeGen.create(selector)));
+                    final int numArgs = (byte1 & 7) + (vstate.getExtB() << 3);
+                    setData(currentPC, insert(createDispatchNode(numArgs, selector)));
                     vstate.resetExtAB();
                     break;
                 }
@@ -2518,11 +2513,60 @@ public final class InterpreterSistaV1Node extends AbstractInterpreterNode {
         final int byte1 = getUnsignedInt(state.bytecode, pc + 1);
         final int numArgs = (byte1 & 7) + (vstate.getExtB() << 3);
         CompilerAsserts.partialEvaluationConstant(numArgs);
-        final Object[] arguments = popN(frame, vstate.sp, numArgs);
-        vstate.sp -= numArgs;
-        final Object receiver = pop(frame, --vstate.sp);
-        FrameAccess.externalizePCAndSP(frame, nextPC, vstate.sp);
-        push(frame, vstate.sp++, sendNary(frame, pc, receiver, arguments));
+        FrameAccess.externalizePCAndSP(frame, nextPC, vstate.sp - 1 - numArgs);
+        Object result;
+        try {
+            result = switch (numArgs) {
+                case 0 -> {
+                    final Object receiver = pop(frame, --vstate.sp);
+                    yield dispatch(frame, pc, receiver);
+                }
+                case 1 -> {
+                    final Object arg1 = pop(frame, --vstate.sp);
+                    final Object receiver = pop(frame, --vstate.sp);
+                    yield dispatch(frame, pc, receiver, arg1);
+                }
+                case 2 -> {
+                    final Object arg2 = pop(frame, --vstate.sp);
+                    final Object arg1 = pop(frame, --vstate.sp);
+                    final Object receiver = pop(frame, --vstate.sp);
+                    yield dispatch(frame, pc, receiver, arg1, arg2);
+                }
+                case 3 -> {
+                    final Object arg3 = pop(frame, --vstate.sp);
+                    final Object arg2 = pop(frame, --vstate.sp);
+                    final Object arg1 = pop(frame, --vstate.sp);
+                    final Object receiver = pop(frame, --vstate.sp);
+                    yield dispatch(frame, pc, receiver, arg1, arg2, arg3);
+                }
+                case 4 -> {
+                    final Object arg4 = pop(frame, --vstate.sp);
+                    final Object arg3 = pop(frame, --vstate.sp);
+                    final Object arg2 = pop(frame, --vstate.sp);
+                    final Object arg1 = pop(frame, --vstate.sp);
+                    final Object receiver = pop(frame, --vstate.sp);
+                    yield dispatch(frame, pc, receiver, arg1, arg2, arg3, arg4);
+                }
+                case 5 -> {
+                    final Object arg5 = pop(frame, --vstate.sp);
+                    final Object arg4 = pop(frame, --vstate.sp);
+                    final Object arg3 = pop(frame, --vstate.sp);
+                    final Object arg2 = pop(frame, --vstate.sp);
+                    final Object arg1 = pop(frame, --vstate.sp);
+                    final Object receiver = pop(frame, --vstate.sp);
+                    yield dispatch(frame, pc, receiver, arg1, arg2, arg3, arg4, arg5);
+                }
+                default -> {
+                    final Object[] arguments = popN(frame, vstate.sp, numArgs);
+                    vstate.sp -= numArgs;
+                    final Object receiver = pop(frame, --vstate.sp);
+                    yield dispatchNary(frame, pc, receiver, arguments);
+                }
+            };
+        } catch (final AbstractStandardSendReturn r) {
+            result = handleReturnException(frame, pc, r);
+        }
+        push(frame, vstate.sp++, followForwarded(pc, result));
         vstate.resetExtAB();
         return nextPC;
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterV3PlusClosuresNode.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/interpreter/InterpreterV3PlusClosuresNode.java
@@ -33,10 +33,9 @@ import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectAtPut0Node;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectAtPut0NodeGen;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectClassNodeGen;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectIdentityNodeGen;
-import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector0NodeFactory.Dispatch0NodeGen;
-import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector1NodeFactory.Dispatch1NodeGen;
-import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector2NodeFactory.Dispatch2NodeGen;
-import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNodeFactory.DispatchNaryNodeGen;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector0Node.Dispatch0Node;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector1Node.Dispatch1Node;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector2Node.Dispatch2Node;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNodeFactory.DispatchSuperNaryNodeGen;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchValueNodeGen;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchValueWithArgNodeGen;
@@ -158,8 +157,9 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                     break;
                 }
                 case BC.SINGLE_EXTENDED_SEND: {
+                    final int numArgs = getUnsignedInt(bc, pc) >> 5;
                     final NativeObject selector = (NativeObject) code.getLiteral(getByte(bc, pc++) & 0x1F);
-                    setData(currentPC, insert(DispatchNaryNodeGen.create(selector)));
+                    setData(currentPC, insert(createDispatchNode(numArgs, selector)));
                     break;
                 }
                 case BC.DOUBLE_EXTENDED_DO_ANYTHING: {
@@ -167,8 +167,9 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                     final int byte3 = getUnsignedInt(bc, pc++);
                     switch (byte2 >> 5) {
                         case 0: {
+                            final int numArgs = byte2 & 0x1F;
                             final NativeObject selector = (NativeObject) code.getLiteral(byte3);
-                            setData(currentPC, insert(DispatchNaryNodeGen.create(selector)));
+                            setData(currentPC, insert(createDispatchNode(numArgs, selector)));
                             break;
                         }
                         case 1: {
@@ -210,8 +211,9 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                     break;
                 }
                 case BC.SECOND_EXTENDED_SEND: {
+                    final int numArgs = getUnsignedInt(bc, pc) >> 6;
                     final NativeObject selector = (NativeObject) code.getLiteral(getByte(bc, pc++) & 0x3F);
-                    setData(currentPC, insert(DispatchNaryNodeGen.create(selector)));
+                    setData(currentPC, insert(createDispatchNode(numArgs, selector)));
                     break;
                 }
                 case BC.PUSH_NEW_ARRAY: {
@@ -267,7 +269,7 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                     break;
                 }
                 case BC.BYTECODE_PRIM_SIZE, BC.BYTECODE_PRIM_NEXT, BC.BYTECODE_PRIM_AT_END, BC.BYTECODE_PRIM_NEW, BC.BYTECODE_PRIM_POINT_X, BC.BYTECODE_PRIM_POINT_Y: {
-                    setData(currentPC, insert(Dispatch0NodeGen.create(image.getSpecialSelector(b - BC.BYTECODE_PRIM_ADD))));
+                    setData(currentPC, insert(Dispatch0Node.create(image.getSpecialSelector(b - BC.BYTECODE_PRIM_ADD))));
                     break;
                 }
                 case BC.BYTECODE_PRIM_CLASS: {
@@ -277,7 +279,7 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                 case BC.BYTECODE_PRIM_ADD, BC.BYTECODE_PRIM_SUBTRACT, BC.BYTECODE_PRIM_LESS_THAN, BC.BYTECODE_PRIM_GREATER_THAN, BC.BYTECODE_PRIM_LESS_OR_EQUAL, BC.BYTECODE_PRIM_GREATER_OR_EQUAL, //
                     BC.BYTECODE_PRIM_EQUAL, BC.BYTECODE_PRIM_NOT_EQUAL, BC.BYTECODE_PRIM_MULTIPLY, BC.BYTECODE_PRIM_DIVIDE, BC.BYTECODE_PRIM_MOD, BC.BYTECODE_PRIM_MAKE_POINT, BC.BYTECODE_PRIM_BIT_SHIFT, BC.BYTECODE_PRIM_DIV, //
                     BC.BYTECODE_PRIM_BIT_AND, BC.BYTECODE_PRIM_BIT_OR, BC.BYTECODE_PRIM_AT, BC.BYTECODE_PRIM_NEXT_PUT, BC.BYTECODE_PRIM_DO, BC.BYTECODE_PRIM_NEW_WITH_ARG: {
-                    setData(currentPC, insert(Dispatch1NodeGen.create(image.getSpecialSelector(b - BC.BYTECODE_PRIM_ADD))));
+                    setData(currentPC, insert(Dispatch1Node.create(image.getSpecialSelector(b - BC.BYTECODE_PRIM_ADD))));
                     break;
                 }
                 case BC.BYTECODE_PRIM_IDENTICAL, BC.BYTECODE_PRIM_NOT_IDENTICAL: {
@@ -293,25 +295,25 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                     break;
                 }
                 case BC.BYTECODE_PRIM_AT_PUT: {
-                    setData(currentPC, insert(Dispatch2NodeGen.create(image.getSpecialSelector(b - BC.BYTECODE_PRIM_ADD))));
+                    setData(currentPC, insert(Dispatch2Node.create(image.getSpecialSelector(b - BC.BYTECODE_PRIM_ADD))));
                     break;
                 }
                 case BC.SEND_LIT_SEL0_0, BC.SEND_LIT_SEL0_1, BC.SEND_LIT_SEL0_2, BC.SEND_LIT_SEL0_3, BC.SEND_LIT_SEL0_4, BC.SEND_LIT_SEL0_5, BC.SEND_LIT_SEL0_6, BC.SEND_LIT_SEL0_7, //
                     BC.SEND_LIT_SEL0_8, BC.SEND_LIT_SEL0_9, BC.SEND_LIT_SEL0_A, BC.SEND_LIT_SEL0_B, BC.SEND_LIT_SEL0_C, BC.SEND_LIT_SEL0_D, BC.SEND_LIT_SEL0_E, BC.SEND_LIT_SEL0_F: {
                     final NativeObject selector = (NativeObject) code.getAndResolveLiteral(b & 0xF);
-                    setData(currentPC, insert(Dispatch0NodeGen.create(selector)));
+                    setData(currentPC, insert(Dispatch0Node.create(selector)));
                     break;
                 }
                 case BC.SEND_LIT_SEL1_0, BC.SEND_LIT_SEL1_1, BC.SEND_LIT_SEL1_2, BC.SEND_LIT_SEL1_3, BC.SEND_LIT_SEL1_4, BC.SEND_LIT_SEL1_5, BC.SEND_LIT_SEL1_6, BC.SEND_LIT_SEL1_7, //
                     BC.SEND_LIT_SEL1_8, BC.SEND_LIT_SEL1_9, BC.SEND_LIT_SEL1_A, BC.SEND_LIT_SEL1_B, BC.SEND_LIT_SEL1_C, BC.SEND_LIT_SEL1_D, BC.SEND_LIT_SEL1_E, BC.SEND_LIT_SEL1_F: {
                     final NativeObject selector = (NativeObject) code.getAndResolveLiteral(b & 0xF);
-                    setData(currentPC, insert(Dispatch1NodeGen.create(selector)));
+                    setData(currentPC, insert(Dispatch1Node.create(selector)));
                     break;
                 }
                 case BC.SEND_LIT_SEL2_0, BC.SEND_LIT_SEL2_1, BC.SEND_LIT_SEL2_2, BC.SEND_LIT_SEL2_3, BC.SEND_LIT_SEL2_4, BC.SEND_LIT_SEL2_5, BC.SEND_LIT_SEL2_6, BC.SEND_LIT_SEL2_7, //
                     BC.SEND_LIT_SEL2_8, BC.SEND_LIT_SEL2_9, BC.SEND_LIT_SEL2_A, BC.SEND_LIT_SEL2_B, BC.SEND_LIT_SEL2_C, BC.SEND_LIT_SEL2_D, BC.SEND_LIT_SEL2_E, BC.SEND_LIT_SEL2_F: {
                     final NativeObject selector = (NativeObject) code.getAndResolveLiteral(b & 0xF);
-                    setData(currentPC, insert(Dispatch2NodeGen.create(selector)));
+                    setData(currentPC, insert(Dispatch2Node.create(selector)));
                     break;
                 }
                 default: {
@@ -529,11 +531,7 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                     }
                     case BC.SINGLE_EXTENDED_SEND: {
                         final int numArgs = getUnsignedInt(bc, pc++) >> 5;
-                        final Object[] arguments = popN(frame, sp, numArgs);
-                        sp -= numArgs;
-                        final Object receiver = pop(frame, --sp);
-                        FrameAccess.externalizePCAndSP(frame, pc, sp);
-                        push(frame, sp++, sendNary(frame, currentPC, receiver, arguments));
+                        sp = handleExtendedSend(frame, currentPC, pc, sp, numArgs);
                         break;
                     }
                     case BC.DOUBLE_EXTENDED_DO_ANYTHING: {
@@ -544,11 +542,7 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                         switch (opType) {
                             case 0: {
                                 final int numArgs = byte2 & 31;
-                                final Object[] arguments = popN(frame, sp, numArgs);
-                                sp -= numArgs;
-                                final Object receiver = pop(frame, --sp);
-                                FrameAccess.externalizePCAndSP(frame, pc, sp);
-                                push(frame, sp++, sendNary(frame, currentPC, receiver, arguments));
+                                sp = handleExtendedSend(frame, currentPC, pc, sp, numArgs);
                                 break;
                             }
                             case 1: {
@@ -601,11 +595,7 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
                     }
                     case BC.SECOND_EXTENDED_SEND: {
                         final int numArgs = getUnsignedInt(bc, pc++) >> 6;
-                        final Object[] arguments = popN(frame, sp, numArgs);
-                        sp -= numArgs;
-                        final Object receiver = pop(frame, --sp);
-                        FrameAccess.externalizePCAndSP(frame, pc, sp);
-                        push(frame, sp++, sendNary(frame, currentPC, receiver, arguments));
+                        sp = handleExtendedSend(frame, currentPC, pc, sp, numArgs);
                         break;
                     }
                     case BC.POP_STACK: {
@@ -1027,6 +1017,73 @@ public final class InterpreterV3PlusClosuresNode extends AbstractInterpreterNode
         } catch (final AbstractStandardSendReturn r) {
             return handleReturnException(frame, currentPC, r);
         }
+    }
+
+    @EarlyInline
+    private int handleExtendedSend(final VirtualFrame frame, final int currentPC, final int pc, final int initialSP, final int numArgs) {
+        int sp = initialSP;
+        CompilerAsserts.partialEvaluationConstant(numArgs);
+        Object result;
+        try {
+            result = switch (numArgs) {
+                case 0 -> {
+                    final Object receiver = pop(frame, --sp);
+                    FrameAccess.externalizePCAndSP(frame, pc, sp);
+                    yield dispatch(frame, currentPC, receiver);
+                }
+                case 1 -> {
+                    final Object arg1 = pop(frame, --sp);
+                    final Object receiver = pop(frame, --sp);
+                    FrameAccess.externalizePCAndSP(frame, pc, sp);
+                    yield dispatch(frame, currentPC, receiver, arg1);
+                }
+                case 2 -> {
+                    final Object arg2 = pop(frame, --sp);
+                    final Object arg1 = pop(frame, --sp);
+                    final Object receiver = pop(frame, --sp);
+                    FrameAccess.externalizePCAndSP(frame, pc, sp);
+                    yield dispatch(frame, currentPC, receiver, arg1, arg2);
+                }
+                case 3 -> {
+                    final Object arg3 = pop(frame, --sp);
+                    final Object arg2 = pop(frame, --sp);
+                    final Object arg1 = pop(frame, --sp);
+                    final Object receiver = pop(frame, --sp);
+                    FrameAccess.externalizePCAndSP(frame, pc, sp);
+                    yield dispatch(frame, currentPC, receiver, arg1, arg2, arg3);
+                }
+                case 4 -> {
+                    final Object arg4 = pop(frame, --sp);
+                    final Object arg3 = pop(frame, --sp);
+                    final Object arg2 = pop(frame, --sp);
+                    final Object arg1 = pop(frame, --sp);
+                    final Object receiver = pop(frame, --sp);
+                    FrameAccess.externalizePCAndSP(frame, pc, sp);
+                    yield dispatch(frame, currentPC, receiver, arg1, arg2, arg3, arg4);
+                }
+                case 5 -> {
+                    final Object arg5 = pop(frame, --sp);
+                    final Object arg4 = pop(frame, --sp);
+                    final Object arg3 = pop(frame, --sp);
+                    final Object arg2 = pop(frame, --sp);
+                    final Object arg1 = pop(frame, --sp);
+                    final Object receiver = pop(frame, --sp);
+                    FrameAccess.externalizePCAndSP(frame, pc, sp);
+                    yield dispatch(frame, currentPC, receiver, arg1, arg2, arg3, arg4, arg5);
+                }
+                default -> {
+                    final Object[] arguments = popN(frame, sp, numArgs);
+                    sp -= numArgs;
+                    final Object receiver = pop(frame, --sp);
+                    FrameAccess.externalizePCAndSP(frame, pc, sp);
+                    yield dispatchNary(frame, currentPC, receiver, arguments);
+                }
+            };
+        } catch (final AbstractStandardSendReturn r) {
+            result = handleReturnException(frame, currentPC, r);
+        }
+        push(frame, sp++, followForwarded(currentPC, result));
+        return sp;
     }
 
     @EarlyInline

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/TruffleSqueakPlugin.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/TruffleSqueakPlugin.java
@@ -11,15 +11,22 @@ import java.util.List;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.Truffle;
+import com.oracle.truffle.api.dsl.Bind;
+import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.NodeFactory;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.DirectCallNode;
+import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.RootNode;
 
 import de.hpi.swa.trufflesqueak.exceptions.PrimitiveFailed;
+import de.hpi.swa.trufflesqueak.image.SqueakImageContext;
 import de.hpi.swa.trufflesqueak.interop.JavaObjectWrapper;
+import de.hpi.swa.trufflesqueak.model.ArrayObject;
 import de.hpi.swa.trufflesqueak.model.NativeObject;
+import de.hpi.swa.trufflesqueak.model.NilObject;
+import de.hpi.swa.trufflesqueak.nodes.accessing.ArrayObjectNodes;
 import de.hpi.swa.trufflesqueak.nodes.interpreter.AbstractInterpreterNode;
 import de.hpi.swa.trufflesqueak.nodes.primitives.AbstractPrimitiveFactoryHolder;
 import de.hpi.swa.trufflesqueak.nodes.primitives.AbstractPrimitiveNode;
@@ -103,6 +110,42 @@ public final class TruffleSqueakPlugin extends AbstractPrimitiveFactoryHolder {
             } else {
                 throw PrimitiveFailed.andTransferToInterpreter();
             }
+        }
+    }
+
+    @GenerateNodeFactory
+    @SqueakPrimitive(names = "primitiveSetDNUShortcutSelectors")
+    protected abstract static class PrimSetDNUShortcutSelectorsNode extends AbstractPrimitiveNode implements Primitive1WithFallback {
+        @Specialization
+        protected final Object doSet(final Object receiver, final ArrayObject array,
+                        @Bind final Node node,
+                        @Cached final ArrayObjectNodes.ArrayObjectToObjectArrayCopyNode toObjectArrayNode) {
+
+            final Object[] elements = toObjectArrayNode.execute(node, array);
+            final int arraySize = elements.length;
+
+            if (arraySize > SqueakImageContext.MAX_DNU_SHORTCUT_ARITY + 1) {
+                CompilerDirectives.transferToInterpreter();
+                throw PrimitiveFailed.BAD_ARGUMENT;
+            }
+
+            final NativeObject[] isolatedSelectors = new NativeObject[arraySize];
+
+            for (int i = 0; i < arraySize; i++) {
+                final Object element = elements[i];
+
+                if (element instanceof final NativeObject nativeObject && getContext().isByteSymbol(nativeObject)) {
+                    isolatedSelectors[i] = nativeObject;
+                } else if (element == NilObject.SINGLETON) {
+                    isolatedSelectors[i] = null;
+                } else {
+                    CompilerDirectives.transferToInterpreter();
+                    throw PrimitiveFailed.BAD_ARGUMENT;
+                }
+            }
+
+            getContext().setDNUShortcutSelectors(isolatedSelectors);
+            return receiver;
         }
     }
 }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/TruffleSqueakPlugin.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/plugins/TruffleSqueakPlugin.java
@@ -124,7 +124,10 @@ public final class TruffleSqueakPlugin extends AbstractPrimitiveFactoryHolder {
             final Object[] elements = toObjectArrayNode.execute(node, array);
             final int arraySize = elements.length;
 
-            if (arraySize > SqueakImageContext.MAX_DNU_SHORTCUT_ARITY + 1) {
+            if (arraySize == 0) {
+                getContext().setDNUShortcutSelectors(null);
+                return receiver;
+            } else if (arraySize > SqueakImageContext.MAX_DNU_SHORTCUT_ARITY + 1) {
                 CompilerDirectives.transferToInterpreter();
                 throw PrimitiveFailed.BAD_ARGUMENT;
             }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ControlPrimitives.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ControlPrimitives.java
@@ -271,12 +271,16 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
     @SqueakPrimitive(indices = 84)
     protected abstract static class PrimPerformWithArguments2Node extends AbstractPrimitiveWithFrameNode implements Primitive2 {
         @SuppressWarnings("unused")
-        @Specialization(guards = {"selector == cachedSelector", "guard.check(receiver)"}, assumptions = "dispatchDirectNode.getAssumptions()", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
+        @Specialization(guards = {"selector == cachedSelector", "guard.check(receiver)",
+                        "arity == cachedArity"}, assumptions = "dispatchDirectNode.getAssumptions()", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
         protected static final Object performCached(final VirtualFrame frame, final Object receiver, final NativeObject selector, final ArrayObject argumentsArray,
                         @Bind final Node node,
                         @Cached("selector") final NativeObject cachedSelector,
                         @Cached("create(receiver)") final LookupClassGuard guard,
-                        @Cached("create(cachedSelector, guard)") final DispatchDirectNaryNode dispatchDirectNode,
+                        @Cached final ArrayObjectSizeNode sizeNode,
+                        @Bind("sizeNode.execute(node, argumentsArray)") final int arity,
+                        @Cached("arity") final int cachedArity,
+                        @Cached("create(cachedSelector, guard, cachedArity)") final DispatchDirectNaryNode dispatchDirectNode,
                         @Exclusive @Cached final ArrayObjectToObjectArrayCopyNode getObjectArrayNode) {
             final Object[] arguments = getObjectArrayNode.execute(node, argumentsArray);
             return dispatchDirectNode.executeWithCheckedArguments(frame, receiver, arguments);
@@ -507,11 +511,12 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
 
         protected abstract Object execute(VirtualFrame frame, ClassObject lookupClass, Object receiver, Object[] arguments);
 
-        @Specialization(guards = "lookupClass == cachedLookupClass", assumptions = {"cachedLookupClass.getClassHierarchyAndMethodDictStable()",
+        @Specialization(guards = {"lookupClass == cachedLookupClass", "arguments.length == cachedArity"}, assumptions = {"cachedLookupClass.getClassHierarchyAndMethodDictStable()",
                         "dispatchDirectNode.getAssumptions()"}, limit = "3")
         protected static final Object doCached(final VirtualFrame frame, @SuppressWarnings("unused") final ClassObject lookupClass, final Object receiver, final Object[] arguments,
                         @SuppressWarnings("unused") @Cached("lookupClass") final ClassObject cachedLookupClass,
-                        @Cached("create(selector, cachedLookupClass)") final DispatchDirectNaryNode dispatchDirectNode) {
+                        @SuppressWarnings("unused") @Cached("arguments.length") final int cachedArity,
+                        @Cached("create(selector, cachedLookupClass, cachedArity)") final DispatchDirectNaryNode dispatchDirectNode) {
             return dispatchDirectNode.executeWithCheckedArguments(frame, receiver, arguments);
         }
     }

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ControlPrimitives.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ControlPrimitives.java
@@ -140,7 +140,7 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
         @Specialization(guards = "selector == cachedSelector", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
         protected static final Object perform0Cached(final VirtualFrame frame, final Object receiver, final NativeObject selector,
                         @Cached("selector") final NativeObject cachedSelector,
-                        @Cached("create(cachedSelector)") final Dispatch0Node dispatchNode) {
+                        @Cached("create(cachedSelector, true)") final Dispatch0Node dispatchNode) {
             return dispatchNode.execute(frame, receiver);
         }
 
@@ -160,7 +160,7 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
         @Specialization(guards = "selector == cachedSelector", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
         protected static final Object perform1Cached(final VirtualFrame frame, final Object receiver, final NativeObject selector, final Object arg1,
                         @Cached("selector") final NativeObject cachedSelector,
-                        @Cached("create(cachedSelector)") final Dispatch1Node dispatchNode) {
+                        @Cached("create(cachedSelector, true)") final Dispatch1Node dispatchNode) {
             return dispatchNode.execute(frame, receiver, arg1);
         }
 
@@ -180,7 +180,7 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
         @Specialization(guards = "selector == cachedSelector", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
         protected static final Object perform2Cached(final VirtualFrame frame, final Object receiver, final NativeObject selector, final Object arg1, final Object arg2,
                         @Cached("selector") final NativeObject cachedSelector,
-                        @Cached("create(cachedSelector)") final Dispatch2Node dispatchNode) {
+                        @Cached("create(cachedSelector, true)") final Dispatch2Node dispatchNode) {
             return dispatchNode.execute(frame, receiver, arg1, arg2);
         }
 
@@ -200,7 +200,7 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
         @Specialization(guards = "selector == cachedSelector", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
         protected static final Object perform3Cached(final VirtualFrame frame, final Object receiver, final NativeObject selector, final Object arg1, final Object arg2, final Object arg3,
                         @Cached("selector") final NativeObject cachedSelector,
-                        @Cached("create(cachedSelector)") final Dispatch3Node dispatchNode) {
+                        @Cached("create(cachedSelector, true)") final Dispatch3Node dispatchNode) {
             return dispatchNode.execute(frame, receiver, arg1, arg2, arg3);
         }
 
@@ -221,7 +221,7 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
         protected static final Object perform4Cached(final VirtualFrame frame, final Object receiver, final NativeObject selector, final Object arg1, final Object arg2, final Object arg3,
                         final Object arg4,
                         @Cached("selector") final NativeObject cachedSelector,
-                        @Cached("create(cachedSelector)") final Dispatch4Node dispatchNode) {
+                        @Cached("create(cachedSelector, true)") final Dispatch4Node dispatchNode) {
             return dispatchNode.execute(frame, receiver, arg1, arg2, arg3, arg4);
         }
 
@@ -243,7 +243,7 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
         protected static final Object perform5Cached(final VirtualFrame frame, final Object receiver, final NativeObject selector, final Object arg1, final Object arg2, final Object arg3,
                         final Object arg4, final Object arg5,
                         @Cached("selector") final NativeObject cachedSelector,
-                        @Cached("create(cachedSelector)") final Dispatch5Node dispatchNode) {
+                        @Cached("create(cachedSelector, true)") final Dispatch5Node dispatchNode) {
             return dispatchNode.execute(frame, receiver, arg1, arg2, arg3, arg4, arg5);
         }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ControlPrimitives.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/nodes/primitives/impl/ControlPrimitives.java
@@ -74,22 +74,28 @@ import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectChangeClassOfToNode;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectClassNode;
 import de.hpi.swa.trufflesqueak.nodes.accessing.SqueakObjectIdentityNode;
 import de.hpi.swa.trufflesqueak.nodes.context.GetOrCreateContextWithoutFrameNode;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector0Node.Dispatch0Node;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector0Node.DispatchDirect0Node;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector0Node.DispatchIndirect0Node;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector1Node.Dispatch1Node;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector1Node.DispatchDirect1Node;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector1Node.DispatchIndirect1Node;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector2Node.Dispatch2Node;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector2Node.DispatchDirect2Node;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector2Node.DispatchIndirect2Node;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector3Node.Dispatch3Node;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector3Node.DispatchDirect3Node;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector3Node.DispatchIndirect3Node;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector4Node.Dispatch4Node;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector4Node.DispatchDirect4Node;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector4Node.DispatchIndirect4Node;
-import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector5Node.DispatchDirect5Node;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector5Node.Dispatch5Node;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelector5Node.DispatchIndirect5Node;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNode.DispatchDirectNaryNode;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNode.DispatchIndirectNaryNode;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNode.DispatchIndirectNaryNode.CreateFrameArgumentsForIndirectCallNaryNode;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNode.DispatchIndirectNaryNode.TryPrimitiveNaryNode;
+import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNode.DispatchPerformNaryNode;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.DispatchSelectorNaryNode.DispatchPrimitiveNode;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.LookupClassGuard;
 import de.hpi.swa.trufflesqueak.nodes.dispatch.ResolveMethodNode;
@@ -131,12 +137,11 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
     @SqueakPrimitive(indices = 83)
     protected abstract static class PrimPerform0Node extends AbstractPrimitiveWithFrameNode implements Primitive1WithFallback {
         @SuppressWarnings("unused")
-        @Specialization(guards = {"selector == cachedSelector", "guard.check(receiver)"}, assumptions = "dispatchDirectNode.getAssumptions()", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
+        @Specialization(guards = "selector == cachedSelector", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
         protected static final Object perform0Cached(final VirtualFrame frame, final Object receiver, final NativeObject selector,
                         @Cached("selector") final NativeObject cachedSelector,
-                        @Cached("create(receiver)") final LookupClassGuard guard,
-                        @Cached("create(cachedSelector, guard, true)") final DispatchDirect0Node dispatchDirectNode) {
-            return dispatchDirectNode.execute(frame, receiver);
+                        @Cached("create(cachedSelector)") final Dispatch0Node dispatchNode) {
+            return dispatchNode.execute(frame, receiver);
         }
 
         @SuppressWarnings("unused")
@@ -152,12 +157,11 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
     @SqueakPrimitive(indices = 83)
     protected abstract static class PrimPerform1Node extends AbstractPrimitiveWithFrameNode implements Primitive2WithFallback {
         @SuppressWarnings("unused")
-        @Specialization(guards = {"selector == cachedSelector", "guard.check(receiver)"}, assumptions = "dispatchDirectNode.getAssumptions()", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
+        @Specialization(guards = "selector == cachedSelector", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
         protected static final Object perform1Cached(final VirtualFrame frame, final Object receiver, final NativeObject selector, final Object arg1,
                         @Cached("selector") final NativeObject cachedSelector,
-                        @Cached("create(receiver)") final LookupClassGuard guard,
-                        @Cached("create(cachedSelector, guard, true)") final DispatchDirect1Node dispatchDirectNode) {
-            return dispatchDirectNode.execute(frame, receiver, arg1);
+                        @Cached("create(cachedSelector)") final Dispatch1Node dispatchNode) {
+            return dispatchNode.execute(frame, receiver, arg1);
         }
 
         @SuppressWarnings("unused")
@@ -173,12 +177,11 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
     @SqueakPrimitive(indices = 83)
     protected abstract static class PrimPerform2Node extends AbstractPrimitiveWithFrameNode implements Primitive3WithFallback {
         @SuppressWarnings("unused")
-        @Specialization(guards = {"selector == cachedSelector", "guard.check(receiver)"}, assumptions = "dispatchDirectNode.getAssumptions()", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
+        @Specialization(guards = "selector == cachedSelector", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
         protected static final Object perform2Cached(final VirtualFrame frame, final Object receiver, final NativeObject selector, final Object arg1, final Object arg2,
                         @Cached("selector") final NativeObject cachedSelector,
-                        @Cached("create(receiver)") final LookupClassGuard guard,
-                        @Cached("create(cachedSelector, guard, true)") final DispatchDirect2Node dispatchDirectNode) {
-            return dispatchDirectNode.execute(frame, receiver, arg1, arg2);
+                        @Cached("create(cachedSelector)") final Dispatch2Node dispatchNode) {
+            return dispatchNode.execute(frame, receiver, arg1, arg2);
         }
 
         @SuppressWarnings("unused")
@@ -194,12 +197,11 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
     @SqueakPrimitive(indices = 83)
     protected abstract static class PrimPerform3Node extends AbstractPrimitiveWithFrameNode implements Primitive4WithFallback {
         @SuppressWarnings("unused")
-        @Specialization(guards = {"selector == cachedSelector", "guard.check(receiver)"}, assumptions = "dispatchDirectNode.getAssumptions()", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
+        @Specialization(guards = "selector == cachedSelector", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
         protected static final Object perform3Cached(final VirtualFrame frame, final Object receiver, final NativeObject selector, final Object arg1, final Object arg2, final Object arg3,
                         @Cached("selector") final NativeObject cachedSelector,
-                        @Cached("create(receiver)") final LookupClassGuard guard,
-                        @Cached("create(cachedSelector, guard, true)") final DispatchDirect3Node dispatchDirectNode) {
-            return dispatchDirectNode.execute(frame, receiver, arg1, arg2, arg3);
+                        @Cached("create(cachedSelector)") final Dispatch3Node dispatchNode) {
+            return dispatchNode.execute(frame, receiver, arg1, arg2, arg3);
         }
 
         @SuppressWarnings("unused")
@@ -215,13 +217,12 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
     @SqueakPrimitive(indices = 83)
     protected abstract static class PrimPerform4Node extends AbstractPrimitiveWithFrameNode implements Primitive5WithFallback {
         @SuppressWarnings("unused")
-        @Specialization(guards = {"selector == cachedSelector", "guard.check(receiver)"}, assumptions = "dispatchDirectNode.getAssumptions()", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
+        @Specialization(guards = "selector == cachedSelector", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
         protected static final Object perform4Cached(final VirtualFrame frame, final Object receiver, final NativeObject selector, final Object arg1, final Object arg2, final Object arg3,
                         final Object arg4,
                         @Cached("selector") final NativeObject cachedSelector,
-                        @Cached("create(receiver)") final LookupClassGuard guard,
-                        @Cached("create(cachedSelector, guard, true)") final DispatchDirect4Node dispatchDirectNode) {
-            return dispatchDirectNode.execute(frame, receiver, arg1, arg2, arg3, arg4);
+                        @Cached("create(cachedSelector)") final Dispatch4Node dispatchNode) {
+            return dispatchNode.execute(frame, receiver, arg1, arg2, arg3, arg4);
         }
 
         @SuppressWarnings("unused")
@@ -238,13 +239,12 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
     @SqueakPrimitive(indices = 83)
     protected abstract static class PrimPerform5Node extends AbstractPrimitiveWithFrameNode implements Primitive6WithFallback {
         @SuppressWarnings("unused")
-        @Specialization(guards = {"selector == cachedSelector", "guard.check(receiver)"}, assumptions = "dispatchDirectNode.getAssumptions()", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
+        @Specialization(guards = "selector == cachedSelector", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
         protected static final Object perform5Cached(final VirtualFrame frame, final Object receiver, final NativeObject selector, final Object arg1, final Object arg2, final Object arg3,
                         final Object arg4, final Object arg5,
                         @Cached("selector") final NativeObject cachedSelector,
-                        @Cached("create(receiver)") final LookupClassGuard guard,
-                        @Cached("create(cachedSelector, guard, true)") final DispatchDirect5Node dispatchDirectNode) {
-            return dispatchDirectNode.execute(frame, receiver, arg1, arg2, arg3, arg4, arg5);
+                        @Cached("create(cachedSelector)") final Dispatch5Node dispatchNode) {
+            return dispatchNode.execute(frame, receiver, arg1, arg2, arg3, arg4, arg5);
         }
 
         @SuppressWarnings("unused")
@@ -271,19 +271,14 @@ public final class ControlPrimitives extends AbstractPrimitiveFactoryHolder {
     @SqueakPrimitive(indices = 84)
     protected abstract static class PrimPerformWithArguments2Node extends AbstractPrimitiveWithFrameNode implements Primitive2 {
         @SuppressWarnings("unused")
-        @Specialization(guards = {"selector == cachedSelector", "guard.check(receiver)",
-                        "arity == cachedArity"}, assumptions = "dispatchDirectNode.getAssumptions()", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
+        @Specialization(guards = "selector == cachedSelector", limit = "PERFORM_SELECTOR_CACHE_LIMIT")
         protected static final Object performCached(final VirtualFrame frame, final Object receiver, final NativeObject selector, final ArrayObject argumentsArray,
                         @Bind final Node node,
                         @Cached("selector") final NativeObject cachedSelector,
-                        @Cached("create(receiver)") final LookupClassGuard guard,
-                        @Cached final ArrayObjectSizeNode sizeNode,
-                        @Bind("sizeNode.execute(node, argumentsArray)") final int arity,
-                        @Cached("arity") final int cachedArity,
-                        @Cached("create(cachedSelector, guard, cachedArity)") final DispatchDirectNaryNode dispatchDirectNode,
+                        @Cached("create(cachedSelector)") final DispatchPerformNaryNode dispatchNode,
                         @Exclusive @Cached final ArrayObjectToObjectArrayCopyNode getObjectArrayNode) {
             final Object[] arguments = getObjectArrayNode.execute(node, argumentsArray);
-            return dispatchDirectNode.executeWithCheckedArguments(frame, receiver, arguments);
+            return dispatchNode.execute(frame, receiver, arguments);
         }
 
         @Megamorphic

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/ArrayUtils.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/ArrayUtils.java
@@ -10,9 +10,11 @@ import java.util.Arrays;
 
 import org.graalvm.collections.UnmodifiableEconomicMap;
 
+import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.nodes.ExplodeLoop;
 
 public final class ArrayUtils {
     @CompilationFinal(dimensions = 1) public static final Object[] EMPTY_ARRAY = new Object[0];
@@ -92,6 +94,14 @@ public final class ArrayUtils {
             }
         }
         return false;
+    }
+
+    @ExplodeLoop
+    public static void copyExploded(final Object[] source, final Object[] dest, final int length) {
+        CompilerAsserts.partialEvaluationConstant(length);
+        for (int i = 0; i < length; i++) {
+            dest[i] = source[i];
+        }
     }
 
     public static byte[] copyOf(final byte[] original, final int newLength) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/FrameAccess.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/FrameAccess.java
@@ -21,8 +21,8 @@ import com.oracle.truffle.api.frame.FrameInstance;
 import com.oracle.truffle.api.frame.FrameSlotKind;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.frame.VirtualFrame;
-
 import com.oracle.truffle.api.nodes.ExplodeLoop;
+
 import de.hpi.swa.trufflesqueak.exceptions.SqueakExceptions.SqueakException;
 import de.hpi.swa.trufflesqueak.model.AbstractSqueakObject;
 import de.hpi.swa.trufflesqueak.model.ArrayObject;
@@ -78,6 +78,11 @@ public final class FrameAccess {
         private static final int CLOSURE_OR_NULL = 1;
         private static final int RECEIVER = 2;
         private static final int ARGUMENTS_START = 3;
+        private static final int ARGUMENT_1 = ARGUMENTS_START;
+        private static final int ARGUMENT_2 = ARGUMENT_1 + 1;
+        private static final int ARGUMENT_3 = ARGUMENT_2 + 1;
+        private static final int ARGUMENT_4 = ARGUMENT_3 + 1;
+        private static final int ARGUMENT_5 = ARGUMENT_4 + 1;
     }
 
     private static final class SlotIndices {
@@ -167,7 +172,7 @@ public final class FrameAccess {
     }
 
     public static int getNumArguments(final Frame frame) {
-        return frame.getArguments().length - getArgumentStartIndex();
+        return frame.getArguments().length - ArgumentIndices.ARGUMENTS_START;
     }
 
     public static Object[] getReceiverAndArguments(final Frame frame) {
@@ -405,7 +410,7 @@ public final class FrameAccess {
         frameArguments[ArgumentIndices.SENDER] = sender;
         frameArguments[ArgumentIndices.CLOSURE_OR_NULL] = closure;
         frameArguments[ArgumentIndices.RECEIVER] = receiver;
-        frameArguments[ArgumentIndices.ARGUMENTS_START] = arg1;
+        frameArguments[ArgumentIndices.ARGUMENT_1] = arg1;
         return frameArguments;
     }
 
@@ -415,8 +420,8 @@ public final class FrameAccess {
         frameArguments[ArgumentIndices.SENDER] = sender;
         frameArguments[ArgumentIndices.CLOSURE_OR_NULL] = closure;
         frameArguments[ArgumentIndices.RECEIVER] = receiver;
-        frameArguments[ArgumentIndices.ARGUMENTS_START] = arg1;
-        frameArguments[ArgumentIndices.ARGUMENTS_START + 1] = arg2;
+        frameArguments[ArgumentIndices.ARGUMENT_1] = arg1;
+        frameArguments[ArgumentIndices.ARGUMENT_2] = arg2;
         return frameArguments;
     }
 
@@ -426,9 +431,9 @@ public final class FrameAccess {
         frameArguments[ArgumentIndices.SENDER] = sender;
         frameArguments[ArgumentIndices.CLOSURE_OR_NULL] = closure;
         frameArguments[ArgumentIndices.RECEIVER] = receiver;
-        frameArguments[ArgumentIndices.ARGUMENTS_START] = arg1;
-        frameArguments[ArgumentIndices.ARGUMENTS_START + 1] = arg2;
-        frameArguments[ArgumentIndices.ARGUMENTS_START + 2] = arg3;
+        frameArguments[ArgumentIndices.ARGUMENT_1] = arg1;
+        frameArguments[ArgumentIndices.ARGUMENT_2] = arg2;
+        frameArguments[ArgumentIndices.ARGUMENT_3] = arg3;
         return frameArguments;
     }
 
@@ -439,10 +444,10 @@ public final class FrameAccess {
         frameArguments[ArgumentIndices.SENDER] = sender;
         frameArguments[ArgumentIndices.CLOSURE_OR_NULL] = closure;
         frameArguments[ArgumentIndices.RECEIVER] = receiver;
-        frameArguments[ArgumentIndices.ARGUMENTS_START] = arg1;
-        frameArguments[ArgumentIndices.ARGUMENTS_START + 1] = arg2;
-        frameArguments[ArgumentIndices.ARGUMENTS_START + 2] = arg3;
-        frameArguments[ArgumentIndices.ARGUMENTS_START + 3] = arg4;
+        frameArguments[ArgumentIndices.ARGUMENT_1] = arg1;
+        frameArguments[ArgumentIndices.ARGUMENT_2] = arg2;
+        frameArguments[ArgumentIndices.ARGUMENT_3] = arg3;
+        frameArguments[ArgumentIndices.ARGUMENT_4] = arg4;
         return frameArguments;
     }
 
@@ -453,11 +458,11 @@ public final class FrameAccess {
         frameArguments[ArgumentIndices.SENDER] = sender;
         frameArguments[ArgumentIndices.CLOSURE_OR_NULL] = closure;
         frameArguments[ArgumentIndices.RECEIVER] = receiver;
-        frameArguments[ArgumentIndices.ARGUMENTS_START] = arg1;
-        frameArguments[ArgumentIndices.ARGUMENTS_START + 1] = arg2;
-        frameArguments[ArgumentIndices.ARGUMENTS_START + 2] = arg3;
-        frameArguments[ArgumentIndices.ARGUMENTS_START + 3] = arg4;
-        frameArguments[ArgumentIndices.ARGUMENTS_START + 4] = arg5;
+        frameArguments[ArgumentIndices.ARGUMENT_1] = arg1;
+        frameArguments[ArgumentIndices.ARGUMENT_2] = arg2;
+        frameArguments[ArgumentIndices.ARGUMENT_3] = arg3;
+        frameArguments[ArgumentIndices.ARGUMENT_4] = arg4;
+        frameArguments[ArgumentIndices.ARGUMENT_5] = arg5;
         return frameArguments;
     }
 
@@ -520,33 +525,33 @@ public final class FrameAccess {
     }
 
     public static void fillClosureTemplateWith(final Object[] template, final Object arg1) {
-        template[ArgumentIndices.ARGUMENTS_START + 0] = arg1;
+        template[ArgumentIndices.ARGUMENT_1] = arg1;
     }
 
     public static void fillClosureTemplateWith(final Object[] template, final Object arg1, final Object arg2) {
-        template[ArgumentIndices.ARGUMENTS_START + 0] = arg1;
-        template[ArgumentIndices.ARGUMENTS_START + 1] = arg2;
+        template[ArgumentIndices.ARGUMENT_1] = arg1;
+        template[ArgumentIndices.ARGUMENT_2] = arg2;
     }
 
     public static void fillClosureTemplateWith(final Object[] template, final Object arg1, final Object arg2, final Object arg3) {
-        template[ArgumentIndices.ARGUMENTS_START + 0] = arg1;
-        template[ArgumentIndices.ARGUMENTS_START + 1] = arg2;
-        template[ArgumentIndices.ARGUMENTS_START + 2] = arg3;
+        template[ArgumentIndices.ARGUMENT_1] = arg1;
+        template[ArgumentIndices.ARGUMENT_2] = arg2;
+        template[ArgumentIndices.ARGUMENT_3] = arg3;
     }
 
     public static void fillClosureTemplateWith(final Object[] template, final Object arg1, final Object arg2, final Object arg3, final Object arg4) {
-        template[ArgumentIndices.ARGUMENTS_START + 0] = arg1;
-        template[ArgumentIndices.ARGUMENTS_START + 1] = arg2;
-        template[ArgumentIndices.ARGUMENTS_START + 2] = arg3;
-        template[ArgumentIndices.ARGUMENTS_START + 3] = arg4;
+        template[ArgumentIndices.ARGUMENT_1] = arg1;
+        template[ArgumentIndices.ARGUMENT_2] = arg2;
+        template[ArgumentIndices.ARGUMENT_3] = arg3;
+        template[ArgumentIndices.ARGUMENT_4] = arg4;
     }
 
     public static void fillClosureTemplateWith(final Object[] template, final Object arg1, final Object arg2, final Object arg3, final Object arg4, final Object arg5) {
-        template[ArgumentIndices.ARGUMENTS_START + 0] = arg1;
-        template[ArgumentIndices.ARGUMENTS_START + 1] = arg2;
-        template[ArgumentIndices.ARGUMENTS_START + 2] = arg3;
-        template[ArgumentIndices.ARGUMENTS_START + 3] = arg4;
-        template[ArgumentIndices.ARGUMENTS_START + 4] = arg5;
+        template[ArgumentIndices.ARGUMENT_1] = arg1;
+        template[ArgumentIndices.ARGUMENT_2] = arg2;
+        template[ArgumentIndices.ARGUMENT_3] = arg3;
+        template[ArgumentIndices.ARGUMENT_4] = arg4;
+        template[ArgumentIndices.ARGUMENT_5] = arg5;
     }
 
     public static int expectedArgumentSize(final int numArgsAndCopied) {

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/MethodCacheEntry.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/MethodCacheEntry.java
@@ -10,14 +10,13 @@ import com.oracle.truffle.api.CompilerAsserts;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import de.hpi.swa.trufflesqueak.model.ClassObject;
-import de.hpi.swa.trufflesqueak.model.CompiledCodeObject;
 import de.hpi.swa.trufflesqueak.model.NativeObject;
 
 public final class MethodCacheEntry {
     private ClassObject classObject;
     private NativeObject selector;
     private Object result;
-    private CompiledCodeObject fallbackMethod;
+    private ClassObject.DispatchFailureResult dispatchFailure;
 
     public ClassObject getClassObject() {
         return classObject;
@@ -31,34 +30,34 @@ public final class MethodCacheEntry {
         return result;
     }
 
-    public CompiledCodeObject getOrCreateFallbackMethod() {
-        if (fallbackMethod == null) {
-            fallbackMethod = createFallbackMethod();
+    public ClassObject.DispatchFailureResult getOrCreateDispatchFailureResult(final int arity) {
+        if (dispatchFailure == null || dispatchFailure.arity() != arity) {
+            dispatchFailure = createDispatchFailureResult(arity);
         }
-        return fallbackMethod;
+        return dispatchFailure;
     }
 
     @CompilerDirectives.TruffleBoundary
-    private CompiledCodeObject createFallbackMethod() {
-        return classObject.resolveDispatchFailure(selector);
+    private ClassObject.DispatchFailureResult createDispatchFailureResult(final int arity) {
+        return classObject.resolveDispatchFailure(selector, arity);
     }
 
     public void setResult(final Object object) {
         result = object;
-        fallbackMethod = null;
+        dispatchFailure = null;
     }
 
     public void freeAndRelease() {
         selector = null; /* Mark it free. */
         result = null; /* Release the method. */
-        fallbackMethod = null;
+        dispatchFailure = null;
     }
 
     public MethodCacheEntry reuseFor(final ClassObject lookupClass, final NativeObject lookupSelector) {
         classObject = lookupClass;
         selector = lookupSelector;
         result = null;
-        fallbackMethod = null;
+        dispatchFailure = null;
         return this;
     }
 

--- a/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/MethodCacheEntry.java
+++ b/src/de.hpi.swa.trufflesqueak/src/de/hpi/swa/trufflesqueak/util/MethodCacheEntry.java
@@ -7,8 +7,8 @@
 package de.hpi.swa.trufflesqueak.util;
 
 import com.oracle.truffle.api.CompilerAsserts;
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 
-import com.oracle.truffle.api.CompilerDirectives;
 import de.hpi.swa.trufflesqueak.model.ClassObject;
 import de.hpi.swa.trufflesqueak.model.NativeObject;
 
@@ -37,7 +37,7 @@ public final class MethodCacheEntry {
         return dispatchFailure;
     }
 
-    @CompilerDirectives.TruffleBoundary
+    @TruffleBoundary
     private ClassObject.DispatchFailureResult createDispatchFailureResult(final int arity) {
         return classObject.resolveDispatchFailure(selector, arity);
     }


### PR DESCRIPTION
This PR replaces the Truffle DSL-generated polymorphic inline caches for message dispatch (`Dispatch0Node` through `DispatchNaryNode`) with a custom Multi-Tier Dispatch Architecture.

On the AWFY benchmarks, the Interpreter performance is faster than `main` and the Peak performance is slightly faster than `main`. **Bounce**, **List** and **NBody** are slower and also have a larger Tier 2 code size which could indicate that the Smalltalk method inlining may be too aggressive for those benchmarks. Perhaps tuning of the inlining budget could better balance the tradeoff between code size and execution speed with respect to instruction cache sizes.

Local testing (Mac mini M2, 16 GB, macOS 15.7.9) of the Cuis 7.3 and 7.5 test suite runtimes show an improvement of performance by 5% and 2%, respectively.

### Core Architecture

- **Tier 0 (Monomorphic)**: Direct execution using a single fast receiver check (`LookupClassGuard`), bypassing array iterations entirely.
- **Tier 1 (Fast / Receiver-Based Polymorphism)**: Checked dispatch up to `DISPATCH_CACHE_LIMIT` (4), where each entry can guard up to `LOOKUP_CACHE_LIMIT` (8) receiver types mapping to the same method target.
- **Tier 2 (Wide / Target-Based Polymorphism)**: Target-based dispatching based on resolved method targets rather than receiver types.
- **Tier 3 (Indirect / Megamorphic)**: Fallback indirect execution.

---

_This PR replaces #275 and is built upon PR #299 and will be rebased once #299 is accepted._